### PR TITLE
Added new `.self` modifier for event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ Adding `.prevent` to an event listener will call `preventDefault` on the trigger
 
 Adding `.stop` to an event listener will call `stopPropagation` on the triggered event. In the above example, this means the "click" event won't bubble from the button to the outer `<div>`. Or in other words, when a user clicks the button, `foo` won't be set to `'bar'`.
 
+**`.self` modifier**
+**Example:** `<div x-on:click.self="foo = 'bar'"><button></button></div>`
+
+Adding `.self` to an event listener will ensure that the handler only runs when the event target is the element where the event listener was register. In the above example, this means the "click" event that bubbles from the button to the outer `<div>` will **not** run the handler.
+
 **`.window` modifier**
 **Example:** `<div x-on:resize.window="isOpen = window.outerWidth > 768 ? false : open"></div>`
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Adding `.stop` to an event listener will call `stopPropagation` on the triggered
 **`.self` modifier**
 **Example:** `<div x-on:click.self="foo = 'bar'"><button></button></div>`
 
-Adding `.self` to an event listener will ensure that the handler only runs when the event target is the element where the event listener was register. In the above example, this means the "click" event that bubbles from the button to the outer `<div>` will **not** run the handler.
+Adding `.self` to an event listener will only trigger the handler if the `$event.target` is the element itself. In the above example, this means the "click" event that bubbles from the button to the outer `<div>` will **not** run the handler.
 
 **`.window` modifier**
 **Example:** `<div x-on:resize.window="isOpen = window.outerWidth > 768 ? false : open"></div>`

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5767,7 +5767,9 @@
         }
 
         if (modifiers.includes('prevent')) e.preventDefault();
-        if (modifiers.includes('stop')) e.stopPropagation();
+        if (modifiers.includes('stop')) e.stopPropagation(); // If the .self modifier isn't present, or if it is present and
+        // the target element matches the element we are registering the
+        // event on, run the handler
 
         if (!modifiers.includes('self') || e.target === el) {
           var returnValue = runListenerHandler(component, expression, e, extraVars);

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5768,13 +5768,16 @@
 
         if (modifiers.includes('prevent')) e.preventDefault();
         if (modifiers.includes('stop')) e.stopPropagation();
-        var returnValue = runListenerHandler(component, expression, e, extraVars);
 
-        if (returnValue === false) {
-          e.preventDefault();
-        } else {
-          if (modifiers.includes('once')) {
-            listenerTarget.removeEventListener(event, _handler2);
+        if (!modifiers.includes('self') || e.target === el) {
+          var returnValue = runListenerHandler(component, expression, e, extraVars);
+
+          if (returnValue === false) {
+            e.preventDefault();
+          } else {
+            if (modifiers.includes('once')) {
+              listenerTarget.removeEventListener(event, _handler2);
+            }
           }
         }
       }.bind(this);

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -716,13 +716,16 @@
 
         if (modifiers.includes('prevent')) e.preventDefault();
         if (modifiers.includes('stop')) e.stopPropagation();
-        const returnValue = runListenerHandler(component, expression, e, extraVars);
 
-        if (returnValue === false) {
-          e.preventDefault();
-        } else {
-          if (modifiers.includes('once')) {
-            listenerTarget.removeEventListener(event, handler);
+        if (!modifiers.includes('self') || e.target === el) {
+          const returnValue = runListenerHandler(component, expression, e, extraVars);
+
+          if (returnValue === false) {
+            e.preventDefault();
+          } else {
+            if (modifiers.includes('once')) {
+              listenerTarget.removeEventListener(event, handler);
+            }
           }
         }
       };

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -715,7 +715,9 @@
         }
 
         if (modifiers.includes('prevent')) e.preventDefault();
-        if (modifiers.includes('stop')) e.stopPropagation();
+        if (modifiers.includes('stop')) e.stopPropagation(); // If the .self modifier isn't present, or if it is present and
+        // the target element matches the element we are registering the
+        // event on, run the handler
 
         if (!modifiers.includes('self') || e.target === el) {
           const returnValue = runListenerHandler(component, expression, e, extraVars);

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -43,13 +43,18 @@ export function registerListener(component, el, event, modifiers, expression, ex
             if (modifiers.includes('prevent')) e.preventDefault()
             if (modifiers.includes('stop')) e.stopPropagation()
 
-            const returnValue = runListenerHandler(component, expression, e, extraVars)
+            // If the .self modifier isn't present, or if it is present and
+            // the target element matches the element we are registering the
+            // event on, run the handler
+            if (! modifiers.includes('self') || e.target === el) {
+                const returnValue = runListenerHandler(component, expression, e, extraVars)
 
-            if (returnValue === false) {
-                e.preventDefault()
-            } else {
-                if (modifiers.includes('once')) {
-                    listenerTarget.removeEventListener(event, handler)
+                if (returnValue === false) {
+                    e.preventDefault()
+                } else {
+                    if (modifiers.includes('once')) {
+                        listenerTarget.removeEventListener(event, handler)
+                    }
                 }
             }
         }

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -66,7 +66,7 @@ test('.stop modifier', async () => {
 test('.self modifier', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: 'bar' }">
-            <div x-on:click.self="foo = 'baz'">
+            <div x-on:click.self="foo = 'baz'" id="selfTarget">
                 <button></button>
             </div>
             <span x-text="foo"></span>
@@ -83,7 +83,7 @@ test('.self modifier', async () => {
         expect(document.querySelector('span').innerText).toEqual('bar')
     })
 
-    document.querySelector('div').click()
+    document.querySelector('#selfTarget').click()
 
     await wait(() => {
         expect(document.querySelector('span').innerText).toEqual('baz')

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -66,20 +66,21 @@ test('.stop modifier', async () => {
 test('.self modifier', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: 'bar' }">
-            <button x-on:click.self="foo = 'baz'">
-                <span></span>
-            </button>
+            <div x-on:click.self="foo = 'baz'">
+                <button></button>
+            </div>
+            <span x-text="foo"></span>
         </div>
     `
 
     Alpine.start()
 
-    expect(document.querySelector('div').__x.$data.foo).toEqual('bar')
+    expect(document.querySelector('span').innerText).toEqual('bar')
 
-    document.querySelector('span').click()
+    document.querySelector('button').click()
 
     await wait(() => {
-        expect(document.querySelector('div').__x.$data.foo).toEqual('bar')
+        expect(document.querySelector('span').innerText).toEqual('bar')
     })
 })
 

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -82,6 +82,12 @@ test('.self modifier', async () => {
     await wait(() => {
         expect(document.querySelector('span').innerText).toEqual('bar')
     })
+
+    document.querySelector('div').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('baz')
+    })
 })
 
 test('.prevent modifier', async () => {

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -63,6 +63,26 @@ test('.stop modifier', async () => {
     })
 })
 
+test('.self modifier', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'bar' }">
+            <button x-on:click.self="foo = 'baz'">
+                <span></span>
+            </button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('div').__x.$data.foo).toEqual('bar')
+
+    document.querySelector('span').click()
+
+    await wait(() => {
+        expect(document.querySelector('div').__x.$data.foo).toEqual('bar')
+    })
+})
+
 test('.prevent modifier', async () => {
     document.body.innerHTML = `
         <div x-data="{}">


### PR DESCRIPTION
This PR introduces a new `.self` modifier with the same behaviour as Vue's implementation. This should also make it easier to prevent event's bubbled from nested elements being handled by parent elements, as in the case of #378.

When used on an element, i.e. `<div @click.self="handle()">`, the `handle()` method will only be called (or expression evaluated) if the element triggering the event matches the element that registered it. This will remove the need to add several `.stop` modifiers to nested elements when you don't want any event bubbling for that particular parent / component.

I'm not sure if it's worth noting in the docs / README that chaining modifiers in different orders, for example `@click.self.prevent` and `@click.prevent.self`, won't have any effect on the order of execution / evaluation since they are not being handled sequentially. The `.prevent` and `.stop` modifiers are always handled first, then the `.self` modifier.

P.s. there's a new test for this feature.