### PR TITLE
Refactor html/text directives into separate files

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5612,6 +5612,10 @@
     el.innerText = output;
   }
 
+  function handleHtmlDirective(component, el, expression, extraVars) {
+    el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars);
+  }
+
   function handleShowDirective(component, el, value, modifiers) {
     var _this = this;
 
@@ -6386,7 +6390,7 @@
               break;
 
             case 'html':
-              el.innerHTML = this.evaluateReturnExpression(el, expression, extraVars);
+              handleHtmlDirective(this, el, expression, extraVars);
               break;
 
             case 'show':

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -593,6 +593,15 @@
     });
   }
 
+  function handleTextDirective(el, output, expression) {
+    // If nested model key is undefined, set the default value to empty string.
+    if (output === undefined && expression.match(/\./).length) {
+      output = '';
+    }
+
+    el.innerText = output;
+  }
+
   function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     const hide = () => {
       el.style.display = 'none';
@@ -1465,13 +1474,8 @@
             break;
 
           case 'text':
-            var output = this.evaluateReturnExpression(el, expression, extraVars); // If nested model key is undefined, set the default value to empty string.
-
-            if (output === undefined && expression.match(/\./).length) {
-              output = '';
-            }
-
-            el.innerText = output;
+            var output = this.evaluateReturnExpression(el, expression, extraVars);
+            handleTextDirective(el, output, expression);
             break;
 
           case 'html':

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -602,6 +602,10 @@
     el.innerText = output;
   }
 
+  function handleHtmlDirective(component, el, expression, extraVars) {
+    el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars);
+  }
+
   function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     const hide = () => {
       el.style.display = 'none';
@@ -1479,7 +1483,7 @@
             break;
 
           case 'html':
-            el.innerHTML = this.evaluateReturnExpression(el, expression, extraVars);
+            handleHtmlDirective(this, el, expression, extraVars);
             break;
 
           case 'show':

--- a/src/component.js
+++ b/src/component.js
@@ -2,6 +2,7 @@ import { walk, saferEval, saferEvalNoReturn, getXAttrs, debounce } from './utils
 import { handleForDirective } from './directives/for'
 import { handleAttributeBindingDirective } from './directives/bind'
 import { handleTextDirective } from './directives/text'
+import { handleHtmlDirective } from './directives/html'
 import { handleShowDirective } from './directives/show'
 import { handleIfDirective } from './directives/if'
 import { registerModelListener } from './directives/model'
@@ -254,7 +255,7 @@ export default class Component {
                     break;
 
                 case 'html':
-                    el.innerHTML = this.evaluateReturnExpression(el, expression, extraVars)
+                    handleHtmlDirective(this, el, expression, extraVars)
                     break;
 
                 case 'show':

--- a/src/component.js
+++ b/src/component.js
@@ -1,6 +1,7 @@
 import { walk, saferEval, saferEvalNoReturn, getXAttrs, debounce } from './utils'
 import { handleForDirective } from './directives/for'
 import { handleAttributeBindingDirective } from './directives/bind'
+import { handleTextDirective } from './directives/text'
 import { handleShowDirective } from './directives/show'
 import { handleIfDirective } from './directives/if'
 import { registerModelListener } from './directives/model'
@@ -249,12 +250,7 @@ export default class Component {
                 case 'text':
                     var output = this.evaluateReturnExpression(el, expression, extraVars);
 
-                    // If nested model key is undefined, set the default value to empty string.
-                    if (output === undefined && expression.match(/\./).length) {
-                        output = ''
-                    }
-
-                    el.innerText = output
+                   handleTextDirective(el, output, expression)
                     break;
 
                 case 'html':

--- a/src/component.js
+++ b/src/component.js
@@ -250,7 +250,7 @@ export default class Component {
                 case 'text':
                     var output = this.evaluateReturnExpression(el, expression, extraVars);
 
-                   handleTextDirective(el, output, expression)
+                    handleTextDirective(el, output, expression)
                     break;
 
                 case 'html':

--- a/src/directives/html.js
+++ b/src/directives/html.js
@@ -1,0 +1,3 @@
+export function handleHtmlDirective(component, el, expression, extraVars) {
+    el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars)
+}

--- a/src/directives/text.js
+++ b/src/directives/text.js
@@ -1,0 +1,8 @@
+export function handleTextDirective(el, output, expression) {
+    // If nested model key is undefined, set the default value to empty string.
+    if (output === undefined && expression.match(/\./).length) {
+        output = ''
+    }
+
+    el.innerText = output
+}


### PR DESCRIPTION
Not sure if `text.js` was intentionally left empty. I was thinking a filter idea so just want to move it to its own file for sake of readability. 


 >update
updated this PR to include `html.js` file as well. It will be better for future updates and maintaince. Now every directive has its own file. 