### PR TITLE
Add window.deferLoadingAlpine()

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6794,6 +6794,7 @@
     return Component;
   }();
 
+  var _this8 = undefined;
   var Alpine = {
     start: function () {
       var _start = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
@@ -6926,7 +6927,16 @@
 
   if (!isTesting()) {
     window.Alpine = Alpine;
-    window.Alpine.start();
+
+    if (window.deferLoadingAlpine) {
+      window.deferLoadingAlpine(function () {
+        _newArrowCheck(this, _this8);
+
+        window.Alpine.start();
+      }.bind(undefined));
+    } else {
+      window.Alpine.start();
+    }
   }
 
 })));

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6794,7 +6794,6 @@
     return Component;
   }();
 
-  var _this8 = undefined;
   var Alpine = {
     start: function () {
       var _start = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
@@ -6930,10 +6929,8 @@
 
     if (window.deferLoadingAlpine) {
       window.deferLoadingAlpine(function () {
-        _newArrowCheck(this, _this8);
-
         window.Alpine.start();
-      }.bind(undefined));
+      });
     } else {
       window.Alpine.start();
     }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1629,7 +1629,7 @@
     window.Alpine = Alpine;
 
     if (window.deferLoadingAlpine) {
-      window.deferLoadingAlpine(() => {
+      window.deferLoadingAlpine(function () {
         window.Alpine.start();
       });
     } else {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1627,7 +1627,14 @@
 
   if (!isTesting()) {
     window.Alpine = Alpine;
-    window.Alpine.start();
+
+    if (window.deferLoadingAlpine) {
+      window.deferLoadingAlpine(() => {
+        window.Alpine.start();
+      });
+    } else {
+      window.Alpine.start();
+    }
   }
 
   return Alpine;

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ if (! isTesting()) {
     window.Alpine = Alpine
 
     if (window.deferLoadingAlpine) {
-        window.deferLoadingAlpine(() => {
+        window.deferLoadingAlpine(function () {
             window.Alpine.start()
         })
    } else {

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,14 @@ const Alpine = {
 
 if (! isTesting()) {
     window.Alpine = Alpine
-    window.Alpine.start()
+
+    if (window.deferLoadingAlpine) {
+        window.deferLoadingAlpine(() => {
+            window.Alpine.start()
+        })
+   } else {
+        window.Alpine.start()
+   }
 }
 
 export default Alpine


### PR DESCRIPTION
Allow third-party libs like Livewire to have better control over when Alpine initializes:

```html
window.deferLoadingAlpine = callback => {
    // When some condition is met, call callback() and Alpine will load
}
```