### PR TITLE
Add module/nomodule pattern to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Think of it like [Tailwind](https://tailwindcss.com/) for JavaScript.
 
 **From CDN:** Add the following script to the end of your `<head>` section.
 ```html
-<script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
+<script type="module" src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js"></script>
+<script nomodule src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine-ie11.min.js" defer></script>
 ```
 
 That's it. It will initialize itself.
+
+The pattern above is the [module/nomodule pattern](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) that will result in the modern bundle automatically loaded on modern browsers, and the IE11 bundle loaded automatically on IE11 and other legacy browsers. 
 
 **From NPM:** Install the package from NPM.
 ```js
@@ -29,11 +32,6 @@ npm i alpinejs
 Include it in your script.
 ```js
 import 'alpinejs'
-```
-
-**For IE11 support** Use the following script instead.
-```html
-<script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine-ie11.min.js" defer></script>
 ```
 
 ## Use


### PR DESCRIPTION
At Caleb's request... a PR to add the module/nomodule pattern to the docs:

https://philipwalton.com/articles/deploying-es2015-code-in-production-today/

https://caniuse.com/#feat=es6-module