### PR TITLE
Bug/x for regression

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5816,7 +5816,7 @@
           return nextEl.__x_for;
         }.bind(this));
       } else {
-        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // If I haven't found a matching key, just insert the element at the current position
+        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // If we haven't found a matching key, just insert the element at the current position
 
         if (!nextEl) {
           nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl);
@@ -5911,7 +5911,7 @@
 
   function lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey) {
     // If the the key's DO match, no need to look ahead.
-    if (nextEl.__x_for_key === currentKey) return nextEl; // If the don't, we'll look ahead for a match.
+    if (nextEl.__x_for_key === currentKey) return nextEl; // If they don't, we'll look ahead for a match.
     // If we find it, we'll move it to the current position in the loop.
 
     var tmpNextEl = nextEl;
@@ -5923,8 +5923,6 @@
 
       tmpNextEl = tmpNextEl.nextElementSibling && tmpNextEl.nextElementSibling.__x_for_key !== undefined ? tmpNextEl.nextElementSibling : false;
     }
-
-    return false;
   }
 
   function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5379,7 +5379,12 @@
           return nextEl.__x_for;
         }.bind(this));
       } else {
-        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // Temporarily remove the key indicator to allow the normal "updateElements" to work
+        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // If I haven't found a matching key, just insert the element at the current position
+
+        if (!nextEl) {
+          nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl);
+        } // Temporarily remove the key indicator to allow the normal "updateElements" to work
+
 
         delete nextEl.__x_for_key;
         nextEl.__x_for = iterationScopeVariables;
@@ -5481,6 +5486,8 @@
 
       tmpNextEl = tmpNextEl.nextElementSibling && tmpNextEl.nextElementSibling.__x_for_key !== undefined ? tmpNextEl.nextElementSibling : false;
     }
+
+    return false;
   }
 
   function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -405,7 +405,7 @@
         nextEl.__x_for = iterationScopeVariables;
         component.initializeElements(nextEl, () => nextEl.__x_for);
       } else {
-        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // If I haven't found a matching key, just insert the element at the current position
+        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // If we haven't found a matching key, just insert the element at the current position
 
         if (!nextEl) {
           nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl);
@@ -487,7 +487,7 @@
 
   function lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey) {
     // If the the key's DO match, no need to look ahead.
-    if (nextEl.__x_for_key === currentKey) return nextEl; // If the don't, we'll look ahead for a match.
+    if (nextEl.__x_for_key === currentKey) return nextEl; // If they don't, we'll look ahead for a match.
     // If we find it, we'll move it to the current position in the loop.
 
     let tmpNextEl = nextEl;
@@ -499,8 +499,6 @@
 
       tmpNextEl = tmpNextEl.nextElementSibling && tmpNextEl.nextElementSibling.__x_for_key !== undefined ? tmpNextEl.nextElementSibling : false;
     }
-
-    return false;
   }
 
   function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -413,7 +413,12 @@
         nextEl.__x_for = iterationScopeVariables;
         component.initializeElements(nextEl, () => nextEl.__x_for);
       } else {
-        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // Temporarily remove the key indicator to allow the normal "updateElements" to work
+        nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey); // If I haven't found a matching key, just insert the element at the current position
+
+        if (!nextEl) {
+          nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl);
+        } // Temporarily remove the key indicator to allow the normal "updateElements" to work
+
 
         delete nextEl.__x_for_key;
         nextEl.__x_for = iterationScopeVariables;
@@ -502,6 +507,8 @@
 
       tmpNextEl = tmpNextEl.nextElementSibling && tmpNextEl.nextElementSibling.__x_for_key !== undefined ? tmpNextEl.nextElementSibling : false;
     }
+
+    return false;
   }
 
   function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -18,7 +18,7 @@ export function handleForDirective(component, templateEl, expression, initialUpd
         if (! nextEl || nextEl.__x_for_key === undefined) {
             nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl)
 
-            // And transition it in if it's not the first page load.
+            // And transition it in if  it's not the first page load.
             transitionIn(nextEl, () => {}, initialUpdate)
 
             nextEl.__x_for = iterationScopeVariables
@@ -26,8 +26,8 @@ export function handleForDirective(component, templateEl, expression, initialUpd
         } else {
             nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey)
 
-            // If I haven't found a matching key, just insert the element at the current position
-            if (!nextEl) {
+            // If we haven't found a matching key, just insert the element at the current position
+            if (! nextEl) {
                 nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl)
             }
 
@@ -115,7 +115,7 @@ function lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey) {
     // If the the key's DO match, no need to look ahead.
     if (nextEl.__x_for_key === currentKey) return nextEl
 
-    // If the don't, we'll look ahead for a match.
+    // If they don't, we'll look ahead for a match.
     // If we find it, we'll move it to the current position in the loop.
     let tmpNextEl = nextEl
 
@@ -126,8 +126,6 @@ function lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey) {
 
         tmpNextEl = (tmpNextEl.nextElementSibling && tmpNextEl.nextElementSibling.__x_for_key !== undefined) ? tmpNextEl.nextElementSibling : false
     }
-
-    return false
 }
 
 function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -26,6 +26,11 @@ export function handleForDirective(component, templateEl, expression, initialUpd
         } else {
             nextEl = lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey)
 
+            // If I haven't found a matching key, just insert the element at the current position
+            if (!nextEl) {
+                nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl)
+            }
+
             // Temporarily remove the key indicator to allow the normal "updateElements" to work
             delete nextEl.__x_for_key
 
@@ -121,6 +126,8 @@ function lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey) {
 
         tmpNextEl = (tmpNextEl.nextElementSibling && tmpNextEl.nextElementSibling.__x_for_key !== undefined) ? tmpNextEl.nextElementSibling : false
     }
+
+    return false
 }
 
 function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -18,7 +18,7 @@ export function handleForDirective(component, templateEl, expression, initialUpd
         if (! nextEl || nextEl.__x_for_key === undefined) {
             nextEl = addElementInLoopAfterCurrentEl(templateEl, currentEl)
 
-            // And transition it in if  it's not the first page load.
+            // And transition it in if it's not the first page load.
             transitionIn(nextEl, () => {}, initialUpdate)
 
             nextEl.__x_for = iterationScopeVariables

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -319,3 +319,34 @@ test('nested x-for', async () => {
     expect(document.querySelectorAll('h2')[1].innerText).toEqual('lob')
     expect(document.querySelectorAll('h2')[2].innerText).toEqual('law')
 })
+
+test('x-for updates the right elements when new item are inserted at the beginning of the list', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ items: [{name: 'one', key: '1'}, {name: 'twp', key: '2'}] }">
+            <button x-on:click="items = [{name: 'zero', key: '0'}, {name: 'one', key: '1'}, {name: 'twp', key: '2'}]"></button>
+
+            <template x-for="item in items" :key="item.key">
+                <span x-text="item.name"></span>
+            </template>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelectorAll('span').length).toEqual(2)
+    const itemA = document.querySelectorAll('span')[0]
+    itemA.setAttribute('order', 'first')
+    const itemB = document.querySelectorAll('span')[1]
+    itemB.setAttribute('order', 'second')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(3) })
+
+    expect(document.querySelectorAll('span')[0].getAttribute('order')).toEqual(null)
+    expect(document.querySelectorAll('span')[0].innerText).toEqual('zero')
+    expect(document.querySelectorAll('span')[1].getAttribute('order')).toEqual('first')
+    expect(document.querySelectorAll('span')[1].innerText).toEqual('one')
+    expect(document.querySelectorAll('span')[2].getAttribute('order')).toEqual('second')
+    expect(document.querySelectorAll('span')[2].innerText).toEqual('two')
+})

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -322,7 +322,7 @@ test('nested x-for', async () => {
 
 test('x-for updates the right elements when new item are inserted at the beginning of the list', async () => {
     document.body.innerHTML = `
-        <div x-data="{ items: [{name: 'one', key: '1'}, {name: 'twp', key: '2'}] }">
+        <div x-data="{ items: [{name: 'one', key: '1'}, {name: 'two', key: '2'}] }">
             <button x-on:click="items = [{name: 'zero', key: '0'}, {name: 'one', key: '1'}, {name: 'two', key: '2'}]"></button>
 
             <template x-for="item in items" :key="item.key">

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -323,7 +323,7 @@ test('nested x-for', async () => {
 test('x-for updates the right elements when new item are inserted at the beginning of the list', async () => {
     document.body.innerHTML = `
         <div x-data="{ items: [{name: 'one', key: '1'}, {name: 'twp', key: '2'}] }">
-            <button x-on:click="items = [{name: 'zero', key: '0'}, {name: 'one', key: '1'}, {name: 'twp', key: '2'}]"></button>
+            <button x-on:click="items = [{name: 'zero', key: '0'}, {name: 'one', key: '1'}, {name: 'two', key: '2'}]"></button>
 
             <template x-for="item in items" :key="item.key">
                 <span x-text="item.name"></span>
@@ -343,10 +343,12 @@ test('x-for updates the right elements when new item are inserted at the beginni
 
     await wait(() => { expect(document.querySelectorAll('span').length).toEqual(3) })
 
-    expect(document.querySelectorAll('span')[0].getAttribute('order')).toEqual(null)
     expect(document.querySelectorAll('span')[0].innerText).toEqual('zero')
-    expect(document.querySelectorAll('span')[1].getAttribute('order')).toEqual('first')
     expect(document.querySelectorAll('span')[1].innerText).toEqual('one')
-    expect(document.querySelectorAll('span')[2].getAttribute('order')).toEqual('second')
     expect(document.querySelectorAll('span')[2].innerText).toEqual('two')
+
+    // Make sure states are preserved
+    expect(document.querySelectorAll('span')[0].getAttribute('order')).toEqual(null)
+    expect(document.querySelectorAll('span')[1].getAttribute('order')).toEqual('first')
+    expect(document.querySelectorAll('span')[2].getAttribute('order')).toEqual('second')
 })


### PR DESCRIPTION
Fixes #371

The x-for refactoring introduced a regression. When updating a keyed list, if new items are not inserted at the end, the lookahead function doesn't return anything and the code doesn't handle it correctly.