### PR TITLE
Add documentation link to x-if warning

### DIFF
--- a/src/directives/if.js
+++ b/src/directives/if.js
@@ -1,7 +1,7 @@
 import { transitionIn, transitionOut } from '../utils'
 
 export function handleIfDirective(el, expressionResult, initialUpdate) {
-    if (el.nodeName.toLowerCase() !== 'template') console.warn(`Alpine: [x-if] directive should only be added to <template> tags.`)
+    if (el.nodeName.toLowerCase() !== 'template') console.warn(`Alpine: [x-if] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#x-if`)
 
     const elementHasAlreadyBeenAdded = el.nextElementSibling && el.nextElementSibling.__x_inserted_me === true
 


### PR DESCRIPTION
Since there's no reasoning in the console warning (would be to verbose anyway), a small documentation link could be useful for curious developers.