### PR TITLE
Fix broken `x-if` element initialization

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5708,7 +5708,7 @@
     component.showDirectiveLastElement = el;
   }
 
-  function handleIfDirective(el, expressionResult, initialUpdate) {
+  function handleIfDirective(component, el, expressionResult, initialUpdate) {
     var _this = this;
 
     if (el.nodeName.toLowerCase() !== 'template') console.warn("Alpine: [x-if] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#x-if");
@@ -5721,6 +5721,7 @@
       transitionIn(el.nextElementSibling, function () {
         _newArrowCheck(this, _this);
       }.bind(this), initialUpdate);
+      component.initializeElements(el.nextElementSibling);
     } else if (!expressionResult && elementHasAlreadyBeenAdded) {
       transitionOut(el.nextElementSibling, function () {
         _newArrowCheck(this, _this);
@@ -6406,7 +6407,7 @@
                 return i.type === 'for';
               }.bind(this)).length > 0) return;
               var output = this.evaluateReturnExpression(el, expression, extraVars);
-              handleIfDirective(el, output, initialUpdate);
+              handleIfDirective(this, el, output, initialUpdate);
               break;
 
             case 'for':

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -672,7 +672,7 @@
     component.showDirectiveLastElement = el;
   }
 
-  function handleIfDirective(el, expressionResult, initialUpdate) {
+  function handleIfDirective(component, el, expressionResult, initialUpdate) {
     if (el.nodeName.toLowerCase() !== 'template') console.warn(`Alpine: [x-if] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#x-if`);
     const elementHasAlreadyBeenAdded = el.nextElementSibling && el.nextElementSibling.__x_inserted_me === true;
 
@@ -681,6 +681,7 @@
       el.parentElement.insertBefore(clone, el.nextElementSibling);
       el.nextElementSibling.__x_inserted_me = true;
       transitionIn(el.nextElementSibling, () => {}, initialUpdate);
+      component.initializeElements(el.nextElementSibling);
     } else if (!expressionResult && elementHasAlreadyBeenAdded) {
       transitionOut(el.nextElementSibling, () => {
         el.nextElementSibling.remove();
@@ -1497,7 +1498,7 @@
             // We will let the "x-for" directive handle the "if"ing.
             if (attrs.filter(i => i.type === 'for').length > 0) return;
             var output = this.evaluateReturnExpression(el, expression, extraVars);
-            handleIfDirective(el, output, initialUpdate);
+            handleIfDirective(this, el, output, initialUpdate);
             break;
 
           case 'for':

--- a/src/component.js
+++ b/src/component.js
@@ -271,7 +271,7 @@ export default class Component {
 
                     var output = this.evaluateReturnExpression(el, expression, extraVars)
 
-                    handleIfDirective(el, output, initialUpdate)
+                    handleIfDirective(this, el, output, initialUpdate)
                     break;
 
                 case 'for':

--- a/src/directives/if.js
+++ b/src/directives/if.js
@@ -1,6 +1,6 @@
 import { transitionIn, transitionOut } from '../utils'
 
-export function handleIfDirective(el, expressionResult, initialUpdate) {
+export function handleIfDirective(component, el, expressionResult, initialUpdate) {
     if (el.nodeName.toLowerCase() !== 'template') console.warn(`Alpine: [x-if] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#x-if`)
 
     const elementHasAlreadyBeenAdded = el.nextElementSibling && el.nextElementSibling.__x_inserted_me === true
@@ -13,6 +13,8 @@ export function handleIfDirective(el, expressionResult, initialUpdate) {
         el.nextElementSibling.__x_inserted_me = true
 
         transitionIn(el.nextElementSibling, () => {}, initialUpdate)
+
+        component.initializeElements(el.nextElementSibling)
     } else if (! expressionResult && elementHasAlreadyBeenAdded) {
         transitionOut(el.nextElementSibling, () => {
             el.nextElementSibling.remove()

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -243,7 +243,7 @@ test('Alpine mutations don\'t trigger (like x-if and x-for) MutationObserver', a
         ] }
     ])
 
-    expect(evaluations).toEqual(1)
+    expect(evaluations).toEqual(2)
 })
 
 test('auto-detect x-data property changes at run-time', async () => {

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -24,3 +24,34 @@ test('x-if', async () => {
 
     await wait(() => { expect(document.querySelector('p')).toBeTruthy() })
 })
+
+test('elements inside x-if are still reactive', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ show: false, foo: 'bar' }">
+            <h1 x-on:click="show = ! show"></h1>
+
+            <template x-if="show">
+                <h2 @click="foo = 'baz'"></h2>
+            </template>
+
+            <span x-text="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('h2')).toBeFalsy()
+    expect(document.querySelector('span').innerText).toEqual('bar')
+
+    document.querySelector('h1').click()
+
+    await wait(() => {
+        expect(document.querySelector('h2')).toBeTruthy()
+    })
+
+    document.querySelector('h2').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('baz')
+    })
+})


### PR DESCRIPTION
In the following snippet, before this PR, "foo" was never getting set to "baz". Now it is.

```html
<div x-data="{ show: false, foo: 'bar' }">
    <h1 x-on:click="show = ! show"></h1>

    <template x-if="show">
        <h2 @click="foo = 'baz'"></h2>
    </template>

    <span x-text="foo"></span>
</div>
```