### PR TITLE
Fixed detection of KeyboardEvents

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5760,7 +5760,7 @@
           }
         }
 
-        if (isKeyEvent(event)) {
+        if (isKeyEvent(e)) {
           if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
             return;
           }
@@ -5802,7 +5802,7 @@
   }
 
   function isKeyEvent(event) {
-    return ['keydown', 'keyup'].includes(event);
+    return event instanceof KeyboardEvent && ['keydown', 'keyup'].includes(event.type);
   }
 
   function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5822,7 +5822,7 @@
 
     if (keyModifiers.length === 0) return false; // If one is passed, AND it matches the key pressed, we'll call it a press.
 
-    if (keyModifiers.length === 1 && e.key && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
+    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
 
     var systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super'];
     var selectedSystemKeyModifiers = systemKeyModifiers.filter(function (modifier) {
@@ -5865,7 +5865,7 @@
         return 'space';
 
       default:
-        return kebabCase(key);
+        return key && kebabCase(key);
     }
   }
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5760,7 +5760,7 @@
           }
         }
 
-        if (isKeyEvent(e)) {
+        if (isKeyEvent(event)) {
           if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
             return;
           }
@@ -5802,7 +5802,7 @@
   }
 
   function isKeyEvent(event) {
-    return event instanceof KeyboardEvent && ['keydown', 'keyup'].includes(event.type);
+    return ['keydown', 'keyup'].includes(event);
   }
 
   function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
@@ -5822,7 +5822,7 @@
 
     if (keyModifiers.length === 0) return false; // If one is passed, AND it matches the key pressed, we'll call it a press.
 
-    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
+    if (keyModifiers.length === 1 && e.key && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
 
     var systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super'];
     var selectedSystemKeyModifiers = systemKeyModifiers.filter(function (modifier) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -762,7 +762,7 @@
 
     if (keyModifiers.length === 0) return false; // If one is passed, AND it matches the key pressed, we'll call it a press.
 
-    if (keyModifiers.length === 1 && e.key && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
+    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
 
     const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super'];
     const selectedSystemKeyModifiers = systemKeyModifiers.filter(modifier => keyModifiers.includes(modifier));
@@ -795,7 +795,7 @@
         return 'space';
 
       default:
-        return kebabCase(key);
+        return key && kebabCase(key);
     }
   }
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -708,7 +708,7 @@
           }
         }
 
-        if (isKeyEvent(e)) {
+        if (isKeyEvent(event)) {
           if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
             return;
           }
@@ -746,7 +746,7 @@
   }
 
   function isKeyEvent(event) {
-    return event instanceof KeyboardEvent && ['keydown', 'keyup'].includes(event.type);
+    return ['keydown', 'keyup'].includes(event);
   }
 
   function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
@@ -762,7 +762,7 @@
 
     if (keyModifiers.length === 0) return false; // If one is passed, AND it matches the key pressed, we'll call it a press.
 
-    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
+    if (keyModifiers.length === 1 && e.key && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
 
     const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super'];
     const selectedSystemKeyModifiers = systemKeyModifiers.filter(modifier => keyModifiers.includes(modifier));

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -708,7 +708,7 @@
           }
         }
 
-        if (isKeyEvent(event)) {
+        if (isKeyEvent(e)) {
           if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
             return;
           }
@@ -746,7 +746,7 @@
   }
 
   function isKeyEvent(event) {
-    return ['keydown', 'keyup'].includes(event);
+    return event instanceof KeyboardEvent && ['keydown', 'keyup'].includes(event.type);
   }
 
   function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -34,7 +34,7 @@ export function registerListener(component, el, event, modifiers, expression, ex
                 }
             }
 
-            if (isKeyEvent(e)) {
+            if (isKeyEvent(event)) {
                 if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
                     return
                 }
@@ -71,7 +71,7 @@ function runListenerHandler(component, expression, e, extraVars) {
 }
 
 function isKeyEvent(event) {
-    return event instanceof KeyboardEvent && ['keydown', 'keyup'].includes(event.type)
+    return ['keydown', 'keyup'].includes(event)
 }
 
 function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
@@ -88,7 +88,7 @@ function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
     if (keyModifiers.length === 0) return false
 
     // If one is passed, AND it matches the key pressed, we'll call it a press.
-    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false
+    if (keyModifiers.length === 1 && e.key && keyModifiers[0] === keyToModifier(e.key)) return false
 
     // The user is listening for key combinations.
     const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super']

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -88,7 +88,7 @@ function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
     if (keyModifiers.length === 0) return false
 
     // If one is passed, AND it matches the key pressed, we'll call it a press.
-    if (keyModifiers.length === 1 && e.key && keyModifiers[0] === keyToModifier(e.key)) return false
+    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false
 
     // The user is listening for key combinations.
     const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super']
@@ -123,6 +123,6 @@ function keyToModifier(key) {
         case 'Spacebar':
             return 'space'
         default:
-            return kebabCase(key)
+            return key && kebabCase(key)
     }
 }

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -34,7 +34,7 @@ export function registerListener(component, el, event, modifiers, expression, ex
                 }
             }
 
-            if (isKeyEvent(event)) {
+            if (isKeyEvent(e)) {
                 if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
                     return
                 }
@@ -71,7 +71,7 @@ function runListenerHandler(component, expression, e, extraVars) {
 }
 
 function isKeyEvent(event) {
-    return ['keydown', 'keyup'].includes(event)
+    return event instanceof KeyboardEvent && ['keydown', 'keyup'].includes(event.type)
 }
 
 function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -1,5 +1,5 @@
 import Alpine from 'alpinejs'
-import { wait, fireEvent } from '@testing-library/dom'
+import { wait, fireEvent, createEvent } from '@testing-library/dom'
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 global.MutationObserver = class {
@@ -407,4 +407,34 @@ test('event instance is passed to method reference', async () => {
     await new Promise(resolve => setTimeout(resolve, 1))
 
     expect(document.querySelector('span').innerText).toEqual('baz')
+})
+
+test('autocomplete event does not trigger keydown with modifier callback', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ count: 0 }">
+            <input type="text" x-on:keydown.?="count++">
+
+            <span x-text="count"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual(0)
+
+    const autocompleteEvent = new Event('keydown')
+
+    console.log(autocompleteEvent)
+
+    fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' })
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual(0) })
+
+    fireEvent.keyDown(document.querySelector('input'), { key: '?' })
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
+
+    fireEvent(document.querySelector('input'), autocompleteEvent)
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual(1) })
 })

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -1,5 +1,5 @@
 import Alpine from 'alpinejs'
-import { wait, fireEvent, createEvent } from '@testing-library/dom'
+import { wait, fireEvent } from '@testing-library/dom'
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 global.MutationObserver = class {

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -424,8 +424,6 @@ test('autocomplete event does not trigger keydown with modifier callback', async
 
     const autocompleteEvent = new Event('keydown')
 
-    console.log(autocompleteEvent)
-
     fireEvent.keyDown(document.querySelector('input'), { key: 'Enter' })
 
     await wait(() => { expect(document.querySelector('span').innerText).toEqual(0) })


### PR DESCRIPTION
Chrome and Safari (and, I suppose, all Chromium and Webkit browsers) have this behaviour where an Event (not a KeyboardEvent) with type "keydown" (and another with "keyup") is triggered on autocomplete input.

https://bugs.chromium.org/p/chromium/issues/detail?id=581537

This fix updates the `isKeyEvent` function by adding a check on the Event object type, and accepting only `KeyboardEvent`. This solves a problem of ghost key events that don't have a type property and cause an error when `keyToModifier` is called with `undefined` argument.

The first attempt to solve this was by fixing the `keyToModifier` function (https://github.com/zupolgec/alpine/commit/2a1f807d288ec2939ac7afdb636e128502efe669), but since the `isListeningForASpecificKeyThatHasntBeenPressed` function is doing nothing on such fake Events, I thought that this is the best solution.