### PR TITLE
Prevent error when turbolinks reloads the page

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6579,6 +6579,13 @@
                   _newArrowCheck(this, _this);
 
                   this.initializeComponent(el);
+                }.bind(this)); // To avoid issue with the mutation observer going mad when turbolinks
+                // reload the page, we disconnect it
+
+                document.addEventListener("turbolinks:click", function () {
+                  _newArrowCheck(this, _this);
+
+                  this.observer.disconnect();
                 }.bind(this)); // It's easier and more performant to just support Turbolinks than listen
                 // to MutationObserver mutations at the document level.
 
@@ -6591,7 +6598,15 @@
                     _newArrowCheck(this, _this2);
 
                     this.initializeComponent(el);
-                  }.bind(this));
+                  }.bind(this)); // Once done, we reconnect the mutation observer
+
+                  var targetNode = document.querySelector('body');
+                  var observerOptions = {
+                    childList: true,
+                    attributes: true,
+                    subtree: true
+                  };
+                  this.observer.observe(targetNode, observerOptions);
                 }.bind(this));
                 this.listenForNewUninitializedComponentsAtRunTime(function (el) {
                   _newArrowCheck(this, _this);
@@ -6599,7 +6614,7 @@
                   this.initializeComponent(el);
                 }.bind(this));
 
-              case 6:
+              case 7:
               case "end":
                 return _context.stop();
             }
@@ -6647,7 +6662,7 @@
         attributes: true,
         subtree: true
       };
-      var observer = new MutationObserver(function (mutations) {
+      this.observer = new MutationObserver(function (mutations) {
         var _this6 = this;
 
         _newArrowCheck(this, _this5);
@@ -6673,7 +6688,7 @@
           }
         }
       }.bind(this));
-      observer.observe(targetNode, observerOptions);
+      this.observer.observe(targetNode, observerOptions);
     },
     initializeComponent: function initializeComponent(el) {
       if (!el.__x) {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -7193,8 +7193,8 @@
           attributes: true,
           subtree: true
         });
-      }.bind(this)); // We don't want tutbolinks to cache elements created by Alpine directives
-      // so we clean up the stage before letting turbolinks do its duty
+      }.bind(this)); // We don't want turbolinks to cache elements created by Alpine directives
+      // so we clean up the stage before letting turbolinks does its duty
 
       document.addEventListener("turbolinks:before-cache", function () {
         var _this9 = this;
@@ -7207,7 +7207,7 @@
 
           var nextEl = el.nextElementSibling;
 
-          while (nextEl && nextEl.__x_for_key) {
+          while (nextEl && typeof nextEl.__x_for_key !== 'undefined') {
             var currEl = nextEl;
             nextEl = nextEl.nextElementSibling;
             currEl.remove();
@@ -7219,7 +7219,7 @@
 
           var nextEl = el.nextElementSibling;
 
-          if (nextEl && nextEl.__x_inserted_me) {
+          if (nextEl && typeof nextEl.__x_inserted_me !== 'undefined') {
             nextEl.remove();
           }
         }.bind(this));

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -7078,42 +7078,11 @@
                   _newArrowCheck(this, _this);
 
                   this.initializeComponent(el);
-                }.bind(this)); // To avoid issue with the mutation observer going mad when turbolinks
-                // reload the page, we disconnect it
-
-                document.addEventListener("turbolinks:click", function () {
-                  _newArrowCheck(this, _this);
-
-                  this.observer.disconnect();
-                }.bind(this)); // It's easier and more performant to just support Turbolinks than listen
-                // to MutationObserver mutations at the document level.
-
-                document.addEventListener("turbolinks:load", function () {
-                  var _this2 = this;
-
-                  _newArrowCheck(this, _this);
-
-                  this.discoverUninitializedComponents(function (el) {
-                    _newArrowCheck(this, _this2);
-
-                    this.initializeComponent(el);
-                  }.bind(this)); // Once done, we reconnect the mutation observer
-
-                  var targetNode = document.querySelector('body');
-                  var observerOptions = {
-                    childList: true,
-                    attributes: true,
-                    subtree: true
-                  };
-                  this.observer.observe(targetNode, observerOptions);
                 }.bind(this));
-                this.listenForNewUninitializedComponentsAtRunTime(function (el) {
-                  _newArrowCheck(this, _this);
+                this.listenForNewUninitializedComponentsAtRunTime();
+                this.initTurbolinksListeners();
 
-                  this.initializeComponent(el);
-                }.bind(this));
-
-              case 7:
+              case 6:
               case "end":
                 return _context.stop();
             }
@@ -7128,50 +7097,44 @@
       return start;
     }(),
     discoverComponents: function discoverComponents(callback) {
-      var _this3 = this;
+      var _this2 = this;
 
       var rootEls = document.querySelectorAll('[x-data]');
       rootEls.forEach(function (rootEl) {
-        _newArrowCheck(this, _this3);
+        _newArrowCheck(this, _this2);
 
         callback(rootEl);
       }.bind(this));
     },
     discoverUninitializedComponents: function discoverUninitializedComponents(callback) {
-      var _this4 = this;
+      var _this3 = this;
 
       var el = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
       var rootEls = (el || document).querySelectorAll('[x-data]');
       Array.from(rootEls).filter(function (el) {
-        _newArrowCheck(this, _this4);
+        _newArrowCheck(this, _this3);
 
         return el.__x === undefined;
       }.bind(this)).forEach(function (rootEl) {
-        _newArrowCheck(this, _this4);
+        _newArrowCheck(this, _this3);
 
         callback(rootEl);
       }.bind(this));
     },
-    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime(callback) {
-      var _this5 = this;
+    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime() {
+      var _this4 = this;
 
-      var targetNode = document.querySelector('body');
-      var observerOptions = {
-        childList: true,
-        attributes: true,
-        subtree: true
-      };
       this.observer = new MutationObserver(function (mutations) {
-        var _this6 = this;
+        var _this5 = this;
 
-        _newArrowCheck(this, _this5);
+        _newArrowCheck(this, _this4);
 
         for (var i = 0; i < mutations.length; i++) {
           if (mutations[i].addedNodes.length > 0) {
             mutations[i].addedNodes.forEach(function (node) {
-              var _this7 = this;
+              var _this6 = this;
 
-              _newArrowCheck(this, _this6);
+              _newArrowCheck(this, _this5);
 
               // Discard non-element nodes (like line-breaks)
               if (node.nodeType !== 1) return; // Discard any changes happening within an existing component.
@@ -7179,7 +7142,7 @@
 
               if (node.parentElement && node.parentElement.closest('[x-data]')) return;
               this.discoverUninitializedComponents(function (el) {
-                _newArrowCheck(this, _this7);
+                _newArrowCheck(this, _this6);
 
                 this.initializeComponent(el);
               }.bind(this), node.parentElement);
@@ -7187,7 +7150,11 @@
           }
         }
       }.bind(this));
-      this.observer.observe(targetNode, observerOptions);
+      this.observer.observe(document.body, {
+        childList: true,
+        attributes: true,
+        subtree: true
+      });
     },
     initializeComponent: function initializeComponent(el) {
       if (!el.__x) {
@@ -7198,6 +7165,65 @@
       if (!newEl.__x) {
         newEl.__x = new Component(newEl, component.getUnobservedData());
       }
+    },
+    initTurbolinksListeners: function initTurbolinksListeners() {
+      var _this7 = this;
+
+      // To avoid issue with the mutation observer going mad when turbolinks
+      // reloads a page, we disconnect it. It will be reconnected by the turbolinks:load event
+      document.addEventListener("turbolinks:click", function () {
+        _newArrowCheck(this, _this7);
+
+        this.observer.disconnect();
+      }.bind(this)); // It's easier and more performant to just support Turbolinks than listen
+      // to MutationObserver mutations at the document level.
+
+      document.addEventListener("turbolinks:load", function () {
+        var _this8 = this;
+
+        _newArrowCheck(this, _this7);
+
+        Alpine.discoverUninitializedComponents(function (el) {
+          _newArrowCheck(this, _this8);
+
+          this.initializeComponent(el);
+        }.bind(this));
+        this.observer.observe(document.body, {
+          childList: true,
+          attributes: true,
+          subtree: true
+        });
+      }.bind(this)); // We don't want tutbolinks to cache elements created by Alpine directives
+      // so we clean up the stage before letting turbolinks do its duty
+
+      document.addEventListener("turbolinks:before-cache", function () {
+        var _this9 = this;
+
+        _newArrowCheck(this, _this7);
+
+        var xFors = document.querySelectorAll('template[x-for]');
+        xFors.forEach(function (el) {
+          _newArrowCheck(this, _this9);
+
+          var nextEl = el.nextElementSibling;
+
+          while (nextEl && nextEl.__x_for_key) {
+            var currEl = nextEl;
+            nextEl = nextEl.nextElementSibling;
+            currEl.remove();
+          }
+        }.bind(this));
+        var xIfs = document.querySelectorAll('template[x-if]');
+        xIfs.forEach(function (el) {
+          _newArrowCheck(this, _this9);
+
+          var nextEl = el.nextElementSibling;
+
+          if (nextEl && nextEl.__x_inserted_me) {
+            nextEl.remove();
+          }
+        }.bind(this));
+      }.bind(this));
     }
   };
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1708,15 +1708,15 @@
           attributes: true,
           subtree: true
         });
-      }); // We don't want tutbolinks to cache elements created by Alpine directives
-      // so we clean up the stage before letting turbolinks do its duty
+      }); // We don't want turbolinks to cache elements created by Alpine directives
+      // so we clean up the stage before letting turbolinks does its duty
 
       document.addEventListener("turbolinks:before-cache", () => {
         const xFors = document.querySelectorAll('template[x-for]');
         xFors.forEach(el => {
           let nextEl = el.nextElementSibling;
 
-          while (nextEl && nextEl.__x_for_key) {
+          while (nextEl && typeof nextEl.__x_for_key !== 'undefined') {
             const currEl = nextEl;
             nextEl = nextEl.nextElementSibling;
             currEl.remove();
@@ -1726,7 +1726,7 @@
         xIfs.forEach(el => {
           let nextEl = el.nextElementSibling;
 
-          if (nextEl && nextEl.__x_inserted_me) {
+          if (nextEl && typeof nextEl.__x_inserted_me !== 'undefined') {
             nextEl.remove();
           }
         });

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1641,30 +1641,9 @@
 
       this.discoverComponents(el => {
         this.initializeComponent(el);
-      }); // To avoid issue with the mutation observer going mad when turbolinks
-      // reload the page, we disconnect it
-
-      document.addEventListener("turbolinks:click", () => {
-        this.observer.disconnect();
-      }); // It's easier and more performant to just support Turbolinks than listen
-      // to MutationObserver mutations at the document level.
-
-      document.addEventListener("turbolinks:load", () => {
-        this.discoverUninitializedComponents(el => {
-          this.initializeComponent(el);
-        }); // Once done, we reconnect the mutation observer
-
-        const targetNode = document.querySelector('body');
-        const observerOptions = {
-          childList: true,
-          attributes: true,
-          subtree: true
-        };
-        this.observer.observe(targetNode, observerOptions);
       });
-      this.listenForNewUninitializedComponentsAtRunTime(el => {
-        this.initializeComponent(el);
-      });
+      this.listenForNewUninitializedComponentsAtRunTime();
+      this.initTurbolinksListeners();
     },
     discoverComponents: function discoverComponents(callback) {
       const rootEls = document.querySelectorAll('[x-data]');
@@ -1678,13 +1657,7 @@
         callback(rootEl);
       });
     },
-    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime(callback) {
-      const targetNode = document.querySelector('body');
-      const observerOptions = {
-        childList: true,
-        attributes: true,
-        subtree: true
-      };
+    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime() {
       this.observer = new MutationObserver(mutations => {
         for (let i = 0; i < mutations.length; i++) {
           if (mutations[i].addedNodes.length > 0) {
@@ -1701,7 +1674,11 @@
           }
         }
       });
-      this.observer.observe(targetNode, observerOptions);
+      this.observer.observe(document.body, {
+        childList: true,
+        attributes: true,
+        subtree: true
+      });
     },
     initializeComponent: function initializeComponent(el) {
       if (!el.__x) {
@@ -1712,7 +1689,50 @@
       if (!newEl.__x) {
         newEl.__x = new Component(newEl, component.getUnobservedData());
       }
+    },
+
+    initTurbolinksListeners() {
+      // To avoid issue with the mutation observer going mad when turbolinks
+      // reloads a page, we disconnect it. It will be reconnected by the turbolinks:load event
+      document.addEventListener("turbolinks:click", () => {
+        this.observer.disconnect();
+      }); // It's easier and more performant to just support Turbolinks than listen
+      // to MutationObserver mutations at the document level.
+
+      document.addEventListener("turbolinks:load", () => {
+        Alpine.discoverUninitializedComponents(el => {
+          this.initializeComponent(el);
+        });
+        this.observer.observe(document.body, {
+          childList: true,
+          attributes: true,
+          subtree: true
+        });
+      }); // We don't want tutbolinks to cache elements created by Alpine directives
+      // so we clean up the stage before letting turbolinks do its duty
+
+      document.addEventListener("turbolinks:before-cache", () => {
+        const xFors = document.querySelectorAll('template[x-for]');
+        xFors.forEach(el => {
+          let nextEl = el.nextElementSibling;
+
+          while (nextEl && nextEl.__x_for_key) {
+            const currEl = nextEl;
+            nextEl = nextEl.nextElementSibling;
+            currEl.remove();
+          }
+        });
+        const xIfs = document.querySelectorAll('template[x-if]');
+        xIfs.forEach(el => {
+          let nextEl = el.nextElementSibling;
+
+          if (nextEl && nextEl.__x_inserted_me) {
+            nextEl.remove();
+          }
+        });
+      });
     }
+
   };
 
   if (!isTesting()) {

--- a/src/index.js
+++ b/src/index.js
@@ -87,13 +87,13 @@ const Alpine = {
             this.observer.observe(document.body, {childList: true, attributes: true, subtree: true})
         })
 
-        // We don't want tutbolinks to cache elements created by Alpine directives
-        // so we clean up the stage before letting turbolinks do its duty
+        // We don't want turbolinks to cache elements created by Alpine directives
+        // so we clean up the stage before letting turbolinks does its duty
         document.addEventListener("turbolinks:before-cache", () => {
             const xFors = document.querySelectorAll('template[x-for]')
             xFors.forEach((el) => {
                 let nextEl = el.nextElementSibling
-                while (nextEl && nextEl.__x_for_key) {
+                while (nextEl && typeof nextEl.__x_for_key !== 'undefined') {
                     const currEl = nextEl
                     nextEl = nextEl.nextElementSibling
                     currEl.remove()
@@ -102,7 +102,7 @@ const Alpine = {
             const xIfs = document.querySelectorAll('template[x-if]')
             xIfs.forEach((el) => {
                 let nextEl = el.nextElementSibling
-                if (nextEl && nextEl.__x_inserted_me) {
+                if (nextEl && typeof nextEl.__x_inserted_me !== 'undefined') {
                     nextEl.remove()
                 }
             })

--- a/turbolinks-manual-test/index.html
+++ b/turbolinks-manual-test/index.html
@@ -7,7 +7,7 @@
         <h1>First Page</h1>
         <a href="/turbolinks-manual-test/navigated-away">Second Page</a>
 
-        <h2>This component should be preserved and working in the Second page</h2>
+        <h2>This component should be preserved and be working in the Second page</h2>
         <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
             <input x-model="foo"></input>
 
@@ -28,7 +28,7 @@
             </template>
         </div>
 
-        <h2>This component should be preserved and not logging any errors when navigating to the Second page</h2>
+        <h2>This component should be preserved and not be logging any errors when navigating to the Second page</h2>
         <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
             <template x-for="item in foo">
                 <span x-text="item"></span>

--- a/turbolinks-manual-test/index.html
+++ b/turbolinks-manual-test/index.html
@@ -5,12 +5,34 @@
     </head>
     <body>
         <h1>First Page</h1>
-        <a href="turbolinks-manual-test/navigated-away">Second Page</a>
+        <a href="/turbolinks-manual-test/navigated-away">Second Page</a>
 
+        <h2>This component should be preserved and working in the Second page</h2>
         <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
             <input x-model="foo"></input>
 
             <button x-on:click="foo = 'baz'"></button>
+        </div>
+
+        <h2>This item should not add a duplicate span item when navigating away and back to this page</h2>
+        <div x-data="{ foo: 'bar', open: true }">
+            <template x-if="open">
+                <span x-text="foo"></span>
+            </template>
+        </div>
+
+        <h2>This item should not add duplicate span items when navigating away and back to this page</h2>
+        <div x-data="{ foo: ['bar', 'baz'] }">
+            <template x-for="item in foo">
+                <span x-text="item"></span>
+            </template>
+        </div>
+
+        <h2>This component should be preserved and not logging any errors when navigating to the Second page</h2>
+        <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
+            <template x-for="item in foo">
+                <span x-text="item"></span>
+            </template>
         </div>
     </body>
 </html>

--- a/turbolinks-manual-test/navigated-away/index.html
+++ b/turbolinks-manual-test/navigated-away/index.html
@@ -5,11 +5,20 @@
     </head>
     <body>
         <h1>Second Page</h1>
+        <a href="javascript:history.back()">Back</a>
 
+        <h2>This component should be preserved and working correctly</h2>
         <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
             <input x-model="foo"></input>
 
             <button x-on:click="foo = 'baz'"></button>
+        </div>
+
+        <h2>This component should be preserved and working correctly (including no errors in console)</h2>
+        <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
+            <template x-for="item in foo">
+                <span x-text="item"></span>
+            </template>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Fixes #319

As described in the issue, alpine acts funny when turbolinks reloads the page if a component has the `data-turbolinks-permanent` attribute. 
I believe that the reason is that turbolinks load the new page and then replace the permanent element with the one from the previous page as described in their documentation.
This seems to trigger the mutation observer which tries to reevaluate all the directives.
If the component has a x-for directive, the injected html already has the generated x-for elements in it which refers variables that do not exists in the DOM.

The quickest solution is to pause the observer once turbolinks does its own stuff. Not sure if you can think of a better solution.

As I quickly mentioned in that issue, I believe that those 2 listeners don't belong to the core but they should be extracted into a separate bridge library.