### PR TITLE
feat(alpine-version)

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -7054,6 +7054,7 @@
   }();
 
   var Alpine = {
+    version: "2.3.0",
     start: function () {
       var _start = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
         var _this = this;

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1631,6 +1631,7 @@
   }
 
   const Alpine = {
+    version: "2.3.0",
     start: async function start() {
       if (!isTesting()) {
         await domReady();

--- a/rollup-ie11.config.js
+++ b/rollup-ie11.config.js
@@ -4,6 +4,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import multi from '@rollup/plugin-multi-entry';
 import replace from '@rollup/plugin-replace';
+import pkg from './package.json';
 
 export default {
     input: ['src/polyfills.js', 'src/index.js'],
@@ -15,8 +16,12 @@ export default {
     plugins: [
         multi(),
         commonjs(),
-        // 'observable-membrane' uses process.env. We don't have that...
-        replace({ "process.env.NODE_ENV": "'production'" }),
+        replace({
+            // 'observable-membrane' uses process.env. We don't have that...
+            "process.env.NODE_ENV": "'production'",
+            // inject Alpine.js package version number
+            "process.env.PKG_VERSION": `"${pkg.version}"`
+        }),
         resolve(),
         filesize(),
         babel({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import filesize from 'rollup-plugin-filesize';
 import resolve from 'rollup-plugin-node-resolve';
 import stripCode from 'rollup-plugin-strip-code';
 import replace from '@rollup/plugin-replace';
+import pkg from './package.json';
 
 export default {
     input: 'src/index.js',
@@ -12,8 +13,12 @@ export default {
         format: 'umd',
     },
     plugins: [
-        // 'observable-membrane' uses process.env. We don't have that...
-        replace({ "process.env.NODE_ENV": "'production'" }),
+        replace({
+            // 'observable-membrane' uses process.env. We don't have that...
+            "process.env.NODE_ENV": "'production'",
+            // inject Alpine.js package version number
+            "process.env.PKG_VERSION": `"${pkg.version}"`
+        }),
         resolve(),
         filesize(),
         babel({

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Component from './component'
 import { domReady, isTesting } from './utils'
 
 const Alpine = {
+    version: process.env.PKG_VERSION,
     start: async function () {
         if (! isTesting()) {
             await domReady()

--- a/test/version.spec.js
+++ b/test/version.spec.js
@@ -1,0 +1,6 @@
+import { version } from 'alpinejs'
+import pkg from '../package.json'
+
+test('Alpine.version matches package.json version field', () => {
+    expect(version).toEqual(String(pkg.version))
+})


### PR DESCRIPTION
Closes #398 

- Add a "version" field on the `Alpine` global, populated by rollup from package.json

**Note for @calebporzio** to keep this number in sync you'll need to rebuild assets _after_ you've bumped the version _before_ publishing. So bump version -> rebuild -> commit -> publish