### PR TITLE
Feature: bind to style with object, array and string merging/override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,24 @@ For example:
 
 In this example, the "hidden" class will only be applied when the value of the `foo` data attribute is `true`.
 
+**`x-bind` for style attributes**
+
+`x-bind` behaves a little differently when binding to the `style` attribute.
+
+For styles, you pass in an object who's keys are style names, and values are either CSS property values (strings) or falsy. If the value is falsy the style will not be applied.
+
+For example:
+`<div x-bind:class="{ display: foo && 'inline', fontSize: 20 + 'px' }"></div>`
+
+In this example, the "display" style will only be applied when the value of the `foo` data attribute is `true`.
+
+`style` bindings also support arrays and will merge/override rules.
+
+For example:
+`<div style="display: inline" x-bind:style="['display: hidden; width: 200px;', 'height: 20px;']"></div>`
+
+In this example, the "display" style will be set to "hidden", "width" will be "200px" and height will be "20px"
+
 **`x-bind` for boolean attributes**
 
 `x-bind` supports boolean attributes in the same way that value attributes, using a variable as the condition or any JavaScript expression that resolves to `true` or `false`.

--- a/src/component.js
+++ b/src/component.js
@@ -166,6 +166,10 @@ export default class Component {
         if (el.hasAttribute('class') && getXAttrs(el).length > 0) {
             el.__x_original_classes = el.getAttribute('class').split(' ')
         }
+        if (el.hasAttribute('style') && getXAttrs(el).length > 0) {
+            // CSSStyleDeclaration, save the text representation of it
+            el.__x_original_style_text = el.style.cssText
+        }
 
         this.registerListeners(el, extraVars)
         this.resolveBoundAttributes(el, true, extraVars)

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,6 +32,58 @@ export function kebabCase(subject) {
     return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase()
 }
 
+// Currently only supports kebab-case & already camelCase-d input
+// in case of camelCase input, should be a noop
+export function camelCase(kebabIn) {
+    const words = kebabIn.split('-')
+    let asCamel = words[0]
+    // Check if this _was_ actual kebab-case
+    if (words.length > 1) {
+        asCamel = asCamel.toLowerCase()
+        // Skip the first word since camelCase starts with lower
+        for (let i = 1; i < words.length; i++) {
+            const w = words[i]
+            asCamel += w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+        }
+    }
+    return asCamel
+}
+
+// Convert CSS to a rule object, inverse of `rulesObjToCssText`
+// CSSStyleDeclaration.cssText -> { rule: value } JS Object
+export function cssTextToRulesObj(cssText) {
+    const ruleObj = {}
+    if (cssText) {
+        cssText.split(';').forEach(styleRule => {
+            if (!styleRule) {
+                // skip empty strings and falsy values
+                return
+            }
+            const ruleEntries = styleRule.split(':')
+            if (ruleEntries.length < 2) {
+                // skip malformed rulename -> value pairs
+                // eg. display; width: 100px;
+                return
+            }
+            const ruleName = ruleEntries[0].trim()
+            const ruleValue = ruleEntries[1].trim()
+            ruleObj[ruleName] = ruleValue
+        })
+    }
+    return ruleObj
+}
+
+// Outputs CSS with no whitespace from rule object, inverse of `cssTextToRulesObj`
+// { rule: value } JS Object -> cssText
+export function rulesObjToCssText(rulesObj) {
+    return Object.keys(rulesObj)
+        // currently there's no need to kebabCase ruleName since
+        // it's coming from cssText/strings regardless and so should
+        // already be in kebab-case
+        .map(ruleName => `${ruleName}:${rulesObj[ruleName]}`)
+        .join(';')
+}
+
 export function walk(el, callback) {
     if (callback(el) === false) return
 

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -175,6 +175,163 @@ test('class attribute bindings are synced by string syntax', async () => {
     expect(document.querySelector('span').classList.contains('baz')).toBeTruthy
 })
 
+test('style attribute bindings are merged by string syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ isOn: false }">
+            <span style="display: inline" x-bind:style="isOn ? 'margin-top: 10px': ''"></span>
+
+            <button @click="isOn = ! isOn"></button>
+        </div>
+    `
+    Alpine.start()
+
+    expect(document.querySelector('span').style.display).toBeTruthy()
+    expect(document.querySelector('span').style.display).toEqual('inline')
+    expect(document.querySelector('span').style.marginTop).toBeFalsy()
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').style.display).toBeTruthy()
+        expect(document.querySelector('span').style.display).toEqual('inline')
+        expect(document.querySelector('span').style.marginTop).toBeTruthy()
+        expect(document.querySelector('span').style.marginTop).toEqual('10px')
+    })
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').style.display).toBeTruthy()
+        expect(document.querySelector('span').style.display).toEqual('inline')
+        expect(document.querySelector('span').style.marginTop).toBeFalsy()
+    })
+})
+
+test('style attribute bindings are merged by array syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ isOn: false }">
+            <span
+                style="display: inline"
+                x-bind:style="isOn ? ['display: hidden; width: 200px;', 'height: 20px;']: ['margin-left: 150px;']"
+            ></span>
+
+            <button @click="isOn = ! isOn"></button>
+        </div>
+    `
+    Alpine.start()
+
+    expect(document.querySelector('span').style.display).toBeTruthy()
+    expect(document.querySelector('span').style.display).toEqual('inline')
+    expect(document.querySelector('span').style.width).toBeFalsy()
+    expect(document.querySelector('span').style.height).toBeFalsy()
+    expect(document.querySelector('span').style.marginLeft).toBeTruthy()
+    expect(document.querySelector('span').style.marginLeft).toEqual('150px')
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').style.display).toBeTruthy()
+    expect(document.querySelector('span').style.display).toEqual('hidden')
+    expect(document.querySelector('span').style.width).toBeTruthy()
+    expect(document.querySelector('span').style.width).toEqual('200px')
+    expect(document.querySelector('span').style.height).toBeTruthy()
+    expect(document.querySelector('span').style.height).toEqual('20px')
+    expect(document.querySelector('span').style.marginLeft).toBeFalsy()
+    })
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').style.display).toBeTruthy()
+        expect(document.querySelector('span').style.display).toEqual('inline')
+        expect(document.querySelector('span').style.width).toBeFalsy()
+        expect(document.querySelector('span').style.height).toBeFalsy()
+        expect(document.querySelector('span').style.marginLeft).toBeTruthy()
+        expect(document.querySelector('span').style.marginLeft).toEqual('150px')
+    })
+})
+
+test('style attribute bindings are removed by object syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ display: false }">
+            <span style="display: inline" x-bind:style="{ display: false }"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').style.display).toBeFalsy()
+})
+
+test('style attribute bindings are added by string syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ initialStyles: 'display: hidden' }">
+            <span x-bind:style="initialStyles"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').style.display).toBeTruthy()
+    expect(document.querySelector('span').style.display).toEqual('hidden')
+})
+
+test('style attribute bindings are added by object syntax, concatenation works & name is camelized', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ numberValue: 20 }">
+            <span x-bind:style="{ 'padding-left': numberValue + 'px' }"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').style.paddingLeft).toBeTruthy()
+    expect(document.querySelector('span').style.paddingLeft).toEqual('20px')
+})
+
+test('style attribute bindings are added by nested object syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ nested: { styleValue: '12px' } }">
+            <span x-bind:style="{ paddingLeft: nested.styleValue }"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').style.paddingLeft).toBeTruthy()
+    expect(document.querySelector('span').style.paddingLeft).toEqual('12px')
+})
+
+test('style attribute bindings are added by array syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{}">
+            <span class="" x-bind:style="['display: inline;', 'padding-top: 100px']"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').style.display).toBeTruthy()
+    expect(document.querySelector('span').style.display).toEqual('inline')
+    expect(document.querySelector('span').style.paddingTop).toBeTruthy()
+    expect(document.querySelector('span').style.paddingTop).toEqual('100px')
+})
+
+test('style attribute bindings are synced by string syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data="{foo: 'display: hidden; cursor: pointer;'}">
+            <span style="display: inline" x-bind:style="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').style.display).toBeTruthy()
+    expect(document.querySelector('span').style.display).toEqual('hidden')
+    expect(document.querySelector('span').style.cursor).toBeTruthy()
+    expect(document.querySelector('span').style.cursor).toEqual('pointer')
+})
+
 test('boolean attributes set to false are removed from element', async () => {
     document.body.innerHTML = `
         <div x-data="{ isSet: false }">


### PR DESCRIPTION
Closes #213 Adds Vue-style binding support for the "style" attribute.

Style binding supports:
- string definition with merging/override support
  - eg. `<div style="display: inline" :style="'padding: 10px'"></div>` -> `display: inline; padding: 10px` applied
- array definition with merge/override support
  - eg. `<div style="display: inline" :style="['display: hidden; width: 200px;', 'height: 20px;']"></div>` -> `display: hidden; width: 200px; height: 20px;`
- object definition with override support
  - eg. `<div style="padding-top: 0" :style="{display: 'hidden', paddingTop: '15px', borderColor: 'teal'}></div>"` -> `display: hidden; padding-top: 15px; border-color: teal`

Update README with style object/array support.

~~Unrelated change (to tests): fixes missing assertion calls in `class` bind tests (see https://github.com/alpinejs/alpine/pull/236/commits/6d9e2a091a5d1c68debc15cb20c10afec3dcf197), I'm happy to submit this as a separate PR.~~ Submitted as https://github.com/alpinejs/alpine/pull/360.