### PR TITLE
Use Tailwind transition and transform classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,24 +341,24 @@ It's important that `x-if` is used on a `<template></template>` tag because Alpi
 ```html
 <div
     x-show="open"
-    x-transition:enter="ease-out transition-slow"
-    x-transition:enter-start="opacity-0 scale-90"
-    x-transition:enter-end="opacity-100 scale-100"
-    x-transition:leave="ease-in transition-slow"
-    x-transition:leave-start="opacity-100 scale-100"
-    x-transition:leave-end="opacity-0 scale-90"
+    x-transition:enter="transition ease-out duration-300"
+    x-transition:enter-start="opacity-0 transform scale-90"
+    x-transition:enter-end="opacity-100 transform scale-100"
+    x-transition:leave="transition ease-in duration-300"
+    x-transition:leave-start="opacity-100 transform scale-100"
+    x-transition:leave-end="opacity-0 transform scale-90"
 >...</div>
 ```
 
 ```html
 <template x-if="open">
     <div
-        x-transition:enter="ease-out transition-slow"
-        x-transition:enter-start="opacity-0 scale-90"
-        x-transition:enter-end="opacity-100 scale-100"
-        x-transition:leave="ease-in transition-slow"
-        x-transition:leave-start="opacity-100 scale-100"
-        x-transition:leave-end="opacity-0 scale-90"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="opacity-0 transform scale-90"
+        x-transition:enter-end="opacity-100 transform scale-100"
+        x-transition:leave="transition ease-in duration-300"
+        x-transition:leave-start="opacity-100 transform scale-100"
+        x-transition:leave-end="opacity-0 transform scale-90"
     >...</div>
 </template>
 ```


### PR DESCRIPTION
Updated the transition snippets to use the new Tailwind classes available in v1.2, so copy-pasters have an immediately working example.