### PR TITLE
Add $watch magic method

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ There are 13 directives available to you:
 | [`x-transition`](#x-transition) |
 | [`x-cloak`](#x-cloak) |
 
-And 5 magic properties:
+And 6 magic properties:
 
 | Magic Properties
 | --- |
@@ -111,6 +111,7 @@ And 5 magic properties:
 | [`$event`](#event) |
 | [`$dispatch`](#dispatch) |
 | [`$nextTick`](#nexttick) |
+| [`$watch`](#watch) |
 
 
 ### Directives
@@ -500,7 +501,17 @@ You can also use `$dispatch()` to trigger data updates for `x-model` bindings. F
 </div>
 ```
 
-`$nextTick` is a magic property that allows you to only execute a given expression AFTER Alpine has made its reactive DOM updates. This is useful for times you want to interact with the DOM state AFTER it's reflected any data updates you've made.
+---
+
+### `$watch`
+**Example:**
+```html
+<div x-data="{ open: false }" x-init="$watch('open', value => console.log(value))">
+    <button @click="open = ! open">Toggle Open</button>
+</div>
+```
+
+You can "watch" a component property with the `$watch` magic method. In the above example, when the button is clicked and `open` is changed, the provided callback will fire and `console.log` the new value.
 
 ## v3 Roadmap
 * Move from `x-ref` to `ref` for Vue parity

--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ You can also use `$dispatch()` to trigger data updates for `x-model` bindings. F
 </div>
 ```
 
+`$nextTick` is a magic property that allows you to only execute a given expression AFTER Alpine has made its reactive DOM updates. This is useful for times you want to interact with the DOM state AFTER it's reflected any data updates you've made.
+
 ---
 
 ### `$watch`

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6310,6 +6310,7 @@
       this.unobservedData.$el = null;
       this.unobservedData.$refs = null;
       this.unobservedData.$nextTick = null;
+      this.unobservedData.$watch = null;
       /* IE11-ONLY:END */
       // Construct a Proxy-based observable. This will be used to handle reactivity.
 
@@ -6329,6 +6330,15 @@
         _newArrowCheck(this, _this);
 
         this.nextTickStack.push(callback);
+      }.bind(this);
+
+      this.watchers = {};
+
+      this.unobservedData.$watch = function (property, callback) {
+        _newArrowCheck(this, _this);
+
+        if (!this.watchers[property]) this.watchers[property] = [];
+        this.watchers[property].push(callback);
       }.bind(this);
 
       this.showDirectiveStack = [];
@@ -6366,7 +6376,7 @@
         Object.keys(unwrappedData).forEach(function (key) {
           _newArrowCheck(this, _this2);
 
-          if (['$el', '$refs', '$nextTick'].includes(key)) return;
+          if (['$el', '$refs', '$nextTick', '$watch'].includes(key)) return;
           copy[key] = unwrappedData[key];
         }.bind(this));
         return copy;
@@ -6379,7 +6389,15 @@
           valueMutated: function valueMutated(target, key) {
             var _this3 = this;
 
-            // Don't react to data changes for cases like the `x-created` hook.
+            if (self.watchers[key]) {
+              self.watchers[key].forEach(function (callback) {
+                _newArrowCheck(this, _this3);
+
+                return callback(target[key]);
+              }.bind(this));
+            } // Don't react to data changes for cases like the `x-created` hook.
+
+
             if (self.pauseReactivity) return;
             debounce(function () {
               _newArrowCheck(this, _this3);

--- a/test/watch.spec.js
+++ b/test/watch.spec.js
@@ -1,0 +1,29 @@
+import Alpine from 'alpinejs'
+import { wait } from '@testing-library/dom'
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+test('$watch', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'bar', bob: 'lob' }" x-init="$watch('foo', value => { bob = value })">
+            <h1 x-text="foo"></h1>
+            <h2 x-text="bob"></h2>
+
+            <button x-on:click="foo = 'baz'"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('h1').innerText).toEqual('bar')
+    expect(document.querySelector('h2').innerText).toEqual('lob')
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('h1').innerText).toEqual('baz')
+        expect(document.querySelector('h2').innerText).toEqual('baz')
+    })
+})


### PR DESCRIPTION
You can now "watch" for data changes in an Alpine component using the new `$watch` magic method.

Example:
```html
<div x-data="{ open: false }" x-init="$watch('open', value => console.log(value))">
    <button @click="open = ! open">Toggle Open</button>
</div>
```
(When the button is clicked, the new value of `open` is `console.log`'d)