### PR TITLE
Change of state without reaction; Update of one DOM element

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -38,9 +38,16 @@ export default class Component {
             this.pauseReactivity = false;
         }
 
-        // Apply the current state to just one element
+        // Apply the current state to just one element.
         this.unobservedData.$update = (element, extraVars = {}) => {
             this.updateElement(element, () => extraVars);
+        }
+
+        // Apply the current state to an element and all its children.
+        this.unobservedData.$updateRecursively = (element, extraVars = {}) => {
+            walk(element, (el) => {
+                this.updateElement(el, () => extraVars);
+            });
         }
 
         // After making user-supplied data methods reactive, we can now add

--- a/src/component.js
+++ b/src/component.js
@@ -31,6 +31,13 @@ export default class Component {
         this.$data = data
         this.membrane = membrane
 
+        // Allows to change state without reaction.
+        this.unobservedData.$withoutReaction = (callback) => {
+            this.pauseReactivity = true;
+            callback();
+            this.pauseReactivity = false;
+        }
+
         // After making user-supplied data methods reactive, we can now add
         // our magic properties to the original data for access.
         this.unobservedData.$el = this.$el

--- a/src/component.js
+++ b/src/component.js
@@ -318,6 +318,9 @@ export default class Component {
         return saferEvalNoReturn(expression, this.$data, {
             ...extraVars(),
             $dispatch: this.getDispatchFunction(el),
+            $wr: (callback) => this.unobservedData.$withoutReaction(callback),
+            $ur: (el, context) => this.unobservedData.$updateRecursively(el, context),
+            $u: (els, context = {}) => els.forEach((el) => this.unobservedData.$update(el, context)),
         })
     }
 

--- a/src/component.js
+++ b/src/component.js
@@ -38,6 +38,11 @@ export default class Component {
             this.pauseReactivity = false;
         }
 
+        // Apply the current state to just one element
+        this.unobservedData.$update = (element, extraVars = {}) => {
+            this.updateElement(element, () => extraVars);
+        }
+
         // After making user-supplied data methods reactive, we can now add
         // our magic properties to the original data for access.
         this.unobservedData.$el = this.$el

--- a/test/update.spec.js
+++ b/test/update.spec.js
@@ -1,0 +1,37 @@
+import Alpine from 'alpinejs'
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+test('$update', async () => {
+    document.body.innerHTML = `
+       <div x-data="{state: 'old', update() { this.$update(this.$refs.span) }}">
+            <span x-text="state" x-ref="span"></span>
+            <button @click="$wr(() => state = 'new' )"></button>
+            <button @click="update"></button>
+        </div>
+    `
+    Alpine.start()
+
+    document.querySelectorAll('button')[0].click()
+    expect(document.querySelector('span').innerText).toEqual('old')
+    document.querySelectorAll('button')[1].click()
+    expect(document.querySelector('span').innerText).toEqual('new')
+})
+
+test('$u', async () => {
+    document.body.innerHTML = `
+        <div x-data="{state: 'old'}">
+            <span x-text="state" x-ref="span"></span>
+            <button @click="$wr(() => state = 'new' )"></button>
+            <button @click="$u([$refs.span])"></button>
+        </div>
+    `
+    Alpine.start()
+
+    document.querySelectorAll('button')[0].click()
+    expect(document.querySelector('span').innerText).toEqual('old')
+    document.querySelectorAll('button')[1].click()
+    expect(document.querySelector('span').innerText).toEqual('new')
+})

--- a/test/updateRecursively.spec.js
+++ b/test/updateRecursively.spec.js
@@ -1,0 +1,43 @@
+import Alpine from 'alpinejs'
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+test('$updateRecursively', async () => {
+    document.body.innerHTML = `
+        <div x-data="{state: 'old', update() { this.$updateRecursively(this.$refs.div) }}">
+            <div x-ref="div">
+                <span x-text="state"></span>
+            </div>
+            <button @click="$wr(() => state = 'new' )"></button>
+            <button @click="update"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelectorAll('button')[0].click()
+    expect(document.querySelector('span').innerText).toEqual('old')
+    document.querySelectorAll('button')[1].click()
+    expect(document.querySelector('span').innerText).toEqual('new')
+})
+
+test('$ur', async () => {
+    document.body.innerHTML = `
+       <div x-data="{state: 'old'}">
+            <div x-ref="div">
+                <span x-text="state"></span>
+            </div>
+            <button @click="$wr(() => state = 'new' )"></button>
+            <button @click="$ur($refs.div, {})"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelectorAll('button')[0].click()
+    expect(document.querySelector('span').innerText).toEqual('old')
+    document.querySelectorAll('button')[1].click()
+    expect(document.querySelector('span').innerText).toEqual('new')
+})

--- a/test/withoutReaction.spec.js
+++ b/test/withoutReaction.spec.js
@@ -1,0 +1,58 @@
+import Alpine from 'alpinejs'
+const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+test('$withoutReaction', async () => {
+    document.body.innerHTML = `
+        <div x-data="{
+                        items: [{id: 1, text: 'id1'}, {id: 2, text: 'id2'}],
+                        update() { this.$withoutReaction(() => {
+                            for (let i = 0; i < this.items.length; i++)
+                                this.items[i].text = 'test'
+                            })
+                         }
+                     }">
+            <template x-for="item in items">
+                <span x-text="item.text"></span>
+            </template>
+
+            <button @click="update()"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelector('button').click()
+
+    await timeout(1)
+
+    expect(document.querySelectorAll('span')[0].innerText).toEqual('id1')
+    expect(document.querySelectorAll('span')[1].innerText).toEqual('id2')
+})
+
+
+test('$wr', async () => {
+    document.body.innerHTML = `
+        <div x-data="{
+                        items: [{id: 1, text: 'id1'}, {id: 2, text: 'id2'}]
+                     }">
+            <template x-for="item in items">
+                <span x-text="item.text"></span>
+            </template>
+
+            <button @click="$wr(() => { items.forEach((i) => i.text = 'test') })"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelector('button').click()
+
+    await timeout(1)
+
+    expect(document.querySelectorAll('span')[0].innerText).toEqual('id1')
+    expect(document.querySelectorAll('span')[1].innerText).toEqual('id2')
+})


### PR DESCRIPTION
### Changes
This PR introduces a few features that I found EXTREMELY useful for my project:

- **ability to make changes to the current state without reaction**
- **ability to update just one DOM element**

### Application
_You have a big list of objects on your page and a click on one of those objects changes the state of that object._
_Current behaviour:_ **all objects and parent components get re-rendered** 
_Desired behaviour:_ **one object gets re-rendered**

### Code fragments of real application
![image](https://user-images.githubusercontent.com/17602927/78708886-7ad3cc00-791b-11ea-918e-ac3d9160e9f8.png)
```
refs() {
    let self = this;
    return {
        category(id) {
            return self.$refs[`category${id}`];
        },
        button() {
            return self.$refs['button'];
        },
        selectAllButton() {
            return self.$refs['selectAllButton'];
        }
    };
}
```
```
selectOrUnselectAll() {
    let shouldSelect = ! this.anySelected();
    this.$withoutReaction(() => {
        this.categories = _.each(this.categories, (category) => category.selected = shouldSelect);
    });
    _.each(this.categories, (category) => {
        this.$update(this.refs().category(category.id), {category});
    });
    this.$update(this.refs().selectAllButton());
    this.$update(this.refs().button());
}
```
```
<button type="button"
        class="dropdown-item"
        x-bind:x-ref="'category' + category.id"
        x-on:click.stop="$wr(() => { category.selected = !category.selected });
                         $u([refs().category(category.id)], {category});
                         $u([refs().button(), refs().selectAllButton()])"
        x-bind:class="{'active': category.selected}">
```

These changes have boosted performance of my project significantly. 