### PR TITLE
Fix Turbolinks error situations

### DIFF
--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1629,17 +1629,9 @@
 
       this.discoverComponents(el => {
         this.initializeComponent(el);
-      }); // It's easier and more performant to just support Turbolinks than listen
-      // to MutationObserver mutations at the document level.
-
-      document.addEventListener("turbolinks:load", () => {
-        this.discoverUninitializedComponents(el => {
-          this.initializeComponent(el);
-        });
       });
-      this.listenForNewUninitializedComponentsAtRunTime(el => {
-        this.initializeComponent(el);
-      });
+      this.listenForNewUninitializedComponentsAtRunTime();
+      this.initTurbolinksListeners();
     },
     discoverComponents: function discoverComponents(callback) {
       const rootEls = document.querySelectorAll('[x-data]');
@@ -1653,14 +1645,13 @@
         callback(rootEl);
       });
     },
-    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime(callback) {
-      const targetNode = document.querySelector('body');
+    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime() {
       const observerOptions = {
         childList: true,
         attributes: true,
         subtree: true
       };
-      const observer = new MutationObserver(mutations => {
+      this.observer = new MutationObserver(mutations => {
         for (let i = 0; i < mutations.length; i++) {
           if (mutations[i].addedNodes.length > 0) {
             mutations[i].addedNodes.forEach(node => {
@@ -1676,7 +1667,7 @@
           }
         }
       });
-      observer.observe(targetNode, observerOptions);
+      this.observer.observe(document.body, observerOptions);
     },
     initializeComponent: function initializeComponent(el) {
       if (!el.__x) {
@@ -1687,7 +1678,60 @@
       if (!newEl.__x) {
         newEl.__x = new Component(newEl, component.getUnobservedData());
       }
+    },
+
+    initTurbolinksListeners() {
+      // It's easier and more performant to just support Turbolinks than listen
+      // to MutationObserver mutations at the document level.
+      document.addEventListener('turbolinks:load', () => {
+        Alpine.discoverUninitializedComponents(el => {
+          this.initializeComponent(el);
+        });
+        this.observer.observe(document.body, {
+          childList: true,
+          attributes: true,
+          subtree: true
+        });
+      }); // Disconnect the the mutation observer to avoid data races, and then
+      // clean up the elements created by Alpine directives before Turbolinks
+      // stores it to cache, unless it's marked as permanent.
+      // The mutiation observer will be reconnected by the turbolinks:load event.
+
+      document.addEventListener('turbolinks:before-cache', () => {
+        this.observer.disconnect();
+        walk(document.body, el => {
+          if (el.hasAttribute('data-turbolinks-permanent')) {
+            return false;
+          }
+
+          if (el.hasAttribute('x-for')) {
+            let nextEl = el.nextElementSibling;
+
+            while (nextEl) {
+              const currEl = nextEl;
+              nextEl = nextEl.nextElementSibling;
+
+              if (typeof currEl.__x_for_key !== 'undefined') {
+                currEl.remove();
+              }
+            }
+
+            return true;
+          }
+
+          if (el.hasAttribute('x-if')) {
+            const ifEl = el.nextElementSibling;
+
+            if (ifEl && typeof ifEl.__x_inserted_me !== 'undefined') {
+              ifEl.remove();
+            }
+          }
+
+          return true;
+        });
+      });
     }
+
   };
 
   if (!isTesting()) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1622,6 +1622,7 @@
 
   const Alpine = {
     version: "2.3.3",
+    pauseObserver: false,
     start: async function start() {
       if (!isTesting()) {
         await domReady();
@@ -1651,7 +1652,9 @@
         attributes: true,
         subtree: true
       };
-      this.observer = new MutationObserver(mutations => {
+      const observer = new MutationObserver(mutations => {
+        if (this.pauseObserver) return;
+
         for (let i = 0; i < mutations.length; i++) {
           if (mutations[i].addedNodes.length > 0) {
             mutations[i].addedNodes.forEach(node => {
@@ -1667,7 +1670,7 @@
           }
         }
       });
-      this.observer.observe(document.body, observerOptions);
+      observer.observe(document.body, observerOptions);
     },
     initializeComponent: function initializeComponent(el) {
       if (!el.__x) {
@@ -1687,43 +1690,46 @@
         Alpine.discoverUninitializedComponents(el => {
           this.initializeComponent(el);
         });
-        this.observer.observe(document.body, {
-          childList: true,
-          attributes: true,
-          subtree: true
+        this.pauseObserver = true;
+      }); // Before swapping the body, clean up any element with x-turbolinks-cached
+      // which not have any Alpine attributes.
+      // Note, at this point all html fragments marked as data-turbolinks-permanent
+      // are already copied over from the previous page so they retain their listener
+      // and custom properties and we don't want to reset them.
+
+      document.addEventListener('turbolinks:before-render', event => {
+        event.data.newBody.querySelectorAll('[x-generated]').forEach(el => {
+          el.removeAttribute('x-generated');
+
+          if (typeof el.__x_for_key === 'undefined' && typeof el.__x_inserted_me === 'undefined') {
+            el.remove();
+          }
         });
-      }); // Disconnect the the mutation observer to avoid data races, and then
-      // clean up the elements created by Alpine directives before Turbolinks
-      // stores it to cache, unless it's marked as permanent.
-      // The mutiation observer will be reconnected by the turbolinks:load event.
+      }); // Paus the the mutation observer to avoid data races, it will be resumed by the turbolinks:load event.
+      // We mark as `x-generated`` all the elements that are crated by an Alpine templating directives.
+      // The reason is that turbolinks caches pages using cloneNode which removes listeners and custom properties
+      // So we need to propagate this infomation using a HTML attribute. I know, not ideal but I could not think
+      // of a better option.
+      // Note, we can't remove any Alpine generated element as yet because if they live inside an element
+      // marked as data-turbolinks-permanent they need to be copied into the next page.
+      // The coping process happens somewhere between before-cache and before-render.
 
       document.addEventListener('turbolinks:before-cache', () => {
-        this.observer.disconnect();
+        this.pauseObserver = true;
         walk(document.body, el => {
-          if (el.hasAttribute('data-turbolinks-permanent')) {
-            return false;
-          }
-
           if (el.hasAttribute('x-for')) {
             let nextEl = el.nextElementSibling;
 
-            while (nextEl) {
+            while (nextEl && nextEl.__x_for_key !== 'undefined') {
               const currEl = nextEl;
               nextEl = nextEl.nextElementSibling;
-
-              if (typeof currEl.__x_for_key !== 'undefined') {
-                currEl.remove();
-              }
+              currEl.setAttribute('x-generated', true);
             }
-
-            return true;
-          }
-
-          if (el.hasAttribute('x-if')) {
+          } else if (el.hasAttribute('x-if')) {
             const ifEl = el.nextElementSibling;
 
             if (ifEl && typeof ifEl.__x_inserted_me !== 'undefined') {
-              ifEl.remove();
+              ifEl.setAttribute('x-generated', true);
             }
           }
 

--- a/turbolinks-manual-test/index.html
+++ b/turbolinks-manual-test/index.html
@@ -5,12 +5,34 @@
     </head>
     <body>
         <h1>First Page</h1>
-        <a href="turbolinks-manual-test/navigated-away">Second Page</a>
+        <a href="/turbolinks-manual-test/navigated-away">Second Page</a>
 
+        <h2>This component should be preserved and be working in the Second page</h2>
         <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
             <input x-model="foo"></input>
 
             <button x-on:click="foo = 'baz'"></button>
+        </div>
+
+        <h2>This item should not add a duplicate span item when navigating away and back to this page</h2>
+        <div x-data="{ foo: 'bar', open: true }">
+            <template x-if="open">
+                <span x-text="foo"></span>
+            </template>
+        </div>
+
+        <h2>This item should not add duplicate span items when navigating away and back to this page</h2>
+        <div x-data="{ foo: ['bar', 'baz'] }">
+            <template x-for="item in foo">
+                <span x-text="item"></span>
+            </template>
+        </div>
+
+        <h2>This component should be preserved and not be logging any errors when navigating to the Second page</h2>
+        <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
+            <template x-for="item in foo">
+                <span x-text="item"></span>
+            </template>
         </div>
     </body>
 </html>

--- a/turbolinks-manual-test/index.html
+++ b/turbolinks-manual-test/index.html
@@ -105,8 +105,6 @@
             </template>
         </div>
     </div>
-
-
 </body>
 
 </html>

--- a/turbolinks-manual-test/index.html
+++ b/turbolinks-manual-test/index.html
@@ -1,38 +1,112 @@
 <html>
-    <head>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-        <script src="/dist/alpine.js" defer></script>
-    </head>
-    <body>
-        <h1>First Page</h1>
-        <a href="/turbolinks-manual-test/navigated-away">Second Page</a>
 
-        <h2>This component should be preserved and be working in the Second page</h2>
-        <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
-            <input x-model="foo"></input>
+<head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js"
+        integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
+    <script src="/dist/alpine.js" defer></script>
+</head>
 
-            <button x-on:click="foo = 'baz'"></button>
+<body>
+    <h1>First Page</h1>
+    <a href="/turbolinks-manual-test/navigated-away">Second Page</a>
+
+
+    <script>
+        function componentAdder() {
+            return {
+                counter: 0,
+                add: function (base) {
+                    var div = document.createElement("div");
+                    this.counter++;
+                    var name = `${base} ${this.counter}`
+
+                    div.innerHTML = `<div x-data="{ open: true }">
+                                <template x-if="open">
+                                    <span>${name}</span>
+                                </template>
+                                </div>`;
+                    this.$el.appendChild(div);
+
+                },
+            }
+        }
+
+    </script>
+    <h2>8.4 The components added when pushing the button should be preserved when navigating away and back</h2>
+    <div x-data="componentAdder()" id="t8_4" data-turbolinks-permanent>
+        <button @click="add('First')"
+            style="width: 50px; height:30px; background-color: lightgrey; margin-bottom: 20px;">Add
+            1</button>
+
+        <div x-data="componentAdder()" id="t8_4_2">
+            <button @click="add('Second')"
+                style="width: 50px; height:30px; background-color: lightblue; margin-bottom: 20px;">Add 2</button>
         </div>
+    </div>
 
-        <h2>This item should not add a duplicate span item when navigating away and back to this page</h2>
-        <div x-data="{ foo: 'bar', open: true }">
+    <h2>1.1 This component should be preserved and be working in the Second page</h2>
+    <div x-data="{ foo: 'bar' }" id="t1_1" data-turbolinks-permanent>
+        <input x-model="foo"></input>
+
+        <button x-on:click="foo = 'baz'"></button>
+    </div>
+
+    <h2>2.0 This item should not add a duplicate span item when navigating away and back to this page</h2>
+    <div x-data="{ foo: 'bar', open: true }">
+        <template x-if="open">
+            <span x-text="foo"></span>
+        </template>
+    </div>
+
+    <h2>3.0 This item should not add duplicate span items when navigating away and back to this page</h2>
+    <div x-data="{ foo: ['bar', 'baz'] }">
+        <template x-for="item3 in foo">
+            <span x-text="item3"></span>
+        </template>
+    </div>
+
+    <h2>4.0 This component should be preserved and not be logging any errors when navigating to the Second page</h2>
+    <div x-data="{ foo: ['bar', 'baz'] }" id="t4_0" data-turbolinks-permanent>
+        <template x-for="item4 in foo">
+            <span x-text="item4"></span>
+        </template>
+    </div>
+
+    <h2>4.2 This component should be preserved and not be logging any errors when navigating to the Second page</h2>
+    <div x-data="{ foo: ['bar', 'baz'] }" id="t4_2" data-turbolinks-permanent>
+        <template x-for="item42 in foo">
+            <span x-text="item42"></span>
+        </template>
+    </div>
+
+    <h2>5.0 This item should not add duplicate span items nor errors when navigating away and back to this page</h2>
+    <div x-data="{ foo: 'bar' }" id="t5_0" data-turbolinks-permanent>
+        <div x-data="{ bob: ['bar', 'baz'] }">
+            <template x-for="item5 in bob">
+                <span x-text="item5"></span>
+            </template>
+        </div>
+    </div>
+
+    <h2>6.3 This item should be preserved when navigating away and back</h2>
+    <div x-data="{ foo: 'bar' }" id="t6_3" data-turbolinks-permanent>
+        <div x-data="{ open: true }">
             <template x-if="open">
-                <span x-text="foo"></span>
+                <span>Item</span>
             </template>
         </div>
+    </div>
 
-        <h2>This item should not add duplicate span items when navigating away and back to this page</h2>
-        <div x-data="{ foo: ['bar', 'baz'] }">
-            <template x-for="item in foo">
-                <span x-text="item"></span>
+    <h2>7.0 This item should be preserved when navigating away and back</h2>
+    <div x-data="{ foo: 'bar' }" id="t7_0" data-turbolinks-permanent>
+        <div x-data="{ open: true }">
+            <template x-if="open">
+                <span>Item</span>
             </template>
         </div>
+    </div>
 
-        <h2>This component should be preserved and not be logging any errors when navigating to the Second page</h2>
-        <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
-            <template x-for="item in foo">
-                <span x-text="item"></span>
-            </template>
-        </div>
-    </body>
+
+</body>
+
 </html>

--- a/turbolinks-manual-test/navigated-away/index.html
+++ b/turbolinks-manual-test/navigated-away/index.html
@@ -5,11 +5,20 @@
     </head>
     <body>
         <h1>Second Page</h1>
+        <a href="javascript:history.back()">Back</a>
 
+        <h2>This component should be preserved and working correctly</h2>
         <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
             <input x-model="foo"></input>
 
             <button x-on:click="foo = 'baz'"></button>
+        </div>
+
+        <h2>This component should be preserved and working correctly (including no errors in console)</h2>
+        <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
+            <template x-for="item in foo">
+                <span x-text="item"></span>
+            </template>
         </div>
     </body>
 </html>

--- a/turbolinks-manual-test/navigated-away/index.html
+++ b/turbolinks-manual-test/navigated-away/index.html
@@ -1,24 +1,88 @@
 <html>
-    <head>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js" integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
-        <script src="/dist/alpine.js" defer></script>
-    </head>
-    <body>
-        <h1>Second Page</h1>
-        <a href="javascript:history.back()">Back</a>
 
-        <h2>This component should be preserved and working correctly</h2>
-        <div x-data="{ foo: 'bar' }" id="foo" data-turbolinks-permanent>
-            <input x-model="foo"></input>
+<head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/turbolinks/5.2.0/turbolinks.js"
+        integrity="sha256-iM4Yzi/zLj/IshPWMC1IluRxTtRjMqjPGd97TZ9yYpU=" crossorigin="anonymous"></script>
+    <script src="/dist/alpine.js" defer></script>
+</head>
 
-            <button x-on:click="foo = 'baz'"></button>
+<body>
+    <h1>Second Page</h1>
+    <a href="javascript:history.back()">Back</a>
+    <a href="/turbolinks-manual-test/">First Page</a>
+
+    <script>
+        function componentAdder() {
+            return {
+                counter: 0,
+                add: function (base) {
+                    var div = document.createElement("div");
+                    this.counter++;
+                    var name = `${base} ${this.counter}`
+
+                    div.innerHTML = `<div x-data="{ open: true }">
+                                <template x-if="open">
+                                    <span>${name}</span>
+                                </template>
+                                </div>`;
+                    this.$el.appendChild(div);
+
+                },
+            }
+        }
+    </script>
+    <h2>8.4 The components added when pushing the button should be preserved when navigating away and back</h2>
+    <div x-data="componentAdder()" id="t8_4" data-turbolinks-permanent>
+        <button @click="add('First')"
+            style="width: 50px; height:30px; background-color: lightgrey; margin-bottom: 20px;">Add
+            1</button>
+
+        <div x-data="componentAdder()" id="t8_4_2">
+            <button @click="add('Second')"
+                style="width: 50px; height:30px; background-color: lightblue; margin-bottom: 20px;">Add 2</button>
         </div>
+    </div>
 
-        <h2>This component should be preserved and working correctly (including no errors in console)</h2>
-        <div x-data="{ foo: ['bar', 'baz'] }" id="bar" data-turbolinks-permanent>
-            <template x-for="item in foo">
-                <span x-text="item"></span>
+
+    <h2>1.1 This component should be preserved and be working in the Second page</h2>
+    <div x-data="{ foo: 'bar' }" id="t1_1" data-turbolinks-permanent>
+        <input x-model="foo"></input>
+
+        <button x-on:click="foo = 'baz'"></button>
+    </div>
+
+    <h2>4.2 This component should be preserved and not be logging any errors when navigating to the Second page</h2>
+    <div x-data="{ foo: ['bar', 'baz'] }" id="t4_2" data-turbolinks-permanent>
+        <template x-for="item42 in foo">
+            <span x-text="item42"></span>
+        </template>
+    </div>
+
+    <h2>6.3 This item should be preserved when navigating away and back</h2>
+    <div x-data="{ foo: 'bar' }" id="t6_3" data-turbolinks-permanent>
+        <div x-data="{ open: true }">
+            <template x-if="open">
+                <span>Item</span>
             </template>
         </div>
-    </body>
+    </div>
+
+    <h2>0.1 This component should be preserved and working correctly (including no errors in console)</h2>
+    <div x-data="{ foo: ['bar', 'baz'] }" id="t0_1" data-turbolinks-permanent>
+        <template x-for="item in foo">
+            <span x-text="item"></span>
+        </template>
+    </div>
+
+    <h2>0.2 This component should be working correctly (including no errors in console)</h2>
+    <div x-data="{ foo: ['bar', 'baz'] }">
+        <template x-for="item in foo">
+            <span x-text="item"></span>
+        </template>
+    </div>
+
+
+
+</body>
+
 </html>


### PR DESCRIPTION
This commit disconnects the mutation observer on `turbolinks:before-cache` and then clean up elements created by Alpine directives, unless marked as `data-turbolinks-permanent`.

The mutiation observer is reconnected at `turbolinks:load`.

This fixes two error situations when Alpine is combined with Turbolinks:

* Duplicate elements on navigation with the back or forward button.
* Errors/data races on Turbolinks navigation with Alpine components marked with `data-turbolinks-permanent`.

Fixes #319
Fixes #372

This PR is continuing the foundation from @SimoTod 's work.

No unit tests (that looks hard), but the manual test cases for this passes for me.

I can add that I have tested this OK on a "real app" that uses Turbolinks in combo with AlpineJS with this patch.