### PR TITLE
Performance improvements

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -4909,19 +4909,17 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait) {
-    var timeout;
+  function debounce(func, wait, context) {
     return function () {
-      var context = this,
-          args = arguments;
+      var args = arguments;
 
       var later = function later() {
-        timeout = null;
+        context.__x_timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      clearTimeout(context.__x_timeout);
+      context.__x_timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext) {
@@ -6389,7 +6387,7 @@
               while (self.nextTickStack.length > 0) {
                 self.nextTickStack.shift()();
               }
-            }.bind(this), 0)();
+            }.bind(this), 0, self)();
           }
         });
         return {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -90,19 +90,17 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait) {
-    var timeout;
+  function debounce(func, wait, context) {
     return function () {
-      var context = this,
-          args = arguments;
+      var args = arguments;
 
       var later = function later() {
-        timeout = null;
+        context.__x_timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      clearTimeout(context.__x_timeout);
+      context.__x_timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext, additionalHelperVariables = {}) {
@@ -1290,7 +1288,7 @@
             while (self.nextTickStack.length > 0) {
               self.nextTickStack.shift()();
             }
-          }, 0)();
+          }, 0, self)();
         }
 
       });

--- a/src/component.js
+++ b/src/component.js
@@ -95,7 +95,7 @@ export default class Component {
                     while (self.nextTickStack.length > 0) {
                         self.nextTickStack.shift()()
                     }
-                }, 0)()
+                }, 0, self)()
             },
         })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,16 +44,15 @@ export function walk(el, callback) {
     }
 }
 
-export function debounce(func, wait) {
-    var timeout
+export function debounce(func, wait, context) {
     return function () {
-        var context = this, args = arguments
+        var args = arguments
         var later = function () {
-            timeout = null
+            context.__x_timeout = null
             func.apply(context, args)
         }
-        clearTimeout(timeout)
-        timeout = setTimeout(later, wait)
+        clearTimeout(context.__x_timeout)
+        context.__x_timeout = setTimeout(later, wait)
     }
 }
 

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -105,3 +105,22 @@ test('Proxies are not nested and duplicated when manipulating an array', async (
     document.querySelector('button').click()
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
+
+test('component does not refresh multiple times when data changes', async () => {
+    window.renderCount = 0
+
+    document.body.innerHTML = `
+        <div x-data="{ items: [], test() {return ++renderCount}  }">
+            <button @click="items.push('ok')"></span>
+            <span x-text="test()"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual(1)
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual(2) })
+})


### PR DESCRIPTION
As mentioned in #272, Alpine refreshes a component many times for each update, especially when using arrays. Despite not being critical right now, this causes an unnecessary performance drop.
The reason sits in the debounce function which doesn't have a context and always instantiates a new timeout variable so the previous calls are never cancelled.

I've chosen to pass the context as a variable rather then using `.bind(self)` because I want to enforce it if the same function will be used in the future (it would be too easy to forget to bind the right context otherwise).

Big thanks to @ahmedkandel for pointing out the issue and suggesting the unit test.