### PR TITLE
Add simple core events

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5315,6 +5315,10 @@
   function transition(el, stages) {
     var _this12 = this;
 
+    var eventContext = {
+      target: el
+    };
+    dispatch('alpine:transition-start', eventContext);
     stages.start();
     stages.during();
     requestAnimationFrame(function () {
@@ -5342,6 +5346,7 @@
             stages.cleanup();
           }
         }.bind(this), duration);
+        dispatch('alpine:transition-end', eventContext);
       }.bind(this));
     }.bind(this));
   } // I grabbed this from Turbolink's codebase.

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -4884,6 +4884,8 @@
     }
   });
 
+  var _this16 = undefined;
+
   // Thanks @stimulus:
   // https://github.com/stimulusjs/stimulus/blob/master/packages/%40stimulus/core/src/application.ts
   function domReady() {
@@ -5342,7 +5344,51 @@
         }.bind(this), duration);
       }.bind(this));
     }.bind(this));
+  } // I grabbed this from Turbolink's codebase.
+
+  function dispatch(eventName) {
+    var _ref = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+        target = _ref.target,
+        cancelable = _ref.cancelable,
+        data = _ref.data;
+
+    var event = document.createEvent("Events");
+    event.initEvent(eventName, true, cancelable == true);
+    event.data = data || {}; // Fix setting `defaultPrevented` when `preventDefault()` is called
+    // http://stackoverflow.com/questions/23349191/event-preventdefault-is-not-working-in-ie-11-for-custom-events
+
+    if (event.cancelable && !preventDefaultSupported) {
+      var preventDefault = event.preventDefault;
+
+      event.preventDefault = function () {
+        var _this15 = this;
+
+        if (!this.defaultPrevented) {
+          Object.defineProperty(this, "defaultPrevented", {
+            get: function get() {
+              _newArrowCheck(this, _this15);
+
+              return true;
+            }.bind(this)
+          });
+        }
+
+        preventDefault.call(this);
+      };
+    }
+
+    (target || document).dispatchEvent(event);
+    return event;
   }
+
+  var preventDefaultSupported = function () {
+    _newArrowCheck(this, _this16);
+
+    var event = document.createEvent("Events");
+    event.initEvent("test", true, true);
+    event.preventDefault();
+    return event.defaultPrevented;
+  }.bind(undefined)();
 
   function isNumeric(subject) {
     return !isNaN(subject);
@@ -6886,8 +6932,9 @@
 
                   this.initializeComponent(el);
                 }.bind(this));
+                dispatch('alpine:loaded');
 
-              case 6:
+              case 7:
               case "end":
                 return _context.stop();
             }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -369,6 +369,10 @@
     transition(el, stages);
   }
   function transition(el, stages) {
+    const eventContext = {
+      target: el
+    };
+    dispatch('alpine:transition-start', eventContext);
     stages.start();
     stages.during();
     requestAnimationFrame(() => {
@@ -386,6 +390,7 @@
             stages.cleanup();
           }
         }, duration);
+        dispatch('alpine:transition-end', eventContext);
       });
     });
   } // I grabbed this from Turbolink's codebase.

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -388,7 +388,44 @@
         }, duration);
       });
     });
+  } // I grabbed this from Turbolink's codebase.
+
+  function dispatch(eventName, {
+    target,
+    cancelable,
+    data
+  } = {}) {
+    const event = document.createEvent("Events");
+    event.initEvent(eventName, true, cancelable == true);
+    event.data = data || {}; // Fix setting `defaultPrevented` when `preventDefault()` is called
+    // http://stackoverflow.com/questions/23349191/event-preventdefault-is-not-working-in-ie-11-for-custom-events
+
+    if (event.cancelable && !preventDefaultSupported) {
+      const {
+        preventDefault
+      } = event;
+
+      event.preventDefault = function () {
+        if (!this.defaultPrevented) {
+          Object.defineProperty(this, "defaultPrevented", {
+            get: () => true
+          });
+        }
+
+        preventDefault.call(this);
+      };
+    }
+
+    (target || document).dispatchEvent(event);
+    return event;
   }
+
+  const preventDefaultSupported = (() => {
+    const event = document.createEvent("Events");
+    event.initEvent("test", true, true);
+    event.preventDefault();
+    return event.defaultPrevented;
+  })();
 
   function isNumeric(subject) {
     return !isNaN(subject);
@@ -1597,6 +1634,7 @@
       this.listenForNewUninitializedComponentsAtRunTime(el => {
         this.initializeComponent(el);
       });
+      dispatch('alpine:loaded');
     },
     discoverComponents: function discoverComponents(callback) {
       const rootEls = document.querySelectorAll('[x-data]');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "alpinejs",
-    "version": "2.1.2",
+    "version": "2.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Component from './component'
-import { domReady, isTesting } from './utils'
+import { domReady, isTesting, dispatch } from './utils'
 
 const Alpine = {
     start: async function () {
@@ -22,6 +22,8 @@ const Alpine = {
         this.listenForNewUninitializedComponentsAtRunTime(el => {
             this.initializeComponent(el)
         })
+
+        dispatch('alpine:loaded')
     },
 
     discoverComponents: function (callback) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -359,6 +359,10 @@ export function transitionClasses(el, classesDuring, classesStart, classesEnd, h
 }
 
 export function transition(el, stages) {
+    const eventContext = { target: el }
+
+    dispatch('alpine:transition-start', eventContext)
+
     stages.start()
     stages.during()
 
@@ -381,6 +385,8 @@ export function transition(el, stages) {
                     stages.cleanup()
                 }
             }, duration);
+
+            dispatch('alpine:transition-end', eventContext)
         })
     });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -385,6 +385,35 @@ export function transition(el, stages) {
     });
 }
 
+// I grabbed this from Turbolink's codebase.
+export function dispatch(eventName, { target, cancelable, data } = {}) {
+    const event = document.createEvent("Events")
+    event.initEvent(eventName, true, cancelable == true)
+    event.data = data || {}
+
+    // Fix setting `defaultPrevented` when `preventDefault()` is called
+    // http://stackoverflow.com/questions/23349191/event-preventdefault-is-not-working-in-ie-11-for-custom-events
+    if (event.cancelable && ! preventDefaultSupported) {
+        const { preventDefault } = event
+        event.preventDefault = function () {
+            if (! this.defaultPrevented) {
+                Object.defineProperty(this, "defaultPrevented", { get: () => true })
+            }
+            preventDefault.call(this)
+        }
+    }
+
+    (target || document).dispatchEvent(event)
+    return event
+}
+
+const preventDefaultSupported = (() => {
+    const event = document.createEvent("Events")
+    event.initEvent("test", true, true)
+    event.preventDefault()
+    return event.defaultPrevented
+})()
+
 function isNumeric(subject){
     return ! isNaN(subject)
 }


### PR DESCRIPTION
This PR closes #283 and introduces **three** new events that are dispatched throughout the Alpine lifecycle.

1. `alpine:loaded` - fired at the document level once Alpine has discovered and initialised all components.

2. `alpine:transition-start` - fired at the transitioning element level once a transition has started but will bubble up to higher levels.

3. `alpine:transition-end` - fired at the transitioning element level after a transition has ended but will bubble up to higher levels.

Happy to make changes to this or introduce new events that people might be interested in. You might note that the original PR had some more events when data changes occur, but at the moment I feel the new `$watch` helper will suffice.

I'm happy to add some tests too, just didn't feel the need to do so at the moment.

/cc @calebporzio @SimoTod @HugoDF 