### PR TITLE
Chore: Select only "dist" folder for npm tarball using 'files'

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
         "postpublish": "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag v$PACKAGE_VERSION && git push --tags"
     },
+    "files": ["dist"],
     "author": "Caleb Porzio",
     "license": "MIT",
     "devDependencies": {


### PR DESCRIPTION
Closes #244 

Should make npm install & publish marginally faster.

`npm pack` output in this branch, package size:  87.6 kB, unpacked size: 347.9 kB.

```
npm notice
npm notice 📦  alpinejs@2.1.0
npm notice === Tarball Contents ===
npm notice 244.6kB dist/alpine-ie11.js
npm notice 62.8kB  dist/alpine.js
npm notice 1.8kB   package.json
npm notice 1.1kB   LICENSE.md
npm notice 19.5kB  README.ja.md
npm notice 18.0kB  README.md
npm notice === Tarball Details ===
npm notice name:          alpinejs
npm notice version:       2.1.0
npm notice filename:      alpinejs-2.1.0.tgz
npm notice package size:  87.6 kB
npm notice unpacked size: 347.9 kB
npm notice shasum:        104296c4fb358a4863b0411335d9913d407c7683
npm notice integrity:     sha512-NFDzx/XRRL3Oh[...]qY2CZ7yXNpuBg==
npm notice total files:   6
npm notice
alpinejs-2.1.0.tgz
```

`npm pack` output on master: package size:  116.6 kB, unpacked size: 523.8 kB
```
npm notice
npm notice 📦  alpinejs@2.1.0
npm notice === Tarball Contents ===
npm notice 188B    .editorconfig
npm notice 16.2kB  examples/index.html
npm notice 592B    turbolinks-manual-test/index.html
npm notice 521B    turbolinks-manual-test/navigated-away/index.html
npm notice 2.6kB   examples/tags.html
npm notice 244.6kB dist/alpine-ie11.js
npm notice 62.8kB  dist/alpine.js
npm notice 241B    babel.config.js
npm notice 3.0kB   src/directives/bind.js
npm notice 13.4kB  test/bind.spec.js
npm notice 504B    test/cloak.spec.js
npm notice 14.0kB  src/component.js
npm notice 8.0kB   test/constructor.spec.js
npm notice 4.1kB   test/data.spec.js
npm notice 658B    test/dispatch.spec.js
npm notice 899B    test/el.spec.js
npm notice 6.2kB   src/directives/for.js
npm notice 8.9kB   test/for.spec.js
npm notice 927B    test/html.spec.js
npm notice 929B    src/directives/if.js
npm notice 587B    test/if.spec.js
npm notice 2.8kB   src/index.js
npm notice 6.3kB   jest.config.js
npm notice 2.9kB   test/lifecycle.spec.js
npm notice 2.4kB   src/directives/model.js
npm notice 9.3kB   test/model.spec.js
npm notice 587B    test/mutations.spec.js
npm notice 1.2kB   test/nesting.spec.js
npm notice 636B    test/next-tick.spec.js
npm notice 4.2kB   src/directives/on.js
npm notice 11.8kB  test/on.spec.js
npm notice 243B    src/polyfills.js
npm notice 893B    test/readonly.spec.js
npm notice 1.1kB   test/ref.spec.js
npm notice 1.4kB   rollup-ie11.config.js
npm notice 760B    rollup.config.js
npm notice 2.0kB   src/directives/show.js
npm notice 4.2kB   test/show.spec.js
npm notice 713B    test/strict-mode.spec.js
npm notice 0       src/directives/text.js
npm notice 891B    test/text.spec.js
npm notice 24.5kB  test/transition.spec.js
npm notice 14.2kB  src/utils.js
npm notice 1.8kB   package.json
npm notice 1.1kB   LICENSE.md
npm notice 19.5kB  README.ja.md
npm notice 18.0kB  README.md
npm notice 69B     .github/FUNDING.yml
npm notice 488B    .github/workflows/run-tests.yml
npm notice === Tarball Details ===
npm notice name:          alpinejs
npm notice version:       2.1.0
npm notice filename:      alpinejs-2.1.0.tgz
npm notice package size:  116.6 kB
npm notice unpacked size: 523.8 kB
npm notice shasum:        93a810c8ab7321ede4772f13c6aa4f8d2cf8e10d
npm notice integrity:     sha512-A4GfDGr8LLN2a[...]dfgMfxvbLgHDA==
npm notice total files:   49
npm notice
alpinejs-2.1.0.tgz
```