### PR TITLE
Automatically call `init` method

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -17,6 +17,7 @@ export default class Component {
         const mountedExpression = this.$el.getAttribute('x-mounted')
 
         const unobservedData = saferEval(dataExpression, {})
+        const initMethodExpression = unobservedData.hasOwnProperty('init') ? 'init()' : null
 
         // Construct a Proxy-based observable. This will be used to handle reactivity.
         this.$data = this.wrapDataInObservable(unobservedData)
@@ -32,11 +33,11 @@ export default class Component {
         }
 
         var initReturnedCallback
-        if (initExpression) {
+        if (initExpression || initMethodExpression) {
             // We want to allow data manipulation, but not trigger DOM updates just yet.
             // We haven't even initialized the elements with their Alpine bindings. I mean c'mon.
             this.pauseReactivity = true
-            initReturnedCallback = this.evaluateReturnExpression(this.$el, initExpression)
+            initReturnedCallback = this.evaluateReturnExpression(this.$el, initExpression ? initExpression : initMethodExpression)
             this.pauseReactivity = false
         }
 

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -52,6 +52,61 @@ test('x-init from data function with callback return for "x-mounted" functionali
     expect(valueB).toEqual('bar')
 })
 
+test('automatic init method from data function', async () => {
+    var spanValue
+    window.setSpanValue = (el) => {
+        spanValue = el.innerHTML
+    }
+    window.data = function() {
+        return {
+            foo: 'bar',
+            init() {
+                window.setSpanValue(this.$refs.foo)
+            }
+        }
+    }
+
+    document.body.innerHTML = `
+        <div x-data="window.data()">
+            <span x-text="foo" x-ref="foo">baz</span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(spanValue).toEqual('baz')
+})
+
+test('automatic init method from data function with callback return for "x-mounted" functionality', async () => {
+    var valueA
+    var valueB
+    window.setValueA = (el) => { valueA = el.innerHTML }
+    window.setValueB = (el) => { valueB = el.innerText }
+    window.data = function() {
+        return {
+            foo: 'bar',
+            init() {
+                window.setValueA(this.$refs.foo)
+
+                return () => {
+                    window.setValueB(this.$refs.foo)
+                }
+            }
+        }
+    }
+
+    document.body.innerHTML = `
+        <div x-data="window.data()">
+            <span x-text="foo" x-ref="foo">baz</span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(valueA).toEqual('baz')
+    expect(valueB).toEqual('bar')
+})
+
 test('x-created', async () => {
     var spanValue
     window.setSpanValue = (el) => {


### PR DESCRIPTION
Solves #155 

Updates the component class to automatically call an `init` method if one exists on the `x-data` object. Always prefers the method from `x-init` over automatic method.