### PR TITLE
fix: polyfill SVGElement.prototype.contains for IE

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -6,3 +6,5 @@ import "element-remove"
 import "classlist-polyfill"
 import "@webcomponents/template"
 import "custom-event-polyfill"
+
+SVGElement.prototype.contains = SVGElement.prototype.contains || HTMLElement.prototype.contains


### PR DESCRIPTION
fix #468 

IE actually has two deficiencies regarding `.contains()`: it doesn't support it for SVG elements and it also doesn't support it on `document`.

This PR only polyfills `SVGElement`, not the more generic `Node` (which would require a custom implementation instead of this one-liner), so `document.contains()` still doesn't work – but Alpine doesn't need that and users who rely on it can polyfill `Node.prototype.contains` themselves.  

So polyfilling `SVGElement` should suffice I think – opinions?