### PR TITLE
nextTick runs before x-for finishes updating

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -23,10 +23,10 @@
   	return module = { exports: {} }, fn(module, module.exports), module.exports;
   }
 
-  (function(){function k(){function p(a){return a?"object"===typeof a||"function"===typeof a:!1}var l=null;var n=function(a,c){function g(){}if(!p(a)||!p(c))throw new TypeError("Cannot create proxy with a non-object as target or handler");l=function(){a=null;g=function(b){throw new TypeError("Cannot perform '"+b+"' on a proxy that has been revoked");};};setTimeout(function(){l=null;},0);var f=c;c={get:null,set:null,apply:null,construct:null};for(var h in f){if(!(h in c))throw new TypeError("Proxy polyfill does not support trap '"+
-  h+"'");c[h]=f[h];}"function"===typeof f&&(c.apply=f.apply.bind(f));var d=this,q=!1,r=!1;"function"===typeof a?(d=function(){var b=this&&this.constructor===d,e=Array.prototype.slice.call(arguments);g(b?"construct":"apply");return b&&c.construct?c.construct.call(this,a,e):!b&&c.apply?c.apply(a,this,e):b?(e.unshift(a),new (a.bind.apply(a,e))):a.apply(this,e)},q=!0):a instanceof Array&&(d=[],r=!0);var t=c.get?function(b){g("get");return c.get(this,b,d)}:function(b){g("get");return this[b]},w=c.set?function(b,
-  e){g("set");c.set(this,b,e,d);}:function(b,e){g("set");this[b]=e;},u={};Object.getOwnPropertyNames(a).forEach(function(b){if(!((q||r)&&b in d)){var e={enumerable:!!Object.getOwnPropertyDescriptor(a,b).enumerable,get:t.bind(a,b),set:w.bind(a,b)};Object.defineProperty(d,b,e);u[b]=!0;}});f=!0;Object.setPrototypeOf?Object.setPrototypeOf(d,Object.getPrototypeOf(a)):d.__proto__?d.__proto__=a.__proto__:f=!1;if(c.get||!f)for(var m in a)u[m]||Object.defineProperty(d,m,{get:t.bind(a,m)});Object.seal(a);Object.seal(d);
-  return d};n.revocable=function(a,c){return {proxy:new n(a,c),revoke:l}};return n}var v="undefined"!==typeof process&&"[object process]"==={}.toString.call(process)||"undefined"!==typeof navigator&&"ReactNative"===navigator.product?commonjsGlobal:self;v.Proxy||(v.Proxy=k(),v.Proxy.revocable=v.Proxy.revocable);})();
+  (function(){function l(){function n(a){return a?"object"===typeof a||"function"===typeof a:!1}var p=null;var g=function(a,b){function f(){}if(!n(a)||!n(b))throw new TypeError("Cannot create proxy with a non-object as target or handler");p=function(){f=function(a){throw new TypeError("Cannot perform '"+a+"' on a proxy that has been revoked");};};var e=b;b={get:null,set:null,apply:null,construct:null};for(var k in e){if(!(k in b))throw new TypeError("Proxy polyfill does not support trap '"+k+"'");b[k]=e[k];}"function"===
+  typeof e&&(b.apply=e.apply.bind(e));var c=this,g=!1,q=!1;"function"===typeof a?(c=function(){var h=this&&this.constructor===c,d=Array.prototype.slice.call(arguments);f(h?"construct":"apply");return h&&b.construct?b.construct.call(this,a,d):!h&&b.apply?b.apply(a,this,d):h?(d.unshift(a),new (a.bind.apply(a,d))):a.apply(this,d)},g=!0):a instanceof Array&&(c=[],q=!0);var r=b.get?function(a){f("get");return b.get(this,a,c)}:function(a){f("get");return this[a]},v=b.set?function(a,d){f("set");b.set(this,
+  a,d,c);}:function(a,b){f("set");this[a]=b;},t={};Object.getOwnPropertyNames(a).forEach(function(b){if(!((g||q)&&b in c)){var d={enumerable:!!Object.getOwnPropertyDescriptor(a,b).enumerable,get:r.bind(a,b),set:v.bind(a,b)};Object.defineProperty(c,b,d);t[b]=!0;}});e=!0;Object.setPrototypeOf?Object.setPrototypeOf(c,Object.getPrototypeOf(a)):c.__proto__?c.__proto__=a.__proto__:e=!1;if(b.get||!e)for(var m in a)t[m]||Object.defineProperty(c,m,{get:r.bind(a,m)});Object.seal(a);Object.seal(c);return c};g.revocable=
+  function(a,b){return {proxy:new g(a,b),revoke:p}};return g}var u="undefined"!==typeof process&&"[object process]"==={}.toString.call(process)||"undefined"!==typeof navigator&&"ReactNative"===navigator.product?commonjsGlobal:self;u.Proxy||(u.Proxy=l(),u.Proxy.revocable=u.Proxy.revocable);})();
 
   !function(e){var t=e.Element.prototype;"function"!=typeof t.matches&&(t.matches=t.msMatchesSelector||t.mozMatchesSelector||t.webkitMatchesSelector||function(e){for(var t=(this.document||this.ownerDocument).querySelectorAll(e),o=0;t[o]&&t[o]!==this;)++o;return Boolean(t[o])}),"function"!=typeof t.closest&&(t.closest=function(e){for(var t=this;t&&1===t.nodeType;){if(t.matches(e))return t;t=t.parentNode;}return null});}(window);
 
@@ -2499,7 +2499,7 @@
       return { __await: arg };
     };
 
-    function AsyncIterator(generator, PromiseImpl) {
+    function AsyncIterator(generator) {
       function invoke(method, arg, resolve, reject) {
         var record = tryCatch(generator[method], generator, arg);
         if (record.type === "throw") {
@@ -2510,14 +2510,14 @@
           if (value &&
               typeof value === "object" &&
               hasOwn.call(value, "__await")) {
-            return PromiseImpl.resolve(value.__await).then(function(value) {
+            return Promise.resolve(value.__await).then(function(value) {
               invoke("next", value, resolve, reject);
             }, function(err) {
               invoke("throw", err, resolve, reject);
             });
           }
 
-          return PromiseImpl.resolve(value).then(function(unwrapped) {
+          return Promise.resolve(value).then(function(unwrapped) {
             // When a yielded Promise is resolved, its final value becomes
             // the .value of the Promise<{value,done}> result for the
             // current iteration.
@@ -2535,7 +2535,7 @@
 
       function enqueue(method, arg) {
         function callInvokeWithMethodAndArg() {
-          return new PromiseImpl(function(resolve, reject) {
+          return new Promise(function(resolve, reject) {
             invoke(method, arg, resolve, reject);
           });
         }
@@ -2575,12 +2575,9 @@
     // Note that simple async functions are implemented on top of
     // AsyncIterator objects; they just return a Promise for the value of
     // the final result produced by the iterator.
-    exports.async = function(innerFn, outerFn, self, tryLocsList, PromiseImpl) {
-      if (PromiseImpl === void 0) PromiseImpl = Promise;
-
+    exports.async = function(innerFn, outerFn, self, tryLocsList) {
       var iter = new AsyncIterator(
-        wrap(innerFn, outerFn, self, tryLocsList),
-        PromiseImpl
+        wrap(innerFn, outerFn, self, tryLocsList)
       );
 
       return exports.isGeneratorFunction(outerFn)
@@ -6043,7 +6040,9 @@
     return new Proxy(target, proxyHandler);
   }
 
-  var Component = /*#__PURE__*/function () {
+  var Component =
+  /*#__PURE__*/
+  function () {
     function Component(el) {
       var _this = this;
 
@@ -6233,9 +6232,11 @@
         }.bind(this));
         this.executeAndClearRemainingShowDirectiveStack(); // Walk through the $nextTick stack and clear it as we go.
 
-        while (this.nextTickStack.length > 0) {
-          this.nextTickStack.shift()();
-        }
+        debounce(function () {
+          while (this.nextTickStack.length > 0) {
+            this.nextTickStack.shift()();
+          }
+        }, 0).bind(this)();
       }
     }, {
       key: "initializeElement",
@@ -6268,11 +6269,13 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack(); // Walk through the $nextTick stack and clear it as we go.
-
-        while (this.nextTickStack.length > 0) {
-          this.nextTickStack.shift()();
-        }
+        this.executeAndClearRemainingShowDirectiveStack();
+        debounce(function () {
+          // Walk through the $nextTick stack and clear it as we go.
+          while (this.nextTickStack.length > 0) {
+            this.nextTickStack.shift()();
+          }
+        }, 0).bind(this)();
       }
     }, {
       key: "executeAndClearRemainingShowDirectiveStack",
@@ -6567,7 +6570,9 @@
 
   var Alpine = {
     start: function () {
-      var _start = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
+      var _start = _asyncToGenerator(
+      /*#__PURE__*/
+      regeneratorRuntime.mark(function _callee() {
         var _this = this;
 
         return regeneratorRuntime.wrap(function _callee$(_context) {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6076,6 +6076,7 @@
 
       this.unobservedData.$el = this.$el;
       this.unobservedData.$refs = this.getRefsProxy();
+      this.nextTickTimeout = null;
       this.nextTickStack = [];
 
       this.unobservedData.$nextTick = function (callback) {
@@ -6230,13 +6231,8 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack(); // Walk through the $nextTick stack and clear it as we go.
-
-        debounce(function () {
-          while (this.nextTickStack.length > 0) {
-            this.nextTickStack.shift()();
-          }
-        }, 0).bind(this)();
+        this.executeAndClearRemainingShowDirectiveStack();
+        this.executeAndClearNextTickStack();
       }
     }, {
       key: "initializeElement",
@@ -6270,12 +6266,7 @@
           el.__x = new Component(el);
         }.bind(this));
         this.executeAndClearRemainingShowDirectiveStack();
-        debounce(function () {
-          // Walk through the $nextTick stack and clear it as we go.
-          while (this.nextTickStack.length > 0) {
-            this.nextTickStack.shift()();
-          }
-        }, 0).bind(this)();
+        this.executeAndClearNextTickStack();
       }
     }, {
       key: "executeAndClearRemainingShowDirectiveStack",
@@ -6562,6 +6553,13 @@
             return ref;
           }
         });
+      }
+    }, {
+      key: "executeAndClearNextTickStack",
+      value: function executeAndClearNextTickStack() {
+        while (this.nextTickStack.length > 0) {
+          this.nextTickStack.shift()();
+        }
       }
     }]);
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6557,9 +6557,18 @@
     }, {
       key: "executeAndClearNextTickStack",
       value: function executeAndClearNextTickStack() {
-        while (this.nextTickStack.length > 0) {
-          this.nextTickStack.shift()();
-        }
+        var self = this;
+
+        var later = function later() {
+          this.nextTickTimeout = null;
+
+          while (self.nextTickStack.length > 0) {
+            self.nextTickStack.shift()();
+          }
+        };
+
+        clearTimeout(this.nextTickTimeout);
+        this.nextTickTimeout = setTimeout(later, 10);
       }
     }]);
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6543,7 +6543,6 @@
 
       this.unobservedData.$el = this.$el;
       this.unobservedData.$refs = this.getRefsProxy();
-      this.nextTickTimeout = null;
       this.nextTickStack = [];
 
       this.unobservedData.$nextTick = function (callback) {
@@ -6700,14 +6699,8 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
-
-        if (rootEl === this.$el) {
-          // Walk through the $nextTick stack and clear it as we go.
-          while (this.nextTickStack.length > 0) {
-            this.nextTickStack.shift()();
-          }
-        }
+        this.executeAndClearRemainingShowDirectiveStack();
+        this.executeAndClearNextTickStack(rootEl);
       }
     }, {
       key: "initializeElement",
@@ -6740,9 +6733,14 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
-
-        if (rootEl === this.$el) {
+        this.executeAndClearRemainingShowDirectiveStack();
+        this.executeAndClearNextTickStack(rootEl);
+      }
+    }, {
+      key: "executeAndClearNextTickStack",
+      value: function executeAndClearNextTickStack(el) {
+        // Skip spawns from alpine directives
+        if (el === this.$el) {
           // Walk through the $nextTick stack and clear it as we go.
           while (this.nextTickStack.length > 0) {
             this.nextTickStack.shift()();

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -23,10 +23,10 @@
   	return module = { exports: {} }, fn(module, module.exports), module.exports;
   }
 
-  (function(){function l(){function n(a){return a?"object"===typeof a||"function"===typeof a:!1}var p=null;var g=function(a,b){function f(){}if(!n(a)||!n(b))throw new TypeError("Cannot create proxy with a non-object as target or handler");p=function(){f=function(a){throw new TypeError("Cannot perform '"+a+"' on a proxy that has been revoked");};};var e=b;b={get:null,set:null,apply:null,construct:null};for(var k in e){if(!(k in b))throw new TypeError("Proxy polyfill does not support trap '"+k+"'");b[k]=e[k];}"function"===
-  typeof e&&(b.apply=e.apply.bind(e));var c=this,g=!1,q=!1;"function"===typeof a?(c=function(){var h=this&&this.constructor===c,d=Array.prototype.slice.call(arguments);f(h?"construct":"apply");return h&&b.construct?b.construct.call(this,a,d):!h&&b.apply?b.apply(a,this,d):h?(d.unshift(a),new (a.bind.apply(a,d))):a.apply(this,d)},g=!0):a instanceof Array&&(c=[],q=!0);var r=b.get?function(a){f("get");return b.get(this,a,c)}:function(a){f("get");return this[a]},v=b.set?function(a,d){f("set");b.set(this,
-  a,d,c);}:function(a,b){f("set");this[a]=b;},t={};Object.getOwnPropertyNames(a).forEach(function(b){if(!((g||q)&&b in c)){var d={enumerable:!!Object.getOwnPropertyDescriptor(a,b).enumerable,get:r.bind(a,b),set:v.bind(a,b)};Object.defineProperty(c,b,d);t[b]=!0;}});e=!0;Object.setPrototypeOf?Object.setPrototypeOf(c,Object.getPrototypeOf(a)):c.__proto__?c.__proto__=a.__proto__:e=!1;if(b.get||!e)for(var m in a)t[m]||Object.defineProperty(c,m,{get:r.bind(a,m)});Object.seal(a);Object.seal(c);return c};g.revocable=
-  function(a,b){return {proxy:new g(a,b),revoke:p}};return g}var u="undefined"!==typeof process&&"[object process]"==={}.toString.call(process)||"undefined"!==typeof navigator&&"ReactNative"===navigator.product?commonjsGlobal:self;u.Proxy||(u.Proxy=l(),u.Proxy.revocable=u.Proxy.revocable);})();
+  (function(){function k(){function p(a){return a?"object"===typeof a||"function"===typeof a:!1}var l=null;var n=function(a,c){function g(){}if(!p(a)||!p(c))throw new TypeError("Cannot create proxy with a non-object as target or handler");l=function(){a=null;g=function(b){throw new TypeError("Cannot perform '"+b+"' on a proxy that has been revoked");};};setTimeout(function(){l=null;},0);var f=c;c={get:null,set:null,apply:null,construct:null};for(var h in f){if(!(h in c))throw new TypeError("Proxy polyfill does not support trap '"+
+  h+"'");c[h]=f[h];}"function"===typeof f&&(c.apply=f.apply.bind(f));var d=this,q=!1,r=!1;"function"===typeof a?(d=function(){var b=this&&this.constructor===d,e=Array.prototype.slice.call(arguments);g(b?"construct":"apply");return b&&c.construct?c.construct.call(this,a,e):!b&&c.apply?c.apply(a,this,e):b?(e.unshift(a),new (a.bind.apply(a,e))):a.apply(this,e)},q=!0):a instanceof Array&&(d=[],r=!0);var t=c.get?function(b){g("get");return c.get(this,b,d)}:function(b){g("get");return this[b]},w=c.set?function(b,
+  e){g("set");c.set(this,b,e,d);}:function(b,e){g("set");this[b]=e;},u={};Object.getOwnPropertyNames(a).forEach(function(b){if(!((q||r)&&b in d)){var e={enumerable:!!Object.getOwnPropertyDescriptor(a,b).enumerable,get:t.bind(a,b),set:w.bind(a,b)};Object.defineProperty(d,b,e);u[b]=!0;}});f=!0;Object.setPrototypeOf?Object.setPrototypeOf(d,Object.getPrototypeOf(a)):d.__proto__?d.__proto__=a.__proto__:f=!1;if(c.get||!f)for(var m in a)u[m]||Object.defineProperty(d,m,{get:t.bind(a,m)});Object.seal(a);Object.seal(d);
+  return d};n.revocable=function(a,c){return {proxy:new n(a,c),revoke:l}};return n}var v="undefined"!==typeof process&&"[object process]"==={}.toString.call(process)||"undefined"!==typeof navigator&&"ReactNative"===navigator.product?commonjsGlobal:self;v.Proxy||(v.Proxy=k(),v.Proxy.revocable=v.Proxy.revocable);})();
 
   !function(e){var t=e.Element.prototype;"function"!=typeof t.matches&&(t.matches=t.msMatchesSelector||t.mozMatchesSelector||t.webkitMatchesSelector||function(e){for(var t=(this.document||this.ownerDocument).querySelectorAll(e),o=0;t[o]&&t[o]!==this;)++o;return Boolean(t[o])}),"function"!=typeof t.closest&&(t.closest=function(e){for(var t=this;t&&1===t.nodeType;){if(t.matches(e))return t;t=t.parentNode;}return null});}(window);
 
@@ -2499,7 +2499,7 @@
       return { __await: arg };
     };
 
-    function AsyncIterator(generator) {
+    function AsyncIterator(generator, PromiseImpl) {
       function invoke(method, arg, resolve, reject) {
         var record = tryCatch(generator[method], generator, arg);
         if (record.type === "throw") {
@@ -2510,14 +2510,14 @@
           if (value &&
               typeof value === "object" &&
               hasOwn.call(value, "__await")) {
-            return Promise.resolve(value.__await).then(function(value) {
+            return PromiseImpl.resolve(value.__await).then(function(value) {
               invoke("next", value, resolve, reject);
             }, function(err) {
               invoke("throw", err, resolve, reject);
             });
           }
 
-          return Promise.resolve(value).then(function(unwrapped) {
+          return PromiseImpl.resolve(value).then(function(unwrapped) {
             // When a yielded Promise is resolved, its final value becomes
             // the .value of the Promise<{value,done}> result for the
             // current iteration.
@@ -2535,7 +2535,7 @@
 
       function enqueue(method, arg) {
         function callInvokeWithMethodAndArg() {
-          return new Promise(function(resolve, reject) {
+          return new PromiseImpl(function(resolve, reject) {
             invoke(method, arg, resolve, reject);
           });
         }
@@ -2575,9 +2575,12 @@
     // Note that simple async functions are implemented on top of
     // AsyncIterator objects; they just return a Promise for the value of
     // the final result produced by the iterator.
-    exports.async = function(innerFn, outerFn, self, tryLocsList) {
+    exports.async = function(innerFn, outerFn, self, tryLocsList, PromiseImpl) {
+      if (PromiseImpl === void 0) PromiseImpl = Promise;
+
       var iter = new AsyncIterator(
-        wrap(innerFn, outerFn, self, tryLocsList)
+        wrap(innerFn, outerFn, self, tryLocsList),
+        PromiseImpl
       );
 
       return exports.isGeneratorFunction(outerFn)
@@ -6506,9 +6509,7 @@
     return new Proxy(target, proxyHandler);
   }
 
-  var Component =
-  /*#__PURE__*/
-  function () {
+  var Component = /*#__PURE__*/function () {
     function Component(el) {
       var _this = this;
 
@@ -6699,8 +6700,14 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack();
-        this.executeAndClearNextTickStack();
+        this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
+
+        if (rootEl === this.$el) {
+          // Walk through the $nextTick stack and clear it as we go.
+          while (this.nextTickStack.length > 0) {
+            this.nextTickStack.shift()();
+          }
+        }
       }
     }, {
       key: "initializeElement",
@@ -6733,8 +6740,14 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack();
-        this.executeAndClearNextTickStack();
+        this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
+
+        if (rootEl === this.$el) {
+          // Walk through the $nextTick stack and clear it as we go.
+          while (this.nextTickStack.length > 0) {
+            this.nextTickStack.shift()();
+          }
+        }
       }
     }, {
       key: "executeAndClearRemainingShowDirectiveStack",
@@ -7032,22 +7045,6 @@
           }
         });
       }
-    }, {
-      key: "executeAndClearNextTickStack",
-      value: function executeAndClearNextTickStack() {
-        var self = this;
-
-        var later = function later() {
-          this.nextTickTimeout = null;
-
-          while (self.nextTickStack.length > 0) {
-            self.nextTickStack.shift()();
-          }
-        };
-
-        clearTimeout(this.nextTickTimeout);
-        this.nextTickTimeout = setTimeout(later, 10);
-      }
     }]);
 
     return Component;
@@ -7055,9 +7052,7 @@
 
   var Alpine = {
     start: function () {
-      var _start = _asyncToGenerator(
-      /*#__PURE__*/
-      regeneratorRuntime.mark(function _callee() {
+      var _start = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
         var _this = this;
 
         return regeneratorRuntime.wrap(function _callee$(_context) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1593,9 +1593,18 @@
     }
 
     executeAndClearNextTickStack() {
-      while (this.nextTickStack.length > 0) {
-        this.nextTickStack.shift()();
-      }
+      const self = this;
+
+      const later = function later() {
+        this.nextTickTimeout = null;
+
+        while (self.nextTickStack.length > 0) {
+          self.nextTickStack.shift()();
+        }
+      };
+
+      clearTimeout(this.nextTickTimeout);
+      this.nextTickTimeout = setTimeout(later, 10);
     }
 
   }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1396,8 +1396,14 @@
       }, el => {
         el.__x = new Component(el);
       });
-      this.executeAndClearRemainingShowDirectiveStack();
-      this.executeAndClearNextTickStack();
+      this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
+
+      if (rootEl === this.$el) {
+        // Walk through the $nextTick stack and clear it as we go.
+        while (this.nextTickStack.length > 0) {
+          this.nextTickStack.shift()();
+        }
+      }
     }
 
     initializeElement(el, extraVars) {
@@ -1419,8 +1425,14 @@
       }, el => {
         el.__x = new Component(el);
       });
-      this.executeAndClearRemainingShowDirectiveStack();
-      this.executeAndClearNextTickStack();
+      this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
+
+      if (rootEl === this.$el) {
+        // Walk through the $nextTick stack and clear it as we go.
+        while (this.nextTickStack.length > 0) {
+          this.nextTickStack.shift()();
+        }
+      }
     }
 
     executeAndClearRemainingShowDirectiveStack() {
@@ -1612,21 +1624,6 @@
         }
 
       });
-    }
-
-    executeAndClearNextTickStack() {
-      const self = this;
-
-      const later = function later() {
-        this.nextTickTimeout = null;
-
-        while (self.nextTickStack.length > 0) {
-          self.nextTickStack.shift()();
-        }
-      };
-
-      clearTimeout(this.nextTickTimeout);
-      this.nextTickTimeout = setTimeout(later, 10);
     }
 
   }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1290,7 +1290,6 @@
 
       this.unobservedData.$el = this.$el;
       this.unobservedData.$refs = this.getRefsProxy();
-      this.nextTickTimeout = null;
       this.nextTickStack = [];
 
       this.unobservedData.$nextTick = callback => {
@@ -1396,14 +1395,8 @@
       }, el => {
         el.__x = new Component(el);
       });
-      this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
-
-      if (rootEl === this.$el) {
-        // Walk through the $nextTick stack and clear it as we go.
-        while (this.nextTickStack.length > 0) {
-          this.nextTickStack.shift()();
-        }
-      }
+      this.executeAndClearRemainingShowDirectiveStack();
+      this.executeAndClearNextTickStack(rootEl);
     }
 
     initializeElement(el, extraVars) {
@@ -1425,9 +1418,13 @@
       }, el => {
         el.__x = new Component(el);
       });
-      this.executeAndClearRemainingShowDirectiveStack(); // Skip spawns from alpine directives
+      this.executeAndClearRemainingShowDirectiveStack();
+      this.executeAndClearNextTickStack(rootEl);
+    }
 
-      if (rootEl === this.$el) {
+    executeAndClearNextTickStack(el) {
+      // Skip spawns from alpine directives
+      if (el === this.$el) {
         // Walk through the $nextTick stack and clear it as we go.
         while (this.nextTickStack.length > 0) {
           this.nextTickStack.shift()();

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1276,6 +1276,7 @@
 
       this.unobservedData.$el = this.$el;
       this.unobservedData.$refs = this.getRefsProxy();
+      this.nextTickTimeout = null;
       this.nextTickStack = [];
 
       this.unobservedData.$nextTick = callback => {
@@ -1379,13 +1380,8 @@
       }, el => {
         el.__x = new Component(el);
       });
-      this.executeAndClearRemainingShowDirectiveStack(); // Walk through the $nextTick stack and clear it as we go.
-
-      debounce(function () {
-        while (this.nextTickStack.length > 0) {
-          this.nextTickStack.shift()();
-        }
-      }, 0).bind(this)();
+      this.executeAndClearRemainingShowDirectiveStack();
+      this.executeAndClearNextTickStack();
     }
 
     initializeElement(el, extraVars) {
@@ -1408,12 +1404,7 @@
         el.__x = new Component(el);
       });
       this.executeAndClearRemainingShowDirectiveStack();
-      debounce(function () {
-        // Walk through the $nextTick stack and clear it as we go.
-        while (this.nextTickStack.length > 0) {
-          this.nextTickStack.shift()();
-        }
-      }, 0).bind(this)();
+      this.executeAndClearNextTickStack();
     }
 
     executeAndClearRemainingShowDirectiveStack() {
@@ -1599,6 +1590,12 @@
         }
 
       });
+    }
+
+    executeAndClearNextTickStack() {
+      while (this.nextTickStack.length > 0) {
+        this.nextTickStack.shift()();
+      }
     }
 
   }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1381,9 +1381,11 @@
       });
       this.executeAndClearRemainingShowDirectiveStack(); // Walk through the $nextTick stack and clear it as we go.
 
-      while (this.nextTickStack.length > 0) {
-        this.nextTickStack.shift()();
-      }
+      debounce(function () {
+        while (this.nextTickStack.length > 0) {
+          this.nextTickStack.shift()();
+        }
+      }, 0).bind(this)();
     }
 
     initializeElement(el, extraVars) {
@@ -1405,11 +1407,13 @@
       }, el => {
         el.__x = new Component(el);
       });
-      this.executeAndClearRemainingShowDirectiveStack(); // Walk through the $nextTick stack and clear it as we go.
-
-      while (this.nextTickStack.length > 0) {
-        this.nextTickStack.shift()();
-      }
+      this.executeAndClearRemainingShowDirectiveStack();
+      debounce(function () {
+        // Walk through the $nextTick stack and clear it as we go.
+        while (this.nextTickStack.length > 0) {
+          this.nextTickStack.shift()();
+        }
+      }, 0).bind(this)();
     }
 
     executeAndClearRemainingShowDirectiveStack() {

--- a/src/component.js
+++ b/src/component.js
@@ -392,8 +392,17 @@ export default class Component {
     }
 
     executeAndClearNextTickStack() {
-        while (this.nextTickStack.length > 0) {
-            this.nextTickStack.shift()()
+        const self = this
+
+        const later = function () {
+            this.nextTickTimeout = null
+            while (self.nextTickStack.length > 0) {
+                self.nextTickStack.shift()()
+            }
         }
+
+        clearTimeout(this.nextTickTimeout)
+
+        this.nextTickTimeout = setTimeout(later, 10)
     }
 }

--- a/src/component.js
+++ b/src/component.js
@@ -36,6 +36,7 @@ export default class Component {
         this.unobservedData.$el = this.$el
         this.unobservedData.$refs = this.getRefsProxy()
 
+        this.nextTickTimeout = null
         this.nextTickStack = []
         this.unobservedData.$nextTick = (callback) => {
             this.nextTickStack.push(callback)
@@ -151,12 +152,7 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
-        // Walk through the $nextTick stack and clear it as we go.
-        debounce(function() {
-            while (this.nextTickStack.length > 0) {
-                this.nextTickStack.shift()()
-            }
-        }, 0).bind(this)()
+        this.executeAndClearNextTickStack()
     }
 
     initializeElement(el, extraVars) {
@@ -182,12 +178,7 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
-        debounce(function() {
-            // Walk through the $nextTick stack and clear it as we go.
-            while (this.nextTickStack.length > 0) {
-                this.nextTickStack.shift()()
-            }
-        }, 0).bind(this)()
+        this.executeAndClearNextTickStack()
     }
 
     executeAndClearRemainingShowDirectiveStack() {
@@ -398,5 +389,11 @@ export default class Component {
                 return ref
             }
         })
+    }
+
+    executeAndClearNextTickStack() {
+        while (this.nextTickStack.length > 0) {
+            this.nextTickStack.shift()()
+        }
     }
 }

--- a/src/component.js
+++ b/src/component.js
@@ -157,7 +157,13 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
-        this.executeAndClearNextTickStack()
+        // Skip spawns from alpine directives
+        if (rootEl === this.$el) {
+            // Walk through the $nextTick stack and clear it as we go.
+            while (this.nextTickStack.length > 0) {
+                this.nextTickStack.shift()()
+            }
+        }
     }
 
     initializeElement(el, extraVars) {
@@ -183,7 +189,13 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
-        this.executeAndClearNextTickStack()
+        // Skip spawns from alpine directives
+        if (rootEl === this.$el) {
+            // Walk through the $nextTick stack and clear it as we go.
+            while (this.nextTickStack.length > 0) {
+                this.nextTickStack.shift()()
+            }
+        }
     }
 
     executeAndClearRemainingShowDirectiveStack() {
@@ -397,20 +409,5 @@ export default class Component {
                 return ref
             }
         })
-    }
-
-    executeAndClearNextTickStack() {
-        const self = this
-
-        const later = function () {
-            this.nextTickTimeout = null
-            while (self.nextTickStack.length > 0) {
-                self.nextTickStack.shift()()
-            }
-        }
-
-        clearTimeout(this.nextTickTimeout)
-
-        this.nextTickTimeout = setTimeout(later, 10)
     }
 }

--- a/src/component.js
+++ b/src/component.js
@@ -152,9 +152,11 @@ export default class Component {
         this.executeAndClearRemainingShowDirectiveStack()
 
         // Walk through the $nextTick stack and clear it as we go.
-        while (this.nextTickStack.length > 0) {
-            this.nextTickStack.shift()()
-        }
+        debounce(function() {
+            while (this.nextTickStack.length > 0) {
+                this.nextTickStack.shift()()
+            }
+        }, 0).bind(this)()
     }
 
     initializeElement(el, extraVars) {
@@ -180,10 +182,12 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
-        // Walk through the $nextTick stack and clear it as we go.
-        while (this.nextTickStack.length > 0) {
-            this.nextTickStack.shift()()
-        }
+        debounce(function() {
+            // Walk through the $nextTick stack and clear it as we go.
+            while (this.nextTickStack.length > 0) {
+                this.nextTickStack.shift()()
+            }
+        }, 0).bind(this)()
     }
 
     executeAndClearRemainingShowDirectiveStack() {

--- a/src/component.js
+++ b/src/component.js
@@ -38,7 +38,6 @@ export default class Component {
         this.unobservedData.$el = this.$el
         this.unobservedData.$refs = this.getRefsProxy()
 
-        this.nextTickTimeout = null
         this.nextTickStack = []
         this.unobservedData.$nextTick = (callback) => {
             this.nextTickStack.push(callback)
@@ -157,13 +156,7 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
-        // Skip spawns from alpine directives
-        if (rootEl === this.$el) {
-            // Walk through the $nextTick stack and clear it as we go.
-            while (this.nextTickStack.length > 0) {
-                this.nextTickStack.shift()()
-            }
-        }
+        this.executeAndClearNextTickStack(rootEl)
     }
 
     initializeElement(el, extraVars) {
@@ -189,8 +182,12 @@ export default class Component {
 
         this.executeAndClearRemainingShowDirectiveStack()
 
+        this.executeAndClearNextTickStack(rootEl)
+    }
+
+    executeAndClearNextTickStack(el) {
         // Skip spawns from alpine directives
-        if (rootEl === this.$el) {
+        if (el === this.$el) {
             // Walk through the $nextTick stack and clear it as we go.
             while (this.nextTickStack.length > 0) {
                 this.nextTickStack.shift()()

--- a/test/next-tick.spec.js
+++ b/test/next-tick.spec.js
@@ -42,5 +42,5 @@ test('nextTick wait for x-for to finish rendering', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => expect(document.querySelector('p').innerText).toEqual(3))
+    await wait(() => { expect(document.querySelector('p').innerText).toEqual(3) })
 })

--- a/test/next-tick.spec.js
+++ b/test/next-tick.spec.js
@@ -20,5 +20,27 @@ test('$nextTick', async () => {
 
     document.querySelector('button').click()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bob') })
+    await wait(() => expect(document.querySelector('span').innerText).toEqual('bob'))
+})
+
+test('nextTick wait for x-for to finish rendering', async () => {
+    document.body.innerHTML = `
+        <div x-data="{list: ['one', 'two'], check: 2}">
+            <template x-for="item in list">
+                <span x-text="item"></span>
+            </template>
+
+            <p x-text="check"></p>
+
+            <button x-on:click="list = ['one', 'two', 'three']; $nextTick(() => {check = document.querySelectorAll('span').length})"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('p').innerText).toEqual(2)
+
+    document.querySelector('button').click()
+
+    await wait(() => expect(document.querySelector('p').innerText).toEqual(3))
 })


### PR DESCRIPTION
Fixes #333
When using x-for and updating the list, Alpine updates all the directives but ignores the x-for item and then it flushes the nextTick stack so the callbacks are currently running before x-for finishes its rendering. After that point, each element of the list calls either initializeElements or updateElements (each of them will try again to empty the nextTick stack).

~~To fix it, I've debounced the stack execution so it should run only at the end (either because the main refresh is the only call or it's the last call of a x-for loop).~~
~~I've duplicated the debounce function because it seemed it was conflicting but I might be wrong.~~

To fix it, will run the stack only if the root element of the update function is the Alpine component and we ignore element generated by x-for and other templating directives.

~~Fixes 317 as well since the nextTick debouncing allows the transition to progress further.~~ (Not true anymore since i've removed the debouncing for a better and neater solution, it needs to be fixed in a different PR)