### PR TITLE
Fix bound classes being removed unnecessarily

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5547,17 +5547,18 @@
         el.value = value;
       }
     } else if (attrName === 'class') {
-      var originalClasses = el.__x_original_classes || [];
-
       if (Array.isArray(value)) {
+        var originalClasses = el.__x_original_classes || [];
         el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '));
       } else if (_typeof(value) === 'object') {
-        var keysSortedByBoolean = Object.keys(value).sort(function (a, b) {
+        // Sorting the keys / class names by their boolean value will ensure that
+        // anything that evaluates to `false` and needs to remove classes is run first.
+        var keysSortedByBooleanValue = Object.keys(value).sort(function (a, b) {
           _newArrowCheck(this, _this);
 
           return value[a] - value[b];
         }.bind(this));
-        keysSortedByBoolean.forEach(function (classNames) {
+        keysSortedByBooleanValue.forEach(function (classNames) {
           var _this2 = this;
 
           _newArrowCheck(this, _this);
@@ -5577,8 +5578,10 @@
           }
         }.bind(this));
       } else {
+        var _originalClasses = el.__x_original_classes || [];
+
         var newClasses = value.split(' ');
-        el.setAttribute('class', arrayUnique(originalClasses.concat(newClasses)).join(' '));
+        el.setAttribute('class', arrayUnique(_originalClasses.concat(newClasses)).join(' '));
       }
     } else if (isBooleanAttr(attrName)) {
       // Boolean attributes have to be explicitly added and removed, not just set.

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5547,11 +5547,17 @@
         el.value = value;
       }
     } else if (attrName === 'class') {
+      var originalClasses = el.__x_original_classes || [];
+
       if (Array.isArray(value)) {
-        var originalClasses = el.__x_original_classes || [];
         el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '));
       } else if (_typeof(value) === 'object') {
-        Object.keys(value).forEach(function (classNames) {
+        var keysSortedByBoolean = Object.keys(value).sort(function (a, b) {
+          _newArrowCheck(this, _this);
+
+          return value[a] - value[b];
+        }.bind(this));
+        keysSortedByBoolean.forEach(function (classNames) {
           var _this2 = this;
 
           _newArrowCheck(this, _this);
@@ -5571,10 +5577,8 @@
           }
         }.bind(this));
       } else {
-        var _originalClasses = el.__x_original_classes || [];
-
         var newClasses = value.split(' ');
-        el.setAttribute('class', arrayUnique(_originalClasses.concat(newClasses)).join(' '));
+        el.setAttribute('class', arrayUnique(originalClasses.concat(newClasses)).join(' '));
       }
     } else if (isBooleanAttr(attrName)) {
       // Boolean attributes have to be explicitly added and removed, not just set.

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -556,13 +556,14 @@
         el.value = value;
       }
     } else if (attrName === 'class') {
-      let originalClasses = el.__x_original_classes || [];
-
       if (Array.isArray(value)) {
+        const originalClasses = el.__x_original_classes || [];
         el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '));
       } else if (typeof value === 'object') {
-        const keysSortedByBoolean = Object.keys(value).sort((a, b) => value[a] - value[b]);
-        keysSortedByBoolean.forEach(classNames => {
+        // Sorting the keys / class names by their boolean value will ensure that
+        // anything that evaluates to `false` and needs to remove classes is run first.
+        const keysSortedByBooleanValue = Object.keys(value).sort((a, b) => value[a] - value[b]);
+        keysSortedByBooleanValue.forEach(classNames => {
           if (value[classNames]) {
             classNames.split(' ').forEach(className => el.classList.add(className));
           } else {
@@ -570,6 +571,7 @@
           }
         });
       } else {
+        const originalClasses = el.__x_original_classes || [];
         const newClasses = value.split(' ');
         el.setAttribute('class', arrayUnique(originalClasses.concat(newClasses)).join(' '));
       }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -556,11 +556,13 @@
         el.value = value;
       }
     } else if (attrName === 'class') {
+      let originalClasses = el.__x_original_classes || [];
+
       if (Array.isArray(value)) {
-        const originalClasses = el.__x_original_classes || [];
         el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '));
       } else if (typeof value === 'object') {
-        Object.keys(value).forEach(classNames => {
+        const keysSortedByBoolean = Object.keys(value).sort((a, b) => value[a] - value[b]);
+        keysSortedByBoolean.forEach(classNames => {
           if (value[classNames]) {
             classNames.split(' ').forEach(className => el.classList.add(className));
           } else {
@@ -568,7 +570,6 @@
           }
         });
       } else {
-        const originalClasses = el.__x_original_classes || [];
         const newClasses = value.split(' ');
         el.setAttribute('class', arrayUnique(originalClasses.concat(newClasses)).join(' '));
       }

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -39,11 +39,12 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             el.value = value
         }
     } else if (attrName === 'class') {
-        let originalClasses = el.__x_original_classes || []
-
         if (Array.isArray(value)) {
+            const originalClasses = el.__x_original_classes || []
             el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '))
         } else if (typeof value === 'object') {
+            // Sorting the keys / class names by their boolean value will ensure that
+            // anything that evaluates to `false` and needs to remove classes is run first.
             const keysSortedByBooleanValue = Object.keys(value).sort((a, b) => value[a] - value[b]);
 
             keysSortedByBooleanValue.forEach(classNames => {
@@ -54,6 +55,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
                 }
             })
         } else {
+            const originalClasses = el.__x_original_classes || []
             const newClasses = value.split(' ')
             el.setAttribute('class', arrayUnique(originalClasses.concat(newClasses)).join(' '))
         }

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -46,7 +46,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         } else if (typeof value === 'object') {
             const keysSortedByBooleanValue = Object.keys(value).sort((a, b) => value[a] - value[b]);
 
-            keysSortedByBoolean.forEach(classNames => {
+            keysSortedByBooleanValue.forEach(classNames => {
                 if (value[classNames]) {
                     classNames.split(' ').forEach(className => el.classList.add(className))
                 } else {

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -39,11 +39,14 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             el.value = value
         }
     } else if (attrName === 'class') {
+        let originalClasses = el.__x_original_classes || []
+
         if (Array.isArray(value)) {
-            const originalClasses = el.__x_original_classes || []
             el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '))
         } else if (typeof value === 'object') {
-            Object.keys(value).forEach(classNames => {
+            const keysSortedByBooleanValue = Object.keys(value).sort((a, b) => value[a] - value[b]);
+
+            keysSortedByBoolean.forEach(classNames => {
                 if (value[classNames]) {
                     classNames.split(' ').forEach(className => el.classList.add(className))
                 } else {
@@ -51,7 +54,6 @@ export function handleAttributeBindingDirective(component, el, attrName, express
                 }
             })
         } else {
-            const originalClasses = el.__x_original_classes || []
             const newClasses = value.split(' ')
             el.setAttribute('class', arrayUnique(originalClasses.concat(newClasses)).join(' '))
         }

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -331,3 +331,27 @@ test('checkbox values are set correctly', async () => {
     expect(document.querySelector('input[name="falseCheckbox"]').value).toEqual('on')
     expect(document.querySelector('input[name="stringCheckbox"]').value).toEqual('foo')
 });
+
+test('classes are removed before being added', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ isOpen: true }">
+            <span :class="{ 'text-red block': isOpen, 'text-red hidden': !isOpen }">
+                Span
+            </span>
+            <button @click="isOpen = !isOpen"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').classList.contains('block')).toBeTruthy()
+    expect(document.querySelector('span').classList.contains('text-red')).toBeTruthy()
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').classList.contains('block')).toBeFalsy()
+        expect(document.querySelector('span').classList.contains('hidden')).toBeTruthy()
+        expect(document.querySelector('span').classList.contains('text-red')).toBeTruthy
+    })
+})


### PR DESCRIPTION
Closes #374. This fix isn't quite what was being suggested in the issue. The actual problem was that the order of operations (adding or removing the classes) was unknown, so the removal of a class might come after the addition of it and vice versa.

I've chosen to keep the footprint of the method the same near enough and instead sort the keys by the value before looping over them. This way, the classes that need to be removed (value evaluates to false) will become the iteratee first, and then new classes will be added afterwards.

If anyone thinks the method suggested in the PR is worth doing instead, let me know and I'll close this for someone else to implement or update the PR accordingly. Both have the same outcome either way and tests pass still.