### PR TITLE
Chore: "format" npm script with Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "semi": false,
+    "singleQuote": true,
+    "printWidth": 120
+}

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5784,7 +5784,7 @@
       _newArrowCheck(this, _this2);
 
       return _objectSpread2({}, extraVars(), {
-        '$event': e
+        $event: e
       });
     }.bind(this));
   }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -746,7 +746,7 @@
   function runListenerHandler(component, expression, e, extraVars) {
     return component.evaluateCommandExpression(e.target, expression, () => {
       return _objectSpread2({}, extraVars(), {
-        '$event': e
+        $event: e
       });
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6880,6 +6880,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
@@ -7228,9 +7234,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "test": "npx jest",
         "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
         "postpublish": "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag v$PACKAGE_VERSION && git push --tags",
-        "format": "prettier ./src/**/*.js --write"
+        "format": "prettier ./src/**/*.js ./test/*.js --write"
     },
     "author": "Caleb Porzio",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "build": "concurrently \"rollup -c\" \"npx rollup -c rollup-ie11.config.js\"",
         "test": "npx jest",
         "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
-        "postpublish": "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag v$PACKAGE_VERSION && git push --tags"
+        "postpublish": "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag v$PACKAGE_VERSION && git push --tags",
+        "format": "prettier ./src/**/*.js --write"
     },
     "author": "Caleb Porzio",
     "license": "MIT",
@@ -34,6 +35,7 @@
         "jest": "^24.8.0",
         "jsdom-simulant": "^1.1.2",
         "observable-membrane": "^0.26.1",
+        "prettier": "^1.19.1",
         "proxy-polyfill": "^0.3.0",
         "rollup": "^1.31.0",
         "rollup-plugin-babel": "^4.3.3",

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -1,4 +1,4 @@
-import { arrayUnique , isBooleanAttr } from '../utils'
+import { arrayUnique, isBooleanAttr } from '../utils'
 
 export function handleAttributeBindingDirective(component, el, attrName, expression, extraVars) {
     var value = component.evaluateReturnExpression(el, expression, extraVars)
@@ -25,7 +25,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
 
                 el.checked = valueFound
             } else {
-                el.checked = !! value
+                el.checked = !!value
             }
             // If we are explicitly binding a string to the :value, set the string,
             // If the value is a boolean, leave it alone, it will be set to "on"
@@ -57,7 +57,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         }
     } else if (isBooleanAttr(attrName)) {
         // Boolean attributes have to be explicitly added and removed, not just set.
-        if (!! value) {
+        if (!!value) {
             el.setAttribute(attrName, '')
         } else {
             el.removeAttribute(attrName)
@@ -68,7 +68,9 @@ export function handleAttributeBindingDirective(component, el, attrName, express
 }
 
 function updateSelect(el, value) {
-    const arrayWrappedValue = [].concat(value).map(value => { return value + '' })
+    const arrayWrappedValue = [].concat(value).map(value => {
+        return value + ''
+    })
 
     Array.from(el.options).forEach(option => {
         option.selected = arrayWrappedValue.includes(option.value || option.text)

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -1,13 +1,14 @@
 import { transitionIn, transitionOut, getXAttrs } from '../utils'
 
 export function handleForDirective(component, el, expression, initialUpdate) {
-    if (el.tagName.toLowerCase() !== 'template') console.warn('Alpine: [x-for] directive should only be added to <template> tags.')
+    if (el.tagName.toLowerCase() !== 'template')
+        console.warn('Alpine: [x-for] directive should only be added to <template> tags.')
 
     const { single, bunch, iterator1, iterator2 } = parseFor(expression)
 
     var items
     const ifAttr = getXAttrs(el, 'if')[0]
-    if (ifAttr && ! component.evaluateReturnExpression(el, ifAttr.expression))  {
+    if (ifAttr && !component.evaluateReturnExpression(el, ifAttr.expression)) {
         // If there is an "x-if" attribute in conjunction with an x-for,
         // AND x-if resolves to false, just pretend the x-for is
         // empty, effectively hiding it.
@@ -19,7 +20,16 @@ export function handleForDirective(component, el, expression, initialUpdate) {
     // As we walk the array, we'll also walk the DOM (updating/creating as we go).
     var previousEl = el
     items.forEach((i, index, group) => {
-        const currentKey = getThisIterationsKeyFromTemplateTag(component, el, single, iterator1, iterator2, i, index, group)
+        const currentKey = getThisIterationsKeyFromTemplateTag(
+            component,
+            el,
+            single,
+            iterator1,
+            iterator2,
+            i,
+            index,
+            group
+        )
         let currentEl = previousEl.nextElementSibling
 
         // Let's check and see if the x-for has already generated an element last time it ran.
@@ -28,7 +38,7 @@ export function handleForDirective(component, el, expression, initialUpdate) {
             if (currentEl.__x_for_key !== currentKey) {
                 // We'll look ahead to see if we can find it further down.
                 var tmpCurrentEl = currentEl
-                while(tmpCurrentEl) {
+                while (tmpCurrentEl) {
                     // If we found it later in the DOM.
                     if (tmpCurrentEl.__x_for_key === currentKey) {
                         // Move it to where it's supposed to be in the DOM.
@@ -38,7 +48,10 @@ export function handleForDirective(component, el, expression, initialUpdate) {
                         break
                     }
 
-                    tmpCurrentEl = (tmpCurrentEl.nextElementSibling && tmpCurrentEl.nextElementSibling.__x_for_key !== undefined) ? tmpCurrentEl.nextElementSibling : false
+                    tmpCurrentEl =
+                        tmpCurrentEl.nextElementSibling && tmpCurrentEl.nextElementSibling.__x_for_key !== undefined
+                            ? tmpCurrentEl.nextElementSibling
+                            : false
                 }
             }
 
@@ -60,7 +73,10 @@ export function handleForDirective(component, el, expression, initialUpdate) {
             // Let's create a clone from the template.
             const clone = document.importNode(el.content, true)
 
-            if (clone.childElementCount !== 1) console.warn('Alpine: <template> tag with [x-for] encountered with multiple element roots. Make sure <template> only has a single child node.')
+            if (clone.childElementCount !== 1)
+                console.warn(
+                    'Alpine: <template> tag with [x-for] encountered with multiple element roots. Make sure <template> only has a single child node.'
+                )
 
             // Insert it where we are in the DOM.
             el.parentElement.insertBefore(clone, currentEl)
@@ -92,9 +108,12 @@ export function handleForDirective(component, el, expression, initialUpdate) {
 
     // Now that we've added/updated/moved all the elements for the current state of the loop.
     // Anything left over, we can get rid of.
-    var nextElementFromOldLoop = (previousEl.nextElementSibling && previousEl.nextElementSibling.__x_for_key !== undefined) ? previousEl.nextElementSibling : false
+    var nextElementFromOldLoop =
+        previousEl.nextElementSibling && previousEl.nextElementSibling.__x_for_key !== undefined
+            ? previousEl.nextElementSibling
+            : false
 
-    while(nextElementFromOldLoop) {
+    while (nextElementFromOldLoop) {
         const nextElementFromOldLoopImmutable = nextElementFromOldLoop
         const nextSibling = nextElementFromOldLoop.nextElementSibling
 
@@ -102,18 +121,18 @@ export function handleForDirective(component, el, expression, initialUpdate) {
             nextElementFromOldLoopImmutable.remove()
         })
 
-        nextElementFromOldLoop = (nextSibling && nextSibling.__x_for_key !== undefined) ? nextSibling : false
+        nextElementFromOldLoop = nextSibling && nextSibling.__x_for_key !== undefined ? nextSibling : false
     }
 }
 
 // This was taken from VueJS 2.* core. Thanks Vue!
-function parseFor (expression) {
+function parseFor(expression) {
     const forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
     const stripParensRE = /^\(|\)$/g
     const forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
 
     const inMatch = expression.match(forAliasRE)
-    if (! inMatch) return
+    if (!inMatch) return
     const res = {}
     res.bunch = inMatch[2].trim()
     const single = inMatch[1].trim().replace(stripParensRE, '')
@@ -128,7 +147,7 @@ function parseFor (expression) {
         res.single = single
     }
     return res
-  }
+}
 
 function getThisIterationsKeyFromTemplateTag(component, el, single, iterator1, iterator2, i, index, group) {
     const keyAttr = getXAttrs(el, 'bind').filter(attr => attr.value === 'key')[0]
@@ -137,7 +156,5 @@ function getThisIterationsKeyFromTemplateTag(component, el, single, iterator1, i
     if (iterator1) keyAliases[iterator1] = index
     if (iterator2) keyAliases[iterator2] = group
 
-    return keyAttr
-        ? component.evaluateReturnExpression(el, keyAttr.expression, () => keyAliases)
-        : index
+    return keyAttr ? component.evaluateReturnExpression(el, keyAttr.expression, () => keyAliases) : index
 }

--- a/src/directives/if.js
+++ b/src/directives/if.js
@@ -1,21 +1,28 @@
 import { transitionIn, transitionOut } from '../utils'
 
 export function handleIfDirective(el, expressionResult, initialUpdate) {
-    if (el.nodeName.toLowerCase() !== 'template') console.warn(`Alpine: [x-if] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#x-if`)
+    if (el.nodeName.toLowerCase() !== 'template')
+        console.warn(
+            `Alpine: [x-if] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#x-if`
+        )
 
     const elementHasAlreadyBeenAdded = el.nextElementSibling && el.nextElementSibling.__x_inserted_me === true
 
-    if (expressionResult && ! elementHasAlreadyBeenAdded) {
-        const clone = document.importNode(el.content, true);
+    if (expressionResult && !elementHasAlreadyBeenAdded) {
+        const clone = document.importNode(el.content, true)
 
         el.parentElement.insertBefore(clone, el.nextElementSibling)
 
         el.nextElementSibling.__x_inserted_me = true
 
         transitionIn(el.nextElementSibling, () => {}, initialUpdate)
-    } else if (! expressionResult && elementHasAlreadyBeenAdded) {
-        transitionOut(el.nextElementSibling, () => {
-            el.nextElementSibling.remove()
-        }, initialUpdate)
+    } else if (!expressionResult && elementHasAlreadyBeenAdded) {
+        transitionOut(
+            el.nextElementSibling,
+            () => {
+                el.nextElementSibling.remove()
+            },
+            initialUpdate
+        )
     }
 }

--- a/src/directives/model.js
+++ b/src/directives/model.js
@@ -3,17 +3,17 @@ import { registerListener } from './on'
 export function registerModelListener(component, el, modifiers, expression, extraVars) {
     // If the element we are binding to is a select, a radio, or checkbox
     // we'll listen for the change event instead of the "input" event.
-    var event = (el.tagName.toLowerCase() === 'select')
-        || ['checkbox', 'radio'].includes(el.type)
-        || modifiers.includes('lazy')
-        ? 'change' : 'input'
+    var event =
+        el.tagName.toLowerCase() === 'select' || ['checkbox', 'radio'].includes(el.type) || modifiers.includes('lazy')
+            ? 'change'
+            : 'input'
 
     const listenerExpression = `${expression} = rightSideOfExpression($event, ${expression})`
 
     registerListener(component, el, event, modifiers, listenerExpression, () => {
         return {
             ...extraVars(),
-            rightSideOfExpression: generateModelAssignmentFunction(el, modifiers, expression),
+            rightSideOfExpression: generateModelAssignmentFunction(el, modifiers, expression)
         }
     })
 }
@@ -23,7 +23,7 @@ function generateModelAssignmentFunction(el, modifiers, expression) {
         // Radio buttons only work properly when they share a name attribute.
         // People might assume we take care of that for them, because
         // they already set a shared "x-model" attribute.
-        if (! el.hasAttribute('name')) el.setAttribute('name', expression)
+        if (!el.hasAttribute('name')) el.setAttribute('name', expression)
     }
 
     return (event, currentValue) => {
@@ -33,18 +33,26 @@ function generateModelAssignmentFunction(el, modifiers, expression) {
         } else if (el.type === 'checkbox') {
             // If the data we are binding to is an array, toggle it's value inside the array.
             if (Array.isArray(currentValue)) {
-                return event.target.checked ? currentValue.concat([event.target.value]) : currentValue.filter(i => i !== event.target.value)
+                return event.target.checked
+                    ? currentValue.concat([event.target.value])
+                    : currentValue.filter(i => i !== event.target.value)
             } else {
                 return event.target.checked
             }
         } else if (el.tagName.toLowerCase() === 'select' && el.multiple) {
             return modifiers.includes('number')
-                ? Array.from(event.target.selectedOptions).map(option => { return parseFloat(option.value || option.text) })
-                : Array.from(event.target.selectedOptions).map(option => { return option.value || option.text })
+                ? Array.from(event.target.selectedOptions).map(option => {
+                      return parseFloat(option.value || option.text)
+                  })
+                : Array.from(event.target.selectedOptions).map(option => {
+                      return option.value || option.text
+                  })
         } else {
             return modifiers.includes('number')
                 ? parseFloat(event.target.value)
-                : (modifiers.includes('trim') ? event.target.value.trim() : event.target.value)
+                : modifiers.includes('trim')
+                ? event.target.value.trim()
+                : event.target.value
         }
     }
 }

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -21,14 +21,13 @@ export function registerListener(component, el, event, modifiers, expression, ex
         // Listen for this event at the root level.
         document.addEventListener(event, handler)
     } else {
-        const listenerTarget = modifiers.includes('window')
-            ? window : (modifiers.includes('document') ? document : el)
+        const listenerTarget = modifiers.includes('window') ? window : modifiers.includes('document') ? document : el
 
         const handler = e => {
             // Remove this global event handler if the element that declared it
             // has been removed. It's now stale.
             if (listenerTarget === window || listenerTarget === document) {
-                if (! document.body.contains(el)) {
+                if (!document.body.contains(el)) {
                     listenerTarget.removeEventListener(event, handler)
                     return
                 }
@@ -60,7 +59,7 @@ export function registerListener(component, el, event, modifiers, expression, ex
 
 function runListenerHandler(component, expression, e, extraVars) {
     return component.evaluateCommandExpression(e.target, expression, () => {
-        return {...extraVars(), '$event': e}
+        return { ...extraVars(), $event: e }
     })
 }
 
@@ -70,7 +69,7 @@ function isKeyEvent(event) {
 
 function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
     let keyModifiers = modifiers.filter(i => {
-        return ! ['window', 'document', 'prevent', 'stop'].includes(i)
+        return !['window', 'document', 'prevent', 'stop'].includes(i)
     })
 
     // If no modifier is specified, we'll call it a press.
@@ -83,7 +82,7 @@ function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
     const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super']
     const selectedSystemKeyModifiers = systemKeyModifiers.filter(modifier => keyModifiers.includes(modifier))
 
-    keyModifiers = keyModifiers.filter(i => ! selectedSystemKeyModifiers.includes(i))
+    keyModifiers = keyModifiers.filter(i => !selectedSystemKeyModifiers.includes(i))
 
     if (selectedSystemKeyModifiers.length > 0) {
         const activelyPressedKeyModifiers = selectedSystemKeyModifiers.filter(modifier => {

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -22,9 +22,9 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         return
     }
 
-    const handle = (resolve) => {
-        if (! value) {
-            if ( el.style.display !== 'none' ) {
+    const handle = resolve => {
+        if (!value) {
+            if (el.style.display !== 'none') {
                 transitionOut(el, () => {
                     resolve(() => {
                         hide()
@@ -34,7 +34,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
                 resolve(() => {})
             }
         } else {
-            if ( el.style.display !== '' ) {
+            if (el.style.display !== '') {
                 transitionIn(el, () => {
                     show()
                 })
@@ -58,7 +58,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
     // x-show is encountered during a DOM tree walk. If an element
     // we encounter is NOT a child of another x-show element we
     // can execute the previous x-show stack (if one exists).
-    if (component.showDirectiveLastElement && ! component.showDirectiveLastElement.contains(el)) {
+    if (component.showDirectiveLastElement && !component.showDirectiveLastElement.contains(el)) {
         component.executeAndClearRemainingShowDirectiveStack()
     }
 

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -330,4 +330,4 @@ test('checkbox values are set correctly', async () => {
     expect(document.querySelector('input[name="trueCheckbox"]').value).toEqual('on')
     expect(document.querySelector('input[name="falseCheckbox"]').value).toEqual('on')
     expect(document.querySelector('input[name="stringCheckbox"]').value).toEqual('foo')
-});
+})

--- a/test/cloak.spec.js
+++ b/test/cloak.spec.js
@@ -16,5 +16,7 @@ test('x-cloak is removed', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('x-cloak')).toBeNull() })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('x-cloak')).toBeNull()
+    })
 })

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -5,7 +5,9 @@ test('auto-detect new components at the top level', async () => {
     var runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -25,20 +27,24 @@ test('auto-detect new components at the top level', async () => {
         {
             target: document.querySelector('section'),
             type: 'childList',
-            addedNodes: [ document.querySelector('div') ],
+            addedNodes: [document.querySelector('div')]
         }
     ])
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' } })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })
 
 test('auto-detect nested new components at the top level', async () => {
     var runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -60,20 +66,24 @@ test('auto-detect nested new components at the top level', async () => {
         {
             target: document.querySelector('section'),
             type: 'childList',
-            addedNodes: [ document.querySelector('article') ],
+            addedNodes: [document.querySelector('article')]
         }
     ])
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' } })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })
 
 test('auto-detect new components and dont lose state of existing ones', async () => {
     var runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -88,9 +98,11 @@ test('auto-detect new components and dont lose state of existing ones', async ()
 
     Alpine.start()
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' } })
 
-    await wait(() => { expect(document.querySelector('#A span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('#A span').innerText).toEqual('bar')
+    })
 
     document.querySelector('#B').innerHTML = `
         <div x-data="{foo: 'baz'}">
@@ -103,7 +115,7 @@ test('auto-detect new components and dont lose state of existing ones', async ()
         {
             target: document.querySelector('#A'),
             type: 'childList',
-            addedNodes: [ document.querySelector('#B div') ],
+            addedNodes: [document.querySelector('#B div')]
         }
     ])
 
@@ -117,7 +129,9 @@ test('auto-detect new components that are wrapped in non-new component tags', as
     var runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -132,9 +146,11 @@ test('auto-detect new components that are wrapped in non-new component tags', as
 
     Alpine.start()
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' } })
 
-    await wait(() => { expect(document.querySelector('#A span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('#A span').innerText).toEqual('bar')
+    })
 
     document.querySelector('#B').innerHTML = `
         <section>
@@ -149,7 +165,7 @@ test('auto-detect new components that are wrapped in non-new component tags', as
         {
             target: document.querySelector('#A'),
             type: 'childList',
-            addedNodes: [ document.querySelector('#B section') ],
+            addedNodes: [document.querySelector('#B section')]
         }
     ])
 
@@ -163,7 +179,9 @@ test('auto-initialize new elements added to a component', async () => {
     var runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -187,25 +205,33 @@ test('auto-initialize new elements added to a component', async () => {
     `
 
     runObservers[0]([
-        { target: document.querySelector('#target'), addedNodes: [
-            document.querySelector('#target span'),
-            document.querySelector('#target button'),
-        ] }
+        {
+            target: document.querySelector('#target'),
+            addedNodes: [document.querySelector('#target span'), document.querySelector('#target button')]
+        }
     ])
 
-    await wait(() => { expect(document.querySelector('#target span').innerText).toEqual(0) })
+    await wait(() => {
+        expect(document.querySelector('#target span').innerText).toEqual(0)
+    })
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
-    await wait(() => { expect(document.querySelector('#target span').innerText).toEqual(1) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(1)
+    })
+    await wait(() => {
+        expect(document.querySelector('#target span').innerText).toEqual(1)
+    })
 })
 
 test('auto-detect x-data property changes at run-time', async () => {
     var runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -230,7 +256,9 @@ test('auto-detect x-data property changes at run-time', async () => {
         }
     ])
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(1)
+    })
 })
 
 test('nested components only get registered once on initialization', async () => {
@@ -240,7 +268,7 @@ test('nested components only get registered once on initialization', async () =>
     }
 
     var initCount = 0
-    window.registerInit = function () {
+    window.registerInit = function() {
         initCount = initCount + 1
     }
 
@@ -293,5 +321,7 @@ test('x-attributes are matched exactly', async () => {
 
     expect(document.getElementById('el1').style.display).toEqual('none')
     expect(document.getElementById('el2').style.display).not.toEqual('none')
-    await wait(() => { expect(document.getElementById('el3').style.display).not.toEqual('none') })
+    await wait(() => {
+        expect(document.getElementById('el3').style.display).not.toEqual('none')
+    })
 })

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -16,7 +16,9 @@ test('data manipulated on component object is reactive', async () => {
 
     document.querySelector('div').__x.$data.foo = 'baz'
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('baz')
+    })
 })
 
 test('x-data attribute value is optional', async () => {
@@ -37,11 +39,11 @@ test('x-data can use attributes from a reusable function', async () => {
             <span x-text="foo"></span>
         </div>
     `
-        test = function() {
-            return {
-                foo: 'bar',
-            }
+    test = function() {
+        return {
+            foo: 'bar'
         }
+    }
 
     Alpine.start()
 
@@ -61,7 +63,9 @@ test('functions in x-data are reactive', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('baz')
+    })
 })
 
 test('Proxies are not nested and duplicated when manipulating an array', async () => {
@@ -77,31 +81,59 @@ test('Proxies are not nested and duplicated when manipulating an array', async (
 
     // Before this fix: https://github.com/alpinejs/alpine/pull/141
     // This test would create exponentially slower performance and eventually stall out.
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
     document.querySelector('h1').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
     document.querySelector('h1').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
     document.querySelector('h1').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
     document.querySelector('h1').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
     document.querySelector('h1').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
     document.querySelector('h1').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+    })
     document.querySelector('button').click()
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })

--- a/test/dispatch.spec.js
+++ b/test/dispatch.spec.js
@@ -20,5 +20,7 @@ test('$dispatch', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('baz')
+    })
 })

--- a/test/el.spec.js
+++ b/test/el.spec.js
@@ -18,13 +18,15 @@ test('$el', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('div').innerHTML).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('div').innerHTML).toEqual('foo')
+    })
 })
 
 test('$el doesnt return a proxy', async () => {
     var isProxy
-    window.setIsProxy = function (el) {
-        isProxy = !! el.isProxy
+    window.setIsProxy = function(el) {
+        isProxy = !!el.isProxy
     }
 
     document.body.innerHTML = `

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -23,7 +23,9 @@ test('x-for', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(2) })
+    await wait(() => {
+        expect(document.querySelectorAll('span').length).toEqual(2)
+    })
 
     expect(document.querySelectorAll('span')[0].innerText).toEqual('foo')
     expect(document.querySelectorAll('span')[1].innerText).toEqual('bar')
@@ -46,7 +48,9 @@ test('removes all elements when array is empty and previously had one item', asy
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(0) })
+    await wait(() => {
+        expect(document.querySelectorAll('span').length).toEqual(0)
+    })
 })
 
 test('removes all elements when array is empty and previously had multiple items', async () => {
@@ -66,7 +70,9 @@ test('removes all elements when array is empty and previously had multiple items
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(0) })
+    await wait(() => {
+        expect(document.querySelectorAll('span').length).toEqual(0)
+    })
 })
 
 test('elements inside of loop are reactive', async () => {
@@ -168,7 +174,9 @@ test('adding key attribute moves dom nodes properly', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(3) })
+    await wait(() => {
+        expect(document.querySelectorAll('span').length).toEqual(3)
+    })
 
     expect(document.querySelectorAll('span')[0].getAttribute('order')).toEqual('second')
     expect(document.querySelectorAll('span')[1].getAttribute('order')).toEqual('first')
@@ -192,7 +200,9 @@ test('can key by index', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(3) })
+    await wait(() => {
+        expect(document.querySelectorAll('span').length).toEqual(3)
+    })
 })
 
 test('can use index inside of loop', async () => {
@@ -227,8 +237,8 @@ test('can use third iterator param (collection) inside of loop', async () => {
 
     Alpine.start()
 
-    expect(document.querySelector('h1').innerText).toEqual(["foo"])
-    expect(document.querySelector('h2').innerText).toEqual(["foo"])
+    expect(document.querySelector('h1').innerText).toEqual(['foo'])
+    expect(document.querySelector('h2').innerText).toEqual(['foo'])
 })
 
 test('can use x-if in conjunction with x-for', async () => {
@@ -278,13 +288,19 @@ test('listeners in loop get fresh iteration data even though they are only regis
 
     document.querySelector('span').click()
 
-    await wait(() => { expect(document.querySelector('h1').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('h1').innerText).toEqual('foo')
+    })
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 
     document.querySelector('span').click()
 
-    await wait(() => { expect(document.querySelector('h1').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('h1').innerText).toEqual('bar')
+    })
 })

--- a/test/html.spec.js
+++ b/test/html.spec.js
@@ -14,7 +14,9 @@ test('x-html on init', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>') })
+    await wait(() => {
+        expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>')
+    })
 })
 
 test('x-html on triggered update', async () => {
@@ -28,9 +30,13 @@ test('x-html on triggered update', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('') })
+    await wait(() => {
+        expect(document.querySelector('span').innerHTML).toEqual('')
+    })
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>') })
+    await wait(() => {
+        expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>')
+    })
 })

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -22,5 +22,7 @@ test('x-if', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('p')).toBeTruthy() })
+    await wait(() => {
+        expect(document.querySelector('p')).toBeTruthy()
+    })
 })

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -7,7 +7,7 @@ global.MutationObserver = class {
 
 test('x-init', async () => {
     var spanValue
-    window.setSpanValue = (el) => {
+    window.setSpanValue = el => {
         spanValue = el.innerHTML
     }
 
@@ -25,8 +25,12 @@ test('x-init', async () => {
 test('x-init from data function with callback return for "x-mounted" functionality', async () => {
     var valueA
     var valueB
-    window.setValueA = (el) => { valueA = el.innerHTML }
-    window.setValueB = (el) => { valueB = el.innerText }
+    window.setValueA = el => {
+        valueA = el.innerHTML
+    }
+    window.setValueB = el => {
+        valueB = el.innerText
+    }
     window.data = function() {
         return {
             foo: 'bar',
@@ -67,7 +71,9 @@ test('callbacks registered within x-init can affect reactive data changes', asyn
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bob') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bob')
+    })
 })
 
 test('callbacks registered within x-init callback can affect reactive data changes', async () => {
@@ -85,7 +91,9 @@ test('callbacks registered within x-init callback can affect reactive data chang
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bob') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bob')
+    })
 })
 
 test('x-init is capable of dispatching an event', async () => {

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -26,9 +26,11 @@ test('x-model updates value when updated via input event', async () => {
 
     Alpine.start()
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'baz' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'baz' } })
 
-    await wait(() => { expect(document.querySelector('input').value).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('input').value).toEqual('baz')
+    })
 })
 
 test('x-model reflects data changed elsewhere', async () => {
@@ -44,7 +46,9 @@ test('x-model reflects data changed elsewhere', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('input').value).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('input').value).toEqual('baz')
+    })
 })
 
 test('x-model casts value to number if number modifier is present', async () => {
@@ -56,9 +60,11 @@ test('x-model casts value to number if number modifier is present', async () => 
 
     Alpine.start()
 
-    fireEvent.input(document.querySelector('input'), { target: { value: '123' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: '123' } })
 
-    await wait(() => { expect(document.querySelector('[x-data]').__x.$data.foo).toEqual(123) })
+    await wait(() => {
+        expect(document.querySelector('[x-data]').__x.$data.foo).toEqual(123)
+    })
 })
 
 test('x-model trims value if trim modifier is present', async () => {
@@ -72,9 +78,11 @@ test('x-model trims value if trim modifier is present', async () => {
 
     Alpine.start()
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar   ' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar   ' } })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })
 
 test('x-model updates value when updated via changed event when lazy modifier is present', async () => {
@@ -86,9 +94,11 @@ test('x-model updates value when updated via changed event when lazy modifier is
 
     Alpine.start()
 
-    fireEvent.change(document.querySelector('input'), { target: { value: 'baz' }})
+    fireEvent.change(document.querySelector('input'), { target: { value: 'baz' } })
 
-    await wait(() => { expect(document.querySelector('input').value).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('input').value).toEqual('baz')
+    })
 })
 
 test('x-model binds checkbox value', async () => {
@@ -103,11 +113,13 @@ test('x-model binds checkbox value', async () => {
     Alpine.start()
 
     expect(document.querySelector('input').checked).toEqual(true)
-    expect(document.querySelector('span').getAttribute('bar')).toEqual("true")
+    expect(document.querySelector('span').getAttribute('bar')).toEqual('true')
 
-    fireEvent.change(document.querySelector('input'), { target: { checked: false }})
+    fireEvent.change(document.querySelector('input'), { target: { checked: false } })
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('bar')).toEqual("false") })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('bar')).toEqual('false')
+    })
 })
 
 test('x-model binds checkbox value to array', async () => {
@@ -124,14 +136,14 @@ test('x-model binds checkbox value to array', async () => {
 
     expect(document.querySelectorAll('input')[0].checked).toEqual(true)
     expect(document.querySelectorAll('input')[1].checked).toEqual(false)
-    expect(document.querySelector('span').getAttribute('bar')).toEqual("bar")
+    expect(document.querySelector('span').getAttribute('bar')).toEqual('bar')
 
-    fireEvent.change(document.querySelectorAll('input')['1'], { target: { checked: true }})
+    fireEvent.change(document.querySelectorAll('input')['1'], { target: { checked: true } })
 
     await wait(() => {
         expect(document.querySelectorAll('input')[0].checked).toEqual(true)
         expect(document.querySelectorAll('input')[1].checked).toEqual(true)
-        expect(document.querySelector('span').getAttribute('bar')).toEqual("bar,baz")
+        expect(document.querySelector('span').getAttribute('bar')).toEqual('bar,baz')
     })
 })
 
@@ -151,7 +163,7 @@ test('x-model binds radio value', async () => {
     expect(document.querySelectorAll('input')[1].checked).toEqual(false)
     expect(document.querySelector('span').getAttribute('bar')).toEqual('bar')
 
-    fireEvent.change(document.querySelectorAll('input')[1], { target: { checked: true }})
+    fireEvent.change(document.querySelectorAll('input')[1], { target: { checked: true } })
 
     await wait(() => {
         expect(document.querySelectorAll('input')[0].checked).toEqual(false)
@@ -180,7 +192,7 @@ test('x-model binds select dropdown', async () => {
     expect(document.querySelectorAll('option')[2].selected).toEqual(false)
     expect(document.querySelector('span').innerText).toEqual('bar')
 
-    fireEvent.change(document.querySelector('select'), { target: { value: 'baz' }});
+    fireEvent.change(document.querySelector('select'), { target: { value: 'baz' } })
 
     await wait(() => {
         expect(document.querySelectorAll('option')[0].selected).toEqual(false)
@@ -211,7 +223,7 @@ test('x-model binds multiple select dropdown', async () => {
     expect(document.querySelector('span').innerText).toEqual(['bar'])
 
     document.querySelectorAll('option')[2].selected = true
-    fireEvent.change(document.querySelector('select'));
+    fireEvent.change(document.querySelector('select'))
 
     await wait(() => {
         expect(document.querySelectorAll('option')[0].selected).toEqual(false)
@@ -234,7 +246,7 @@ test('x-model binds nested keys', async () => {
     expect(document.querySelector('input').value).toEqual('foo')
     expect(document.querySelector('span').innerText).toEqual('foo')
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' } })
 
     await wait(() => {
         expect(document.querySelector('input').value).toEqual('bar')
@@ -255,7 +267,7 @@ test('x-model undefined nested model key defaults to empty string', async () => 
     expect(document.querySelector('input').value).toEqual('')
     expect(document.querySelector('span').innerText).toEqual('')
 
-    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' } })
 
     await wait(() => {
         expect(document.querySelector('input').value).toEqual('bar')

--- a/test/mutations.spec.js
+++ b/test/mutations.spec.js
@@ -4,7 +4,9 @@ test('catch disconnected nodes that were used as targets for any mutations', asy
     const runObservers = []
 
     global.MutationObserver = class {
-        constructor(callback) { runObservers.push(callback) }
+        constructor(callback) {
+            runObservers.push(callback)
+        }
         observe() {}
     }
 
@@ -15,11 +17,13 @@ test('catch disconnected nodes that were used as targets for any mutations', asy
 
     Alpine.start()
 
-    runObservers.forEach(cb => cb([
-        {
-            target: document.createElement('div'),
-            type: 'childList',
-            addedNodes: [ document.createElement('div') ],
-        }
-    ]))
+    runObservers.forEach(cb =>
+        cb([
+            {
+                target: document.createElement('div'),
+                type: 'childList',
+                addedNodes: [document.createElement('div')]
+            }
+        ])
+    )
 })

--- a/test/nesting.spec.js
+++ b/test/nesting.spec.js
@@ -25,7 +25,9 @@ test('can nest components', async () => {
 
     await timeout(20)
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })
 
 test('can access parent properties after nested components', async () => {

--- a/test/next-tick.spec.js
+++ b/test/next-tick.spec.js
@@ -20,5 +20,7 @@ test('$nextTick', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bob') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bob')
+    })
 })

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -21,7 +21,9 @@ test('data modified in event listener updates affected attribute bindings', asyn
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('baz')
+    })
 })
 
 test('nested data modified in event listener updates affected attribute bindings', async () => {
@@ -39,9 +41,10 @@ test('nested data modified in event listener updates affected attribute bindings
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('baz')
+    })
 })
-
 
 test('.stop modifier', async () => {
     document.body.innerHTML = `
@@ -94,7 +97,9 @@ test('.window modifier', async () => {
 
     document.body.click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('baz')
+    })
 })
 
 test('unbind global event handler when element is removed', async () => {
@@ -134,7 +139,9 @@ test('.document modifier', async () => {
 
     document.body.click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('baz')
+    })
 })
 
 test('.once modifier', async () => {
@@ -152,7 +159,9 @@ test('.once modifier', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('1') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('1')
+    })
 
     document.querySelector('button').click()
 
@@ -176,11 +185,15 @@ test('.once modifier does not remove listener if false is returned', async () =>
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('1') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('1')
+    })
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('2') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('2')
+    })
 
     await timeout(25)
 
@@ -202,19 +215,27 @@ test('keydown modifiers', async () => {
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(2) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(2)
+    })
 
     fireEvent.keyDown(document.querySelector('input'), { key: ' ' })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(4) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(4)
+    })
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Spacebar' })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(6) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(6)
+    })
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Escape' })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(7) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(7)
+    })
 })
 
 test('keydown combo modifiers', async () => {
@@ -232,11 +253,15 @@ test('keydown combo modifiers', async () => {
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(0) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(0)
+    })
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Enter', metaKey: true })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(1)
+    })
 })
 
 test('keydown with specified key and stop modifier only stops for specified key', async () => {
@@ -256,7 +281,9 @@ test('keydown with specified key and stop modifier only stops for specified key'
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Escape' })
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(1)
+    })
 
     fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' })
 
@@ -269,12 +296,16 @@ test('click away', async () => {
     // make our own implementation using a specific class added to the class. Ugh.
     Object.defineProperties(window.HTMLElement.prototype, {
         offsetHeight: {
-          get: function() { return this.classList.contains('hidden') ? 0 : 1 }
+            get: function() {
+                return this.classList.contains('hidden') ? 0 : 1
+            }
         },
         offsetWidth: {
-          get: function() { return this.classList.contains('hidden') ? 0 : 1 }
+            get: function() {
+                return this.classList.contains('hidden') ? 0 : 1
+            }
         }
-    });
+    })
 
     document.body.innerHTML = `
         <div id="outer">
@@ -294,19 +325,27 @@ test('click away', async () => {
 
     document.querySelector('li').click()
 
-    await wait(() => { expect(document.querySelector('ul').classList.contains('hidden')).toEqual(false) })
+    await wait(() => {
+        expect(document.querySelector('ul').classList.contains('hidden')).toEqual(false)
+    })
 
     document.querySelector('ul').click()
 
-    await wait(() => { expect(document.querySelector('ul').classList.contains('hidden')).toEqual(false) })
+    await wait(() => {
+        expect(document.querySelector('ul').classList.contains('hidden')).toEqual(false)
+    })
 
     document.querySelector('#outer').click()
 
-    await wait(() => { expect(document.querySelector('ul').classList.contains('hidden')).toEqual(true) })
+    await wait(() => {
+        expect(document.querySelector('ul').classList.contains('hidden')).toEqual(true)
+    })
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('ul').classList.contains('hidden')).toEqual(false) })
+    await wait(() => {
+        expect(document.querySelector('ul').classList.contains('hidden')).toEqual(false)
+    })
 })
 
 test('supports short syntax', async () => {
@@ -324,9 +363,10 @@ test('supports short syntax', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('baz')
+    })
 })
-
 
 test('event with colon', async () => {
     document.body.innerHTML = `
@@ -341,11 +381,13 @@ test('event with colon', async () => {
 
     expect(document.querySelector('span').getAttribute('foo')).toEqual('bar')
 
-    var event = new CustomEvent('my:event');
+    var event = new CustomEvent('my:event')
 
-    document.dispatchEvent(event);
+    document.dispatchEvent(event)
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('foo')).toEqual('baz')
+    })
 })
 
 test('prevent default action when an event returns false', async () => {

--- a/test/readonly.spec.js
+++ b/test/readonly.spec.js
@@ -22,10 +22,12 @@ test('read-only properties do not break the proxy', async () => {
 
     const input = document.querySelector('input')
     Object.defineProperty(input, 'files', {
-        get: () => [new File(["foo"], "foo.txt", {type: "text/plain"})]
+        get: () => [new File(['foo'], 'foo.txt', { type: 'text/plain' })]
     })
 
-    input.dispatchEvent(new Event('change'));
+    input.dispatchEvent(new Event('change'))
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(1)
+    })
 })

--- a/test/ref.spec.js
+++ b/test/ref.spec.js
@@ -20,7 +20,9 @@ test('can reference elements from event listeners', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('lob') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('lob')
+    })
 })
 
 test('can reference elements from data object methods', async () => {
@@ -38,5 +40,7 @@ test('can reference elements from data object methods', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('lob') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('lob')
+    })
 })

--- a/test/show.spec.js
+++ b/test/show.spec.js
@@ -20,7 +20,9 @@ test('x-show toggles display: none; with no other style attributes', async () =>
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;')
+    })
 })
 
 test('x-show toggles display: none; with other style attributes', async () => {
@@ -38,7 +40,9 @@ test('x-show toggles display: none; with other style attributes', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('color: blue; display: none;') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('style')).toEqual('color: blue; display: none;')
+    })
 })
 
 test('x-show waits for transitions within it to finish before hiding an elements', async () => {
@@ -64,7 +68,11 @@ test('x-show waits for transitions within it to finish before hiding an elements
 
     document.querySelector('button').click()
 
-    await new Promise((resolve) => setTimeout(() => { resolve(); }, 50))
+    await new Promise(resolve =>
+        setTimeout(() => {
+            resolve()
+        }, 50)
+    )
 
     await wait(() => {
         expect(document.querySelector('span').getAttribute('style')).toEqual(null)
@@ -119,7 +127,11 @@ test('x-show works with nested x-shows of different functions (hiding vs showing
 
     document.querySelector('button').click()
 
-    await new Promise((resolve) => setTimeout(() => { resolve(); }, 50))
+    await new Promise(resolve =>
+        setTimeout(() => {
+            resolve()
+        }, 50)
+    )
 
     await wait(() => {
         expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;')

--- a/test/strict-mode.spec.js
+++ b/test/strict-mode.spec.js
@@ -6,13 +6,13 @@ global.MutationObserver = class {
 }
 
 test('Proxy does not error in strict mode when reactivity is suspended', async () => {
-    "use strict"
+    'use strict'
 
-    global.statCounter = function () {
+    global.statCounter = function() {
         return {
             count: 0,
             init() {
-                this.count = 1200;
+                this.count = 1200
             }
         }
     }
@@ -26,5 +26,7 @@ test('Proxy does not error in strict mode when reactivity is suspended', async (
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1200) })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual(1200)
+    })
 })

--- a/test/text.spec.js
+++ b/test/text.spec.js
@@ -14,7 +14,9 @@ test('x-text on init', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })
 
 test('x-text on triggered update', async () => {
@@ -28,9 +30,13 @@ test('x-text on triggered update', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('')
+    })
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
 })

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -9,15 +9,15 @@ test('transition in', async () => {
     // Hijack "requestAnimationFrame" for finer-tuned control in this test.
     var frameStack = []
 
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
         frameStack.push(callback)
-    });
+    })
 
     // Hijack "getComputeStyle" because js-dom is weird with it.
     // (hardcoding 10ms transition time for later assertions)
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return { transitionDuration: '.01s' }
-    });
+    })
 
     document.body.innerHTML = `
         <div x-data="{ show: false }">
@@ -34,14 +34,16 @@ test('transition in', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;')
+    })
 
     document.querySelector('button').click()
 
     // Wait out the intial Alpine refresh debounce.
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
-            resolve();
+            resolve()
         }, 5)
     )
 
@@ -64,13 +66,13 @@ test('transition in', async () => {
     expect(document.querySelector('span').classList.contains('enter-end')).toEqual(true)
     expect(document.querySelector('span').getAttribute('style')).toEqual(null)
 
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
             expect(document.querySelector('span').classList.contains('enter')).toEqual(false)
             expect(document.querySelector('span').classList.contains('enter-start')).toEqual(false)
             expect(document.querySelector('span').classList.contains('enter-end')).toEqual(false)
             expect(document.querySelector('span').getAttribute('style')).toEqual(null)
-            resolve();
+            resolve()
         }, 10)
     )
 })
@@ -79,15 +81,15 @@ test('transition out', async () => {
     // Hijack "requestAnimationFrame" for finer-tuned control in this test.
     var frameStack = []
 
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
         frameStack.push(callback)
-    });
+    })
 
     // Hijack "getComputeStyle" because js-dom is weird with it.
     // (hardcoding 10ms transition time for later assertions)
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return { transitionDuration: '.01s' }
-    });
+    })
 
     document.body.innerHTML = `
         <div x-data="{ show: true }">
@@ -104,14 +106,16 @@ test('transition out', async () => {
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual(null) })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('style')).toEqual(null)
+    })
 
     document.querySelector('button').click()
 
     // Wait out the intial Alpine refresh debounce.
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
-            resolve();
+            resolve()
         }, 5)
     )
 
@@ -134,13 +138,13 @@ test('transition out', async () => {
     expect(document.querySelector('span').classList.contains('leave-end')).toEqual(true)
     expect(document.querySelector('span').getAttribute('style')).toEqual(null)
 
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
             expect(document.querySelector('span').classList.contains('leave')).toEqual(false)
             expect(document.querySelector('span').classList.contains('leave-start')).toEqual(false)
             expect(document.querySelector('span').classList.contains('leave-end')).toEqual(false)
             expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;')
-            resolve();
+            resolve()
         }, 10)
     )
 })
@@ -148,13 +152,13 @@ test('transition out', async () => {
 test('original class attribute classes are preserved after transition finishes', async () => {
     var frameStack = []
 
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
         frameStack.push(callback)
-    });
+    })
 
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return { transitionDuration: '.01s' }
-    });
+    })
 
     document.body.innerHTML = `
         <div x-data="{ show: false }">
@@ -170,14 +174,16 @@ test('original class attribute classes are preserved after transition finishes',
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+    await wait(() => {
+        expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;')
+    })
 
     document.querySelector('button').click()
 
     // Wait out the intial Alpine refresh debounce.
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
-            resolve();
+            resolve()
         }, 5)
     )
 
@@ -194,11 +200,11 @@ test('original class attribute classes are preserved after transition finishes',
     expect(document.querySelector('span').classList.contains('enter')).toEqual(true)
     expect(document.querySelector('span').getAttribute('style')).toEqual(null)
 
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
             expect(document.querySelector('span').classList.contains('enter')).toEqual(true)
             expect(document.querySelector('span').getAttribute('style')).toEqual(null)
-            resolve();
+            resolve()
         }, 10)
     )
 })
@@ -207,15 +213,15 @@ test('transition in not called when item is already visible', async () => {
     // Hijack "requestAnimationFrame" for finer-tuned control in this test.
     var frameStack = []
 
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
         frameStack.push(callback)
-    });
+    })
 
     // Hijack "getComputeStyle" because js-dom is weird with it.
     // (hardcoding 10ms transition time for later assertions)
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return { transitionDuration: '.01s' }
-    });
+    })
 
     document.body.innerHTML = `
         <div x-data="{ show: true }">
@@ -237,9 +243,9 @@ test('transition in not called when item is already visible', async () => {
     document.querySelector('button').click()
 
     // Wait out the intial Alpine refresh debounce.
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
-            resolve();
+            resolve()
         }, 5)
     )
 
@@ -256,15 +262,15 @@ test('transition out not called when item is already hidden', async () => {
     // Hijack "requestAnimationFrame" for finer-tuned control in this test.
     var frameStack = []
 
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
         frameStack.push(callback)
-    });
+    })
 
     // Hijack "getComputeStyle" because js-dom is weird with it.
     // (hardcoding 10ms transition time for later assertions)
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return { transitionDuration: '.01s' }
-    });
+    })
 
     document.body.innerHTML = `
         <div x-data="{ show: false }">
@@ -288,9 +294,9 @@ test('transition out not called when item is already hidden', async () => {
     document.querySelector('button').click()
 
     // Wait out the intial Alpine refresh debounce.
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
-            resolve();
+            resolve()
         }, 5)
     )
 
@@ -310,7 +316,7 @@ test('transition with x-show.transition helper', async () => {
         'opacity: 1; transform: scale(1); transform-origin: center; transition-property: opacity transform; transition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         '',
         'display: none;',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.out', [
@@ -319,7 +325,7 @@ test('transition with x-show.transition helper', async () => {
         'opacity: 1; transform: scale(1); transform-origin: center; transition-property: opacity transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'opacity: 1; transform: scale(1); transform-origin: center; transition-property: opacity transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'opacity: 0; transform: scale(0.95); transform-origin: center; transition-property: opacity transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition', [
@@ -330,7 +336,7 @@ test('transition with x-show.transition helper', async () => {
         'opacity: 1; transform: scale(1); transform-origin: center; transition-property: opacity transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'opacity: 1; transform: scale(1); transform-origin: center; transition-property: opacity transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'opacity: 0; transform: scale(0.95); transform-origin: center; transition-property: opacity transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.opacity', [
@@ -341,7 +347,7 @@ test('transition with x-show.transition helper', async () => {
         'opacity: 1; transition-property: opacity; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'opacity: 1; transition-property: opacity; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'opacity: 0; transition-property: opacity; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale', [
@@ -352,7 +358,7 @@ test('transition with x-show.transition helper', async () => {
         'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.95); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85', [
@@ -363,7 +369,7 @@ test('transition with x-show.transition helper', async () => {
         'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.85); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85.duration.200ms', [
@@ -374,7 +380,7 @@ test('transition with x-show.transition helper', async () => {
         'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.85); transform-origin: center; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85.duration.200ms.origin.top', [
@@ -385,7 +391,7 @@ test('transition with x-show.transition helper', async () => {
         'transform: scale(1); transform-origin: top; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(1); transform-origin: top; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.85); transform-origin: top; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85.duration.200ms.origin.top.left', [
@@ -396,34 +402,37 @@ test('transition with x-show.transition helper', async () => {
         'transform: scale(1); transform-origin: top left; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(1); transform-origin: top left; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.85); transform-origin: top left; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
+        'display: none;'
     ])
 
-    await assertTransitionHelperStyleAttributeValues('x-show.transition.in.scale.85.duration.200ms.origin.top.left.out.scale.75.duration.500ms.origin.bottom.right', [
-        'display: none; transform: scale(0.85); transform-origin: top left; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'transform: scale(0.85); transform-origin: top left; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'transform: scale(1); transform-origin: top left; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        '',
-        'transform: scale(1); transform-origin: bottom right; transition-property: transform; transition-duration: 0.5s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'transform: scale(1); transform-origin: bottom right; transition-property: transform; transition-duration: 0.5s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'transform: scale(0.75); transform-origin: bottom right; transition-property: transform; transition-duration: 0.5s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
-        'display: none;',
-    ])
+    await assertTransitionHelperStyleAttributeValues(
+        'x-show.transition.in.scale.85.duration.200ms.origin.top.left.out.scale.75.duration.500ms.origin.bottom.right',
+        [
+            'display: none; transform: scale(0.85); transform-origin: top left; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+            'transform: scale(0.85); transform-origin: top left; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+            'transform: scale(1); transform-origin: top left; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+            '',
+            'transform: scale(1); transform-origin: bottom right; transition-property: transform; transition-duration: 0.5s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+            'transform: scale(1); transform-origin: bottom right; transition-property: transform; transition-duration: 0.5s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+            'transform: scale(0.75); transform-origin: bottom right; transition-property: transform; transition-duration: 0.5s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+            'display: none;'
+        ]
+    )
 })
 
 async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleAttributeExpectations) {
     // Hijack "requestAnimationFrame" for finer-tuned control in this test.
     var frameStack = []
 
-    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
         frameStack.push(callback)
-    });
+    })
 
     // Hijack "getComputeStyle" because js-dom is weird with it.
     // (hardcoding 10ms transition time for later assertions)
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return { transitionDuration: '.02s' }
-    });
+    })
 
     document.body.innerHTML = `
         <div x-data="{ show: false }">
@@ -438,9 +447,9 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
     document.querySelector('button').click()
 
     // Wait out the intial Alpine refresh debounce.
-    await new Promise((resolve) =>
+    await new Promise(resolve =>
         setTimeout(() => {
-            resolve();
+            resolve()
         }, 5)
     )
 
@@ -448,7 +457,7 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[index])
 
-    while(frameStack.length) {
+    while (frameStack.length) {
         frameStack.pop()()
         expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
     }
@@ -464,7 +473,7 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
 
-    while(frameStack.length) {
+    while (frameStack.length) {
         frameStack.pop()()
         expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
     }


### PR DESCRIPTION
Relates to #190 

Creates a prettier config that causes relatively few changes (mostly wanted changes since there were random `;` and missing/extra spaces)

Feel free to close if this isn't something we need, but I would rather let a tool format my code than have to worry about it myself.

Creates "format" & applies it in separate commits for the source & the tests.