### PR TITLE
Fix safari bug for input type="hidden"

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5993,7 +5993,7 @@
         }
       } else if (el.tagName === 'SELECT') {
         updateSelect(el, value);
-      } else {
+      } else if (el.type === 'text') {
         // Cursor position should be restored back to origin due to a safari bug
         var selectionStart = el.selectionStart;
         var selectionEnd = el.selectionEnd;
@@ -6003,6 +6003,8 @@
         if (el === document.activeElement && selectionStart !== null) {
           el.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
         }
+      } else {
+        el.value = value;
       }
     } else if (attrName === 'class') {
       if (Array.isArray(value)) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -556,7 +556,7 @@
         }
       } else if (el.tagName === 'SELECT') {
         updateSelect(el, value);
-      } else {
+      } else if (el.type === 'text') {
         // Cursor position should be restored back to origin due to a safari bug
         const selectionStart = el.selectionStart;
         const selectionEnd = el.selectionEnd;
@@ -566,6 +566,8 @@
         if (el === document.activeElement && selectionStart !== null) {
           el.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
         }
+      } else {
+        el.value = value;
       }
     } else if (attrName === 'class') {
       if (Array.isArray(value)) {

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -42,7 +42,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             }
         } else if (el.tagName === 'SELECT') {
             updateSelect(el, value)
-        } else {
+        } else if (el.type === 'text') {
             // Cursor position should be restored back to origin due to a safari bug
             const selectionStart = el.selectionStart
             const selectionEnd = el.selectionEnd
@@ -53,6 +53,8 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             if (el === document.activeElement && selectionStart !== null) {
                 el.setSelectionRange(selectionStart, selectionEnd, selectionDirection)
             }
+        } else {
+            el.value = value
         }
     } else if (attrName === 'class') {
         if (Array.isArray(value)) {


### PR DESCRIPTION
Currently, `x-model` does not work on "hidden" inputs in Safari because of a recent bug fix (ironically to fix a different safari bug)