### PR TITLE
Added .once modifier to x-html and x-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ If you wish to customize this, you can specifiy a custom wait time like so:
 
 `x-text` works similarly to `x-bind`, except instead of updating the value of an attribute, it will update the `innerText` of an element.
 
+**`.once` modifier**
+**Example:** `<button x-text.once="foo"></button>`
+
+Adding the `.once` modifier to the `x-text` will ensure that the element content will only be set once at the initialization of component. This is useful when you need to show the data in its initial state.
+
 ---
 
 ### `x-html`
@@ -380,6 +385,11 @@ If you wish to customize this, you can specifiy a custom wait time like so:
 > :warning: **Only use on trusted content and never on user-provided content.** :warning:
 >
 > Dynamically rendering HTML from third parties can easily lead to [XSS](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting) vulnerabilities.
+
+**`.once` modifier**
+**Example:** `<button x-text.once="foo"></button>`
+
+Adding the `.once` modifier to the `x-html` will ensure that the element content will only be set once at the initialization of component. This is useful when you need to show the data in its initial state.
 
 ---
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6068,8 +6068,14 @@
     }.bind(this));
   }
 
-  function handleTextDirective(el, output, expression) {
-    // If nested model key is undefined, set the default value to empty string.
+  function handleTextDirective(el, output, modifiers, expression) {
+    var initialUpdate = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
+
+    if (modifiers.includes('once') && !initialUpdate) {
+      return;
+    } // If nested model key is undefined, set the default value to empty string.
+
+
     if (output === undefined && expression.match(/\./).length) {
       output = '';
     }
@@ -6077,7 +6083,13 @@
     el.innerText = output;
   }
 
-  function handleHtmlDirective(component, el, expression, extraVars) {
+  function handleHtmlDirective(component, el, modifiers, expression, extraVars) {
+    var initialUpdate = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : false;
+
+    if (modifiers.includes('once') && !initialUpdate) {
+      return;
+    }
+
     el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars);
   }
 
@@ -6876,11 +6888,11 @@
 
             case 'text':
               var output = this.evaluateReturnExpression(el, expression, extraVars);
-              handleTextDirective(el, output, expression);
+              handleTextDirective(el, output, modifiers, expression, initialUpdate);
               break;
 
             case 'html':
-              handleHtmlDirective(this, el, expression, extraVars);
+              handleHtmlDirective(this, el, modifiers, expression, extraVars, initialUpdate);
               break;
 
             case 'show':

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -608,8 +608,12 @@
     });
   }
 
-  function handleTextDirective(el, output, expression) {
-    // If nested model key is undefined, set the default value to empty string.
+  function handleTextDirective(el, output, modifiers, expression, initialUpdate = false) {
+    if (modifiers.includes('once') && !initialUpdate) {
+      return;
+    } // If nested model key is undefined, set the default value to empty string.
+
+
     if (output === undefined && expression.match(/\./).length) {
       output = '';
     }
@@ -617,7 +621,11 @@
     el.innerText = output;
   }
 
-  function handleHtmlDirective(component, el, expression, extraVars) {
+  function handleHtmlDirective(component, el, modifiers, expression, extraVars, initialUpdate = false) {
+    if (modifiers.includes('once') && !initialUpdate) {
+      return;
+    }
+
     el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars);
   }
 
@@ -1514,11 +1522,11 @@
 
           case 'text':
             var output = this.evaluateReturnExpression(el, expression, extraVars);
-            handleTextDirective(el, output, expression);
+            handleTextDirective(el, output, modifiers, expression, initialUpdate);
             break;
 
           case 'html':
-            handleHtmlDirective(this, el, expression, extraVars);
+            handleHtmlDirective(this, el, modifiers, expression, extraVars, initialUpdate);
             break;
 
           case 'show':

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "alpinejs",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/component.js
+++ b/src/component.js
@@ -263,11 +263,11 @@ export default class Component {
                 case 'text':
                     var output = this.evaluateReturnExpression(el, expression, extraVars);
 
-                    handleTextDirective(el, output, expression)
+                    handleTextDirective(el, output, modifiers, expression, initialUpdate)
                     break;
 
                 case 'html':
-                    handleHtmlDirective(this, el, expression, extraVars)
+                    handleHtmlDirective(this, el, modifiers, expression, extraVars, initialUpdate)
                     break;
 
                 case 'show':

--- a/src/directives/html.js
+++ b/src/directives/html.js
@@ -1,3 +1,7 @@
-export function handleHtmlDirective(component, el, expression, extraVars) {
+export function handleHtmlDirective(component, el, modifiers, expression, extraVars, initialUpdate = false) {
+    if (modifiers.includes('once') && !initialUpdate) {
+        return;
+    }
+
     el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars)
 }

--- a/src/directives/text.js
+++ b/src/directives/text.js
@@ -1,4 +1,8 @@
-export function handleTextDirective(el, output, expression) {
+export function handleTextDirective(el, output, modifiers, expression, initialUpdate = false) {
+    if (modifiers.includes('once') && !initialUpdate) {
+        return;
+    }
+
     // If nested model key is undefined, set the default value to empty string.
     if (output === undefined && expression.match(/\./).length) {
         output = ''

--- a/test/html.spec.js
+++ b/test/html.spec.js
@@ -34,3 +34,33 @@ test('x-html on triggered update', async () => {
 
     await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>') })
 })
+
+test('x-html.once on init', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: '<h1>bar</h1>' }">
+            <span x-html.once="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>') })
+})
+
+test('x-html.once on triggered update', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: '<h1>foo</h1>' }">
+            <button x-on:click="foo = '<h2>bar</h2>'"></button>
+
+            <span x-html.once="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>foo</h1>') })
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>foo</h1>') })
+})

--- a/test/text.spec.js
+++ b/test/text.spec.js
@@ -34,3 +34,33 @@ test('x-text on triggered update', async () => {
 
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
+
+test('x-text.once on init', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'initial text' }">
+            <span x-text.once="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('initial text') })
+})
+
+test('x-text.once on triggered update', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'initial text' }">
+            <button x-on:click="foo = 'updated text'"></button>
+
+            <span x-text.once="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('initial text') })
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('initial text') })
+})


### PR DESCRIPTION
I'm not sure if this modifier has a common-enough use case to be included in the library but I needed it and added it, so feel free to shoot it down if it is deemed unnecessary. Though it only adds 271 bytes to the raw output, and probably a minuscule amount to the gzipped output so it shouldn't be an issue performance-wise.

The way it works is that `x-html.once` and `x-text.once` basically does not respond to any updates in the component after the initialization.