### PR TITLE
Feature - CSS animations

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5770,6 +5770,11 @@
       // Note: Safari's transitionDuration property will list out comma separated transition durations
       // for every single transition property. Let's grab the first one and call it a day.
       var duration = Number(getComputedStyle(el).transitionDuration.replace(/,.*/, '').replace('s', '')) * 1000;
+
+      if (duration === 0) {
+        duration = Number(getComputedStyle(el).animationDuration.replace('s', '')) * 1000;
+      }
+
       stages.show();
       requestAnimationFrame(function () {
         var _this14 = this;

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -369,6 +369,11 @@
       // Note: Safari's transitionDuration property will list out comma separated transition durations
       // for every single transition property. Let's grab the first one and call it a day.
       let duration = Number(getComputedStyle(el).transitionDuration.replace(/,.*/, '').replace('s', '')) * 1000;
+
+      if (duration === 0) {
+        duration = Number(getComputedStyle(el).animationDuration.replace('s', '')) * 1000;
+      }
+
       stages.show();
       requestAnimationFrame(() => {
         stages.end();

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,6 +12,27 @@
             .scale-100 { transform: scale(1); }
             .ease-in { transition-timing-function: cubic-bezier(0.4, 0, 1, 1); }
             .ease-out { transition-timing-function: cubic-bezier(0, 0, 0.2, 1); }
+
+            /** Thanks Animate.css */
+            .animation {animation-duration: 1000ms; --animate-duration: 1000ms; }
+            @keyframes jackInTheBox {
+                from { opacity: 0; transform: scale(0.1) rotate(30deg); transform-origin: center bottom; }
+                50% { transform: rotate(-10deg); }
+                70% { transform: rotate(3deg); }
+                to { opacity: 1; transform: scale(1); }
+            }
+            @keyframes hinge {
+                0% {animation-timing-function: ease-in-out;}
+                20%, 60% { transform: rotate3d(0, 0, 1, 80deg); animation-timing-function: ease-in-out; }
+                40%, 80% { transform: rotate3d(0, 0, 1, 60deg); animation-timing-function: ease-in-out; opacity: 1; }
+                to { transform: translate3d(0, 700px, 0); opacity: 0; }
+            }
+            .jackInTheBox {animation-name: jackInTheBox;}
+            .hinge {
+                animation-duration: calc(var(--animate-duration) * 2);
+                animation-name: hinge;
+                transform-origin: top left;
+            }
         </style>
 
         <script src="/dist/alpine.js" defer></script>
@@ -288,6 +309,31 @@
                                     x-transition:leave-start="opacity-100 scale-100"
                                     x-transition:leave="ease-in transition-faster"
                                     x-transition:leave-end="opacity-0 scale-90">
+                                    <div>
+                                        hey
+                                    </div>
+                                    <div>
+                                        <button x-on:click="open= false" type="button">
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td>CSS animations</td>
+                    <td>
+                        <div x-data="{ open: false }">
+                            <button x-on:click="open= ! open">
+                                Open Modal
+                            </button>
+
+                            <div x-show="open"
+                                x-transition:enter="animation jackInTheBox"
+                                x-transition:leave="animation hinge">
                                     <div>
                                         hey
                                     </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -360,6 +360,10 @@ export function transition(el, stages) {
         // for every single transition property. Let's grab the first one and call it a day.
         let duration = Number(getComputedStyle(el).transitionDuration.replace(/,.*/, '').replace('s', '')) * 1000
 
+        if (duration === 0) {
+            duration = Number(getComputedStyle(el).animationDuration.replace('s', '')) * 1000
+        }
+
         stages.show()
 
         requestAnimationFrame(() => {

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -536,3 +536,85 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
 }
+
+test('x-transition supports css animation', async () => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+        setTimeout(callback, 0)
+    });
+
+    // (hardcoding 10ms animation time for later assertions)
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
+        return {
+            transitionDuration: '0s',
+            animationDuration: '.1s'
+        }
+    });
+
+    document.body.innerHTML = `
+        <div x-data="{ show: false }">
+            <button x-on:click="show = ! show"></button>
+
+            <span
+                x-show="show"
+                x-transition:enter="animation-enter"
+                x-transition:leave="animation-leave"
+            ></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+
+    document.querySelector('button').click()
+
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 99)
+    )
+
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 10)
+    )
+
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(false)
+
+    document.querySelector('button').click()
+
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 99)
+    )
+
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 10)
+    )
+
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
+})

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -566,55 +566,57 @@ test('x-transition supports css animation', async () => {
 
     await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
 
+    // Testing animation enter
     document.querySelector('button').click()
 
+    // Wait for the first requestAnimationFrame
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
         }, 0)
     )
-
     expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
 
+    // The class should still be there since the animationDuration property is 100ms
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
         }, 99)
     )
-
     expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
 
+    // The class shouldn't be there anymore
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
         }, 10)
     )
-
     expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(false)
 
+    // Testing animation enter
     document.querySelector('button').click()
 
+    // Wait for the first requestAnimationFrame
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
         }, 0)
     )
-
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
 
+    // The class should still be there since the animationDuration property is 100ms
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
         }, 99)
     )
-
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
 
+    // The class shouldn't be there anymore
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
         }, 10)
     )
-
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
 })


### PR DESCRIPTION
Right now, Alpine only considers the transition-duration property.
Animation (and animation libraries such ad animate.css) usually define an animation-duration property instead. This means that Alpine runs all the stage steps in less then a millisecond and animations don't have time to complete.

This PR makes easier for developers to use css animations and css animation libraries without workarounds. Note, at the moment is already possible to set a transition-duration property matching the animation length but it's counterintuitive so this PR is more a nice to have.

Vue js for example support it without workarounds: https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes

Original discussion: https://github.com/alpinejs/alpine/discussions/489

Mini demo: https://codepen.io/SimoTod/pen/jObeYpQ
