### PR TITLE
Fix mutation observer reinitializing element(s) in x-if within x-for usecase

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -322,7 +322,7 @@ export default class Component {
 
                 if (mutations[i].addedNodes.length > 0) {
                     mutations[i].addedNodes.forEach(node => {
-                        if (node.nodeType !== 1) return
+                        if (node.nodeType !== 1 || node.__x_inserted_me) return
 
                         if (node.matches('[x-data]')) {
                             node.__x = new Component(node)


### PR DESCRIPTION
Fixes #189.

Node(s) handled by the if-directive triggers mutation observer to reinitialize the handled node(s). 

In the case of ```x-if``` within ```x-for```, the node is reinitialized without additional value (provided by ```x-for```) resulting in eval reporting undefined object even though it shouldn't be