### PR TITLE
Update x-on, $event and $dispatch docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ These behave exactly like VueJs's transition directives, except they have differ
 
 > Note: The $event property is only available in the DOM.
 
-If you need to access $event inside of a Javascript function you can pass it in directly:
+If you need to access $event inside of a JavaScript function you can pass it in directly:
 
 `<button x-on:click="myFunction($event)"></button>`
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ Boolean attributes are supported as per the [HTML specification](https://html.sp
 
 If any data is modified in the expression, other element attributes "bound" to this data, will be updated.
 
+> Note: You can also specify a Javascript function name
+
+**Example:** `<button x-on:click="myFunction"></button>`
+
+This is equivalent to: `<button x-on:click="myFunction($event)"></button>`
+
 **`keydown` modifiers**
 
 **Example:** `<input type="text" x-on:keydown.escape="open = false">`
@@ -536,6 +542,12 @@ These behave exactly like VueJs's transition directives, except they have differ
 
 `$event` is a magic property that can be used within an event listener to retrieve the native browser "Event" object.
 
+> Note: The $event property is only available in the DOM.
+
+If you need to access $event inside of a Javascript function you can pass it in directly:
+
+`<button x-on:click="myFunction($event)"></button>`
+
 ---
 
 ### `$dispatch`
@@ -561,6 +573,12 @@ You can also use `$dispatch()` to trigger data updates for `x-model` bindings. F
     </span>
 </div>
 ```
+
+> Note: The $dispatch property is only available in the DOM.
+
+If you need to access $dispatch inside of a Javascript function you can pass it in directly:
+
+`<button x-on:click="myFunction($dispatch)"></button>`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ You can also use `$dispatch()` to trigger data updates for `x-model` bindings. F
 
 > Note: The $dispatch property is only available in the DOM.
 
-If you need to access $dispatch inside of a Javascript function you can pass it in directly:
+If you need to access $dispatch inside of a JavaScript function you can pass it in directly:
 
 `<button x-on:click="myFunction($dispatch)"></button>`
 


### PR DESCRIPTION
Added an example of how to access $event and $dispatch inside of a
Javascript function.  This also includes adding an example of passing in
a Javascript name to x-on.