### PR TITLE
Add a npm bundle size badge (minified + gzipped) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Alpine.js
 
+![npm bundle size](https://img.shields.io/bundlephobia/minzip/alpinejs)
+
 Alpine.js offers you the reactive and declarative nature of big frameworks like Vue or React at a much lower cost.
 
 You get to keep your DOM, and sprinkle in behavior as you see fit.


### PR DESCRIPTION
This lets people preview the latest version's bundle's size.