### PR TITLE
Don't react if the mutated key is array length

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -4910,18 +4910,17 @@
     }
   }
   function debounce(func, wait) {
-    var timeout;
+    var context = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this;
     return function () {
-      var context = this,
-          args = arguments;
+      var args = arguments;
 
       var later = function later() {
-        timeout = null;
+        context.debounce_timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      clearTimeout(context.debounce_timeout);
+      context.debounce_timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext) {
@@ -6392,7 +6391,7 @@
               while (self.nextTickStack.length > 0) {
                 self.nextTickStack.shift()();
               }
-            }.bind(this), 0)();
+            }.bind(this), 0, self)();
           }
         });
         return {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6380,7 +6380,9 @@
             var _this3 = this;
 
             // Don't react to data changes for cases like the `x-created` hook.
-            if (self.pauseReactivity) return;
+            if (self.pauseReactivity) return; // Don't react if the mutated key is array length as it is a consequence of another mutated property like pushing to the array
+
+            if (Array.isArray(target) && key === 'length') return;
             debounce(function () {
               _newArrowCheck(this, _this3);
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6380,7 +6380,8 @@
             var _this3 = this;
 
             // Don't react to data changes for cases like the `x-created` hook.
-            if (self.pauseReactivity) return; // Don't react if the mutated key is array length as it is a consequence of another mutated property like pushing to the array
+            if (self.pauseReactivity) return; // Don't react if the mutated key is array length as it is a consequence of another mutated property
+            // like pushing to the array
 
             if (Array.isArray(target) && key === 'length') return;
             debounce(function () {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -4910,17 +4910,18 @@
     }
   }
   function debounce(func, wait) {
-    var context = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this;
+    var timeout;
     return function () {
-      var args = arguments;
+      var context = this,
+          args = arguments;
 
       var later = function later() {
-        context.debounce_timeout = null;
+        timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(context.debounce_timeout);
-      context.debounce_timeout = setTimeout(later, wait);
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext) {
@@ -6391,7 +6392,7 @@
               while (self.nextTickStack.length > 0) {
                 self.nextTickStack.shift()();
               }
-            }.bind(this), 0, self)();
+            }.bind(this), 0)();
           }
         });
         return {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1283,7 +1283,9 @@
       let membrane = new ReactiveMembrane({
         valueMutated(target, key) {
           // Don't react to data changes for cases like the `x-created` hook.
-          if (self.pauseReactivity) return;
+          if (self.pauseReactivity) return; // Don't react if the mutated key is array length as it is a consequence of another mutated property like pushing to the array
+
+          if (Array.isArray(target) && key === 'length') return;
           debounce(() => {
             self.updateElements(self.$el); // Walk through the $nextTick stack and clear it as we go.
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1283,7 +1283,8 @@
       let membrane = new ReactiveMembrane({
         valueMutated(target, key) {
           // Don't react to data changes for cases like the `x-created` hook.
-          if (self.pauseReactivity) return; // Don't react if the mutated key is array length as it is a consequence of another mutated property like pushing to the array
+          if (self.pauseReactivity) return; // Don't react if the mutated key is array length as it is a consequence of another mutated property
+          // like pushing to the array
 
           if (Array.isArray(target) && key === 'length') return;
           debounce(() => {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -90,17 +90,19 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait, context = this) {
+  function debounce(func, wait) {
+    var timeout;
     return function () {
-      var args = arguments;
+      var context = this,
+          args = arguments;
 
       var later = function later() {
-        context.debounce_timeout = null;
+        timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(context.debounce_timeout);
-      context.debounce_timeout = setTimeout(later, wait);
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext, additionalHelperVariables = {}) {
@@ -1291,7 +1293,7 @@
             while (self.nextTickStack.length > 0) {
               self.nextTickStack.shift()();
             }
-          }, 0, self)();
+          }, 0)();
         }
 
       });

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -90,19 +90,17 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait) {
-    var timeout;
+  function debounce(func, wait, context = this) {
     return function () {
-      var context = this,
-          args = arguments;
+      var args = arguments;
 
       var later = function later() {
-        timeout = null;
+        context.debounce_timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      clearTimeout(context.debounce_timeout);
+      context.debounce_timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext, additionalHelperVariables = {}) {
@@ -1293,7 +1291,7 @@
             while (self.nextTickStack.length > 0) {
               self.nextTickStack.shift()();
             }
-          }, 0)();
+          }, 0, self)();
         }
 
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alpinejs",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/component.js
+++ b/src/component.js
@@ -88,6 +88,9 @@ export default class Component {
                 // Don't react to data changes for cases like the `x-created` hook.
                 if (self.pauseReactivity) return
 
+                // Don't react if the mutated key is array length as it is a consequence of another mutated property like pushing to the array
+                if (Array.isArray(target) && key === 'length' ) return
+
                 debounce(() => {
                     self.updateElements(self.$el)
 

--- a/src/component.js
+++ b/src/component.js
@@ -88,8 +88,9 @@ export default class Component {
                 // Don't react to data changes for cases like the `x-created` hook.
                 if (self.pauseReactivity) return
 
-                // Don't react if the mutated key is array length as it is a consequence of another mutated property like pushing to the array
-                if (Array.isArray(target) && key === 'length' ) return
+                // Don't react if the mutated key is array length as it is a consequence of another mutated property
+                // like pushing to the array
+                if (Array.isArray(target) && key === 'length') return
 
                 debounce(() => {
                     self.updateElements(self.$el)

--- a/src/component.js
+++ b/src/component.js
@@ -99,7 +99,7 @@ export default class Component {
                     while (self.nextTickStack.length > 0) {
                         self.nextTickStack.shift()()
                     }
-                }, 0)()
+                }, 0, self)()
             },
         })
 

--- a/src/component.js
+++ b/src/component.js
@@ -99,7 +99,7 @@ export default class Component {
                     while (self.nextTickStack.length > 0) {
                         self.nextTickStack.shift()()
                     }
-                }, 0, self)()
+                }, 0)()
             },
         })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,16 +44,15 @@ export function walk(el, callback) {
     }
 }
 
-export function debounce(func, wait) {
-    var timeout
+export function debounce(func, wait, context = this) {
     return function () {
-        var context = this, args = arguments
+        var args = arguments
         var later = function () {
-            timeout = null
+            context.debounce_timeout = null
             func.apply(context, args)
         }
-        clearTimeout(timeout)
-        timeout = setTimeout(later, wait)
+        clearTimeout(context.debounce_timeout)
+        context.debounce_timeout = setTimeout(later, wait)
     }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,15 +44,16 @@ export function walk(el, callback) {
     }
 }
 
-export function debounce(func, wait, context = this) {
+export function debounce(func, wait) {
+    var timeout
     return function () {
-        var args = arguments
+        var context = this, args = arguments
         var later = function () {
-            context.debounce_timeout = null
+            timeout = null
             func.apply(context, args)
         }
-        clearTimeout(context.debounce_timeout)
-        context.debounce_timeout = setTimeout(later, wait)
+        clearTimeout(timeout)
+        timeout = setTimeout(later, wait)
     }
 }
 

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -105,3 +105,67 @@ test('Proxies are not nested and duplicated when manipulating an array', async (
     document.querySelector('button').click()
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
+
+test('array.push is reactive', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ items: ['foo'] }">
+            <span x-text="items.toString()"></span>
+            <button x-on:click="items.push('bar')"></button>
+        </div>
+    `
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual('foo')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo,bar') })
+})
+
+test('array.pop is reactive', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ items: ['foo', 'bar'] }">
+            <span x-text="items.toString()"></span>
+            <button x-on:click="items.pop()"></button>
+        </div>
+    `
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual('foo,bar')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+})
+
+test('array.shift is reactive', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ items: ['foo', 'bar'] }">
+            <span x-text="items.toString()"></span>
+            <button x-on:click="items.shift()"></button>
+        </div>
+    `
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual('foo,bar')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+})
+
+test('array.unshift is reactive', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ items: ['foo'] }">
+            <span x-text="items.toString()"></span>
+            <button x-on:click="items.unshift('bar')"></button>
+        </div>
+    `
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual('foo')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar,foo') })
+})

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -106,6 +106,25 @@ test('Proxies are not nested and duplicated when manipulating an array', async (
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
 
+test('array length mutation will be ignored while items mutations are reactive', async () => {
+    window.renderCount = 0
+
+    document.body.innerHTML = `
+        <div x-data="{ items: ['foo', 'bar', 'baz'], test() {return ++renderCount} }">
+            <span x-text="test()"></span>
+            <button x-on:click="items.push('qux')"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(renderCount).toEqual(1)
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(renderCount).toEqual(2) })
+})
+
 test('array.push is reactive', async () => {
     document.body.innerHTML = `
         <div x-data="{ items: ['foo'] }">
@@ -113,6 +132,7 @@ test('array.push is reactive', async () => {
             <button x-on:click="items.push('bar')"></button>
         </div>
     `
+
     Alpine.start()
 
     expect(document.querySelector('span').innerText).toEqual('foo')
@@ -129,6 +149,7 @@ test('array.pop is reactive', async () => {
             <button x-on:click="items.pop()"></button>
         </div>
     `
+
     Alpine.start()
 
     expect(document.querySelector('span').innerText).toEqual('foo,bar')
@@ -145,6 +166,7 @@ test('array.shift is reactive', async () => {
             <button x-on:click="items.shift()"></button>
         </div>
     `
+
     Alpine.start()
 
     expect(document.querySelector('span').innerText).toEqual('foo,bar')
@@ -161,6 +183,7 @@ test('array.unshift is reactive', async () => {
             <button x-on:click="items.unshift('bar')"></button>
         </div>
     `
+
     Alpine.start()
 
     expect(document.querySelector('span').innerText).toEqual('foo')


### PR DESCRIPTION
Fixes #250
Inside observable-membrane the `ReactiveProxyHandler` calls back `valueMutated` twice when adding a new index to an array, first time for the new index and second time unnecessarily for the change in array length which causes repeated component rendering.