### PR TITLE
Feature/x on registers multiple listeners

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -165,7 +165,7 @@ export default class Component {
 
     getEventNamesFromXAttrValue(value) {
         const firstCharacter = value[0]
-        const lastCharacter = value[value.length]
+        const lastCharacter = value[value.length - 1]
 
         if(firstCharacter !== '[' && lastCharacter !== ']') {
             return [value]

--- a/src/component.js
+++ b/src/component.js
@@ -163,11 +163,27 @@ export default class Component {
         this.resolveBoundAttributes(el, false, extraVars)
     }
 
+    getEventNamesFromXAttrValue(value) {
+        const firstCharacter = value[0]
+        const lastCharacter = value[value.length]
+
+        if(firstCharacter !== '[' && lastCharacter !== ']') {
+            return [value]
+        }
+  
+        eventNames = value.split(/[,\[\]]+/)
+        eventNames.shift()
+        eventNames.pop()
+
+        return eventNames
+    }
+
     registerListeners(el, extraVars) {
         getXAttrs(el).forEach(({ type, value, modifiers, expression }) => {
             switch (type) {
                 case 'on':
-                    registerListener(this, el, value, modifiers, expression, extraVars)
+                    let events = this.getEventNamesFromXAttrValue(value)
+                    events.forEach(event => registerListener(this, el, event, modifiers, expression, extraVars))
                     break;
 
                 case 'model':

--- a/src/component.js
+++ b/src/component.js
@@ -171,7 +171,7 @@ export default class Component {
             return [value]
         }
   
-        eventNames = value.split(/[,\[\]]+/)
+        const eventNames = value.split(/[,\[\]]+/)
         eventNames.shift()
         eventNames.pop()
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,7 +84,7 @@ export function getXAttrs(el, type) {
             const name = replaceAtAndColonWithStandardSyntax(attr.name)
 
             const typeMatch = name.match(/x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)/)
-            const valueMatch = name.match(/:([a-zA-Z\-:]+)/)
+            const valueMatch = name.match(/:([\[,\]a-zA-Z\-:]+)/)
             const modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || []
 
             return {

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -326,6 +326,46 @@ test('event with colon', async () => {
     await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
 })
 
+test('single event registered with bracket notation', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'bar' }">
+            <button x-on:[click]="foo = 'baz'"></button>
+
+            <span x-bind:foo="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').getAttribute('foo')).toEqual('bar')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+})
+
+test('multiple events registered with bracket notation', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: true }">
+            <button x-on:[click,touchend]="foo = !foo"></button>
+
+            <span x-bind:foo="foo ? 'bar' : 'baz'"></span>
+        </div>
+    `
+
+    const span = document.querySelector('span')
+    const button = document.querySelector('button')
+    Alpine.start()
+
+    expect(span.getAttribute('foo')).toEqual('bar')
+
+    button.click()
+    await wait(() => { expect(span.getAttribute('foo')).toEqual('baz') })
+
+    var event = new Event('touchend');
+    button.dispatchEvent(event);
+    await wait(() => { expect(span.getAttribute('foo')).toEqual('bar') })
+})
 
 test('prevent default action when an event returns false', async () => {
     window.confirm = jest.fn().mockImplementation(() => false)


### PR DESCRIPTION
Addresses feature request #173 

This PR adds support for registering multiple listeners with one x-on directive using the following syntax:

```html
<button  x-on:[click,touchend]="doSomething()" > 
    Do something!
</button>
```

I was not sure if this is a feature you'd like to have, either way it was an interesting source dive :)

## Backwards compatibility
This change won't have any impact I am aware of. Normal `x-on` attributes stil work the way they used to.

## Caveats
In this proof of concept it is currently not possible to separate event names with spaces. Might be able to add that, but this might have some impact on allowed attribute names that alpine parses. Not sure if this could lead to any side effects.

## Thoughts
I was wondering how Vue would do it, but it turns out they don't support this (as far as i'm aware)
Syntax therefore is wide open. Maybe losing the brackets makes it an easier read and keeps the filtering of allowed attribute characters more strict?

If you are open to the idea i'm happy to iterate on this and add some tests