### PR TITLE
Minor improvement to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Think of it like [Tailwind](https://tailwindcss.com/) for JavaScript.
 
 That's it. It will initialize itself.
 
-For production environments, it's recommend linking to a specific version number to avoid unexpected breakage from newer versions. 
+For production environments, it's recommended to pin a specific version number in the link to avoid unexpected breakage from newer versions. 
 For example, to use version `2.3.5`:
 ```html
 <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.3.5/dist/alpine.min.js" defer></script>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Think of it like [Tailwind](https://tailwindcss.com/) for JavaScript.
 
 That's it. It will initialize itself.
 
+For production environments, it's recommend linking to a specific version number to avoid unexpected breakage from newer versions. 
+For example, to use version `2.3.5`:
+```html
+<script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.3.5/dist/alpine.min.js" defer></script>
+```
+
 **From NPM:** Install the package from NPM.
 ```js
 npm i alpinejs


### PR DESCRIPTION
People seems to use the 2.x.x CDN link in production so when we release a new version, if there are bug fixings changing the behaviour or accidental BCs, they'll get bugs straight into production without updating anything.

It should be obvious, but we should suggest they use a specific version number in production.