### PR TITLE
x-ignore directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ These behave exactly like VueJs's transition directives, except they have differ
 ### `x-ignore`
 **Example:**
 ```html
-<div x-ignore>
+<div x-ignore="true">
     <div x-data="{foo:'UNTRUSTED CONTENT'}">
         <span x-text="foo">"foo" never gets bind by alpine</span>
     </div>

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ These behave exactly like VueJs's transition directives, except they have differ
 ```html
 <div x-ignore="true">
     <div x-data="{foo:'bar'}">
-        <span x-text="foo">"foo" will not set to 'bar' by Alpine</span>
+        <span x-text="foo">foo won't be set to 'bar' by Alpine</span>
     </div>
 </div>
 ```

--- a/README.md
+++ b/README.md
@@ -481,11 +481,11 @@ These behave exactly like VueJs's transition directives, except they have differ
 ```html
 <div x-ignore="true">
     <div x-data="{foo:'bar'}">
-        <span x-text="foo">"foo" never gets bind by alpine</span>
+        <span x-text="foo">"foo" will not set to 'bar' by Alpine</span>
     </div>
 </div>
 ```
-`x-ignore` can be used to stop DOM walking and ignoring any components within the element.
+`x-ignore` can be used to mark an element's children as "to be ignored" by Alpine. This means that Alpine will not walk the DOM tree any further and will not initialise any components within the `x-ignore`-ed element.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ These behave exactly like VueJs's transition directives, except they have differ
 **Example:**
 ```html
 <div x-ignore="true">
-    <div x-data="{foo:'UNTRUSTED CONTENT'}">
+    <div x-data="{foo:'bar'}">
         <span x-text="foo">"foo" never gets bind by alpine</span>
     </div>
 </div>

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ There are 13 directives available to you:
 | [`x-if`](#x-if) | Remove an element completely from the DOM. Needs to be used on a `<template>` tag. |
 | [`x-for`](#x-for) | Create new DOM nodes for each item in an array. Needs to be used on a `<template>` tag. |
 | [`x-transition`](#x-transition) | Directives for applying classes to various stages of an element's transition |
+| [`x-ignore`](#x-ignore) | Ignores components within the the element. |
 | [`x-cloak`](#x-cloak) | This attribute is removed when Alpine initializes. Useful for hiding pre-initialized DOM. |
 
 And 6 magic properties:
@@ -472,6 +473,19 @@ These behave exactly like VueJs's transition directives, except they have differ
 | `:leave` | Applied during the entire leaving phase. |
 | `:leave-start` | Added immediately when a leaving transition is triggered, removed after one frame. |
 | `:leave-end` | Added one frame after a leaving transition is triggered (at the same time `leave-start` is removed), removed when the transition/animation finishes.
+
+---
+
+### `x-ignore`
+**Example:**
+```html
+<div x-ignore>
+    <div x-data="{foo:'UNTRUSTED CONTENT'}">
+        <span x-text="foo">"foo" never gets bind by alpine</span>
+    </div>
+</div>
+```
+`x-ignore` can be used to stop DOM walking and ignoring any components within the element.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ There are 13 directives available to you:
 | [`x-if`](#x-if) | Remove an element completely from the DOM. Needs to be used on a `<template>` tag. |
 | [`x-for`](#x-for) | Create new DOM nodes for each item in an array. Needs to be used on a `<template>` tag. |
 | [`x-transition`](#x-transition) | Directives for applying classes to various stages of an element's transition |
-| [`x-ignore`](#x-ignore) | Ignores components within the the element. |
+| [`x-ignore`](#x-ignore) | Ignores components within the element. |
 | [`x-cloak`](#x-cloak) | This attribute is removed when Alpine initializes. Useful for hiding pre-initialized DOM. |
 
 And 6 magic properties:

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5355,7 +5355,7 @@
   }
   function walk(el, callback) {
     // Detect ignore element and return if we hit one
-    if (el.parentElement.closest('[x-ignore]')) return;
+    if (el.parentElement.closest('[x-ignore]:not([x-ignore=false])')) return;
     if (callback(el) === false) return;
     var node = el.firstElementChild;
 
@@ -7109,7 +7109,7 @@
         _newArrowCheck(this, _this3);
 
         // Detect ignore element and return if we hit one
-        if (rootEl.parentElement.closest('[x-ignore]')) return;
+        if (rootEl.parentElement.closest('[x-ignore]:not([x-ignore=false])')) return;
         callback(rootEl);
       }.bind(this));
     },

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5354,6 +5354,8 @@
     return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase();
   }
   function walk(el, callback) {
+    // Detect ignore element and return if we hit one
+    if (el.parentElement.closest('[x-ignore]')) return;
     if (callback(el) === false) return;
     var node = el.firstElementChild;
 
@@ -7106,6 +7108,8 @@
       rootEls.forEach(function (rootEl) {
         _newArrowCheck(this, _this3);
 
+        // Detect ignore element and return if we hit one
+        if (rootEl.parentElement.closest('[x-ignore]')) return;
         callback(rootEl);
       }.bind(this));
     },

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -75,7 +75,7 @@
   }
   function walk(el, callback) {
     // Detect ignore element and return if we hit one
-    if (el.parentElement.closest('[x-ignore]')) return;
+    if (el.parentElement.closest('[x-ignore]:not([x-ignore=false])')) return;
     if (callback(el) === false) return;
     let node = el.firstElementChild;
 
@@ -1647,7 +1647,7 @@
       const rootEls = document.querySelectorAll('[x-data]');
       rootEls.forEach(rootEl => {
         // Detect ignore element and return if we hit one
-        if (rootEl.parentElement.closest('[x-ignore]')) return;
+        if (rootEl.parentElement.closest('[x-ignore]:not([x-ignore=false])')) return;
         callback(rootEl);
       });
     },

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -74,6 +74,8 @@
     return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase();
   }
   function walk(el, callback) {
+    // Detect ignore element and return if we hit one
+    if (el.parentElement.closest('[x-ignore]')) return;
     if (callback(el) === false) return;
     let node = el.firstElementChild;
 
@@ -1644,6 +1646,8 @@
     discoverComponents: function discoverComponents(callback) {
       const rootEls = document.querySelectorAll('[x-data]');
       rootEls.forEach(rootEl => {
+        // Detect ignore element and return if we hit one
+        if (rootEl.parentElement.closest('[x-ignore]')) return;
         callback(rootEl);
       });
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "alpinejs",
-    "version": "2.2.2",
+    "version": "2.2.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const Alpine = {
 
         rootEls.forEach(rootEl => {
             // Detect ignore element and return if we hit one
-            if (rootEl.parentElement.closest('[x-ignore]')) return
+            if (rootEl.parentElement.closest('[x-ignore]:not([x-ignore=false])')) return
 
             callback(rootEl)
         })

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,9 @@ const Alpine = {
         const rootEls = document.querySelectorAll('[x-data]');
 
         rootEls.forEach(rootEl => {
+            // Detect ignore element and return if we hit one
+            if (rootEl.parentElement.closest('[x-ignore]')) return
+
             callback(rootEl)
         })
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,9 @@ export function kebabCase(subject) {
 }
 
 export function walk(el, callback) {
+    // Detect ignore element and return if we hit one
+    if (el.parentElement.closest('[x-ignore]')) return
+
     if (callback(el) === false) return
 
     let node = el.firstElementChild

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ export function kebabCase(subject) {
 
 export function walk(el, callback) {
     // Detect ignore element and return if we hit one
-    if (el.parentElement.closest('[x-ignore]')) return
+    if (el.parentElement.closest('[x-ignore]:not([x-ignore=false])')) return
 
     if (callback(el) === false) return
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,7 +76,7 @@ export function saferEvalNoReturn(expression, dataContext, additionalHelperVaria
     )
 }
 
-const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/
+const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ignore|ref)\b/
 
 export function isXAttr(attr) {
     const name = replaceAtAndColonWithStandardSyntax(attr.name)

--- a/test/ignore.spec.js
+++ b/test/ignore.spec.js
@@ -7,7 +7,7 @@ global.MutationObserver = class {
 
 test('x-ignore ignores initialization of any new components within the node', async () => {
     document.body.innerHTML = `
-    <div x-ignore>
+    <div x-ignore="true">
         <div x-data="{foo:'foo'}">
             <span x-text="foo"></span>
         </div>

--- a/test/ignore.spec.js
+++ b/test/ignore.spec.js
@@ -19,7 +19,7 @@ test('x-ignore ignores initialization of any new components within the node', as
     await wait(() => { expect(document.querySelector('span').innerText).toEqual(undefined) })
 })
 
-test('x-ignore if set to false it will initialize any new components within the node', async () => {
+test('if x-ignore set to false it will initialize any new components within the node', async () => {
     document.body.innerHTML = `
     <div x-ignore="false">
         <div x-data="{foo:'foo'}">
@@ -30,10 +30,34 @@ test('x-ignore if set to false it will initialize any new components within the 
 
     Alpine.start()
 
-    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+     })
 })
 
-test('x-ignore if empty ignores initialization of any new components within the node', async () => {
+test('Nested x-ignore set to true nodes will not initialize any new components within the node', async () => {
+    document.body.innerHTML = `
+    <div x-ignore="false">
+        <div x-data="{foo:'foo'}">
+            <span x-text="foo"></span>
+        </div>
+        <div x-ignore="true">
+            <div x-data="{bar:'baz'}">
+                <h1 x-text="bar"></h1>
+            </div>
+        </div>
+    </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => {
+        expect(document.querySelector('span').innerText).toEqual('foo')
+        expect(document.querySelector('h1').innerText).toEqual(undefined)
+     })
+})
+
+test('if x-ignore attribute without a value, it will default to "true"', async () => {
     document.body.innerHTML = `
     <div x-ignore>
         <div x-data="{foo:'foo'}">

--- a/test/ignore.spec.js
+++ b/test/ignore.spec.js
@@ -7,7 +7,35 @@ global.MutationObserver = class {
 
 test('x-ignore ignores initialization of any new components within the node', async () => {
     document.body.innerHTML = `
-    <div x-ignore="true">
+    <div x-ignore="ignore" data="{ignore:true}">
+        <div x-data="{foo:'foo'}">
+            <span x-text="foo"></span>
+        </div>
+    </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual(undefined) })
+})
+
+test('x-ignore if set to false it will initialize any new components within the node', async () => {
+    document.body.innerHTML = `
+    <div x-ignore="false">
+        <div x-data="{foo:'foo'}">
+            <span x-text="foo"></span>
+        </div>
+    </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('foo') })
+})
+
+test('x-ignore if empty ignores initialization of any new components within the node', async () => {
+    document.body.innerHTML = `
+    <div x-ignore>
         <div x-data="{foo:'foo'}">
             <span x-text="foo"></span>
         </div>

--- a/test/ignore.spec.js
+++ b/test/ignore.spec.js
@@ -1,0 +1,20 @@
+import Alpine from 'alpinejs'
+import { wait } from '@testing-library/dom'
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+test('x-ignore ignores initialization of any new components within the node', async () => {
+    document.body.innerHTML = `
+    <div x-ignore>
+        <div x-data="{foo:'foo'}">
+            <span x-text="foo"></span>
+        </div>
+    </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual(undefined) })
+})


### PR DESCRIPTION
>Updated description!

Fixes #393 New directive to ~~secure Alpine for untrusted DOM nodes~~ stop Alpine walk in the defined node. It still does not cover any security of the untrusted content. Just a way to stop Alpine initialize components within the node. 


Usage:

```html
   <div x-ignore="ignore" x-data="{ignore: true}">
        <div x-data="{foo:'foo'}">
            <span x-text="foo"></span>
        </div>
    </div>
```
it will ignore any `x-data` components within the applied node. There is a `x-ignore` test and all green. Docs updated as well.
> if `ignore` set to `false`, it will initialize  components within