### PR TITLE
Debounce timeout never gets cleared

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -4909,8 +4909,7 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait) {
-    var context = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this;
+  function debounce(func, wait, context) {
     return function () {
       var args = arguments;
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -4910,18 +4910,17 @@
     }
   }
   function debounce(func, wait) {
-    var timeout;
+    var context = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : this;
     return function () {
-      var context = this,
-          args = arguments;
+      var args = arguments;
 
       var later = function later() {
-        timeout = null;
+        context.debounce_timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      clearTimeout(context.debounce_timeout);
+      context.debounce_timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext) {
@@ -6389,7 +6388,7 @@
               while (self.nextTickStack.length > 0) {
                 self.nextTickStack.shift()();
               }
-            }.bind(this), 0)();
+            }.bind(this), 0, self)();
           }
         });
         return {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -90,7 +90,7 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait, context = this) {
+  function debounce(func, wait, context) {
     return function () {
       var args = arguments;
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -90,19 +90,17 @@
       node = node.nextElementSibling;
     }
   }
-  function debounce(func, wait) {
-    var timeout;
+  function debounce(func, wait, context = this) {
     return function () {
-      var context = this,
-          args = arguments;
+      var args = arguments;
 
       var later = function later() {
-        timeout = null;
+        context.debounce_timeout = null;
         func.apply(context, args);
       };
 
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
+      clearTimeout(context.debounce_timeout);
+      context.debounce_timeout = setTimeout(later, wait);
     };
   }
   function saferEval(expression, dataContext, additionalHelperVariables = {}) {
@@ -1290,7 +1288,7 @@
             while (self.nextTickStack.length > 0) {
               self.nextTickStack.shift()();
             }
-          }, 0)();
+          }, 0, self)();
         }
 
       });

--- a/src/component.js
+++ b/src/component.js
@@ -95,7 +95,7 @@ export default class Component {
                     while (self.nextTickStack.length > 0) {
                         self.nextTickStack.shift()()
                     }
-                }, 0)()
+                }, 0, self)()
             },
         })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ export function walk(el, callback) {
     }
 }
 
-export function debounce(func, wait, context = this) {
+export function debounce(func, wait, context) {
     return function () {
         var args = arguments
         var later = function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,16 +44,15 @@ export function walk(el, callback) {
     }
 }
 
-export function debounce(func, wait) {
-    var timeout
+export function debounce(func, wait, context = this) {
     return function () {
-        var context = this, args = arguments
+        var args = arguments
         var later = function () {
-            timeout = null
+            context.debounce_timeout = null
             func.apply(context, args)
         }
-        clearTimeout(timeout)
-        timeout = setTimeout(later, wait)
+        clearTimeout(context.debounce_timeout)
+        context.debounce_timeout = setTimeout(later, wait)
     }
 }
 

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -105,3 +105,22 @@ test('Proxies are not nested and duplicated when manipulating an array', async (
     document.querySelector('button').click()
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
+
+test('component refresh one time per update whatever the number of mutations in the update', async () => {
+    window.refreshCount = 0
+
+    document.body.innerHTML = `
+        <div x-data="{ items: ['foo', 'bar'], qux: 'quux', test() {return ++refreshCount} }">
+            <span x-text="test()"></span>
+            <button x-on:click="items.push('baz'); qux = 'corge';"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(refreshCount).toEqual(1)
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(refreshCount).toEqual(2) })
+})


### PR DESCRIPTION
Fixes #272
Inside utils.js the debounce function declares timeout variable for each call which preventing the timeout from being cleared and causes repeated component rendering.