### PR TITLE
Adds extra check for parentElement on mutation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ const Alpine = {
 
                         // Discard any changes happening within an existing component.
                         // They will take care of themselves.
-                        if (node.parentElement.closest('[x-data]')) return
+                        if (node.parentElement && node.parentElement.closest('[x-data]')) return
 
                         this.discoverUninitializedComponents((el) => {
                             this.initializeComponent(el)


### PR DESCRIPTION
In the case where the parentElement is null this would otherwise throw an error.

(The mutation happening in my example is from another script)

<img width="1418" alt="Screen Shot 2020-01-24 at 7 41 56 PM" src="https://user-images.githubusercontent.com/1478421/73070316-9c0f4980-3ee2-11ea-9174-81806d40c94d.png">
