### PR TITLE
Update the example import statement, fix eslint error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm i alpinejs
 
 Include it in your script.
 ```js
-import Alpine from 'alpinejs'
+import 'alpinejs'
 ```
 
 For IE11, polyfills will need to be provided. Please load the following scripts before the Alpine script above.


### PR DESCRIPTION
As the `Alpine` variable is not used in the installation example, eslint could throw a `'Alpine' is defined but never used` error which would cause a build to fail.

Simplifying the import statement and not setting a variable name fixes this issue.