### PR TITLE
fix(IE11): Run observable-membrane through Babel for IE11 build

### DIFF
--- a/rollup-ie11.config.js
+++ b/rollup-ie11.config.js
@@ -21,7 +21,12 @@ export default {
         filesize(),
         babel({
             babelrc: false,
-            exclude: 'node_modules/**',
+            // observable-membrane doesn't ship with IE11
+            // compatible code...
+            include: [
+                'src/**',
+                'node_modules/observable-membrane/**',
+            ],
             presets: [
                 [
                     "@babel/preset-env",


### PR DESCRIPTION
Closes #259 

- Switch to babel `includes` syntax for IE11 rollup build
- include "src/**" and observable membrane globs for babel compilation for IE11
- Build assets (doesn't seem to have

I'm going to need someone to test on IE11, can be done through CDN: https://cdn.jsdelivr.net/gh/HugoDF/alpine@fix-compile-membrane/dist/alpine-ie11.js