### PR TITLE
Improve $nextTick for transitions 

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6741,9 +6741,12 @@
           _newArrowCheck(this, _this8);
 
           el.__x = new Component(el);
-        }.bind(this));
+        }.bind(this)); // In presence of x-show directives walk through the $nextTick from inside the directive handler
+        // otherwise proceed with $nextTick
 
-        if (!this.executeAndClearRemainingShowDirectiveStack()) {
+        if (this.showDirectiveStack.length > 0) {
+          this.executeAndClearRemainingShowDirectiveStack();
+        } else {
           this.executeAndClearNextTickStack(rootEl);
         }
       }
@@ -6763,10 +6766,9 @@
       value: function executeAndClearRemainingShowDirectiveStack() {
         var _this9 = this;
 
-        if (this.showDirectiveStack.length === 0) return false; // The goal here is to start all the x-show transitions
+        // The goal here is to start all the x-show transitions
         // and build a nested promise chain so that elements
         // only hide when the children are finished hiding.
-
         this.showDirectiveStack.reverse().map(function (thing) {
           var _this10 = this;
 
@@ -6805,7 +6807,6 @@
 
         this.showDirectiveStack = [];
         this.showDirectiveLastElement = undefined;
-        return true;
       }
     }, {
       key: "updateElement",

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6107,25 +6107,31 @@
     }
 
     var tick = function tick() {
+      var _this2 = this;
+
       _newArrowCheck(this, _this);
 
-      component.executeAndClearNextTickStack(component.$el);
+      setTimeout(function () {
+        _newArrowCheck(this, _this2);
+
+        return component.executeAndClearNextTickStack(component.$el);
+      }.bind(this));
     }.bind(this);
 
     var handle = function handle(resolve) {
-      var _this2 = this;
+      var _this3 = this;
 
       _newArrowCheck(this, _this);
 
       if (!value) {
         if (el.style.display !== 'none') {
           transitionOut(el, function () {
-            var _this3 = this;
+            var _this4 = this;
 
-            _newArrowCheck(this, _this2);
+            _newArrowCheck(this, _this3);
 
             resolve(function () {
-              _newArrowCheck(this, _this3);
+              _newArrowCheck(this, _this4);
 
               hide();
               tick();
@@ -6133,13 +6139,13 @@
           }.bind(this));
         } else {
           resolve(function () {
-            _newArrowCheck(this, _this2);
+            _newArrowCheck(this, _this3);
           }.bind(this));
         }
       } else {
         if (el.style.display !== '') {
           transitionIn(el, function () {
-            _newArrowCheck(this, _this2);
+            _newArrowCheck(this, _this3);
 
             show();
             tick();
@@ -6148,7 +6154,7 @@
 
 
         resolve(function () {
-          _newArrowCheck(this, _this2);
+          _newArrowCheck(this, _this3);
         }.bind(this));
       }
     }.bind(this); // The working of x-show is a bit complex because we need to

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6106,6 +6106,12 @@
       return;
     }
 
+    var tick = function tick() {
+      _newArrowCheck(this, _this);
+
+      component.executeAndClearNextTickStack(component.$el);
+    }.bind(this);
+
     var handle = function handle(resolve) {
       var _this2 = this;
 
@@ -6122,6 +6128,7 @@
               _newArrowCheck(this, _this3);
 
               hide();
+              tick();
             }.bind(this));
           }.bind(this));
         } else {
@@ -6135,6 +6142,7 @@
             _newArrowCheck(this, _this2);
 
             show();
+            tick();
           }.bind(this));
         } // Resolve immediately, only hold up parent `x-show`s for hidin.
 
@@ -6734,8 +6742,10 @@
 
           el.__x = new Component(el);
         }.bind(this));
-        this.executeAndClearRemainingShowDirectiveStack();
-        this.executeAndClearNextTickStack(rootEl);
+
+        if (!this.executeAndClearRemainingShowDirectiveStack()) {
+          this.executeAndClearNextTickStack(rootEl);
+        }
       }
     }, {
       key: "executeAndClearNextTickStack",
@@ -6753,9 +6763,10 @@
       value: function executeAndClearRemainingShowDirectiveStack() {
         var _this9 = this;
 
-        // The goal here is to start all the x-show transitions
+        if (this.showDirectiveStack.length === 0) return false; // The goal here is to start all the x-show transitions
         // and build a nested promise chain so that elements
         // only hide when the children are finished hiding.
+
         this.showDirectiveStack.reverse().map(function (thing) {
           var _this10 = this;
 
@@ -6794,6 +6805,7 @@
 
         this.showDirectiveStack = [];
         this.showDirectiveLastElement = undefined;
+        return true;
       }
     }, {
       key: "updateElement",

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1416,9 +1416,12 @@
         this.updateElement(el, extraVars);
       }, el => {
         el.__x = new Component(el);
-      });
+      }); // In presence of x-show directives walk through the $nextTick from inside the directive handler
+      // otherwise proceed with $nextTick
 
-      if (!this.executeAndClearRemainingShowDirectiveStack()) {
+      if (this.showDirectiveStack.length > 0) {
+        this.executeAndClearRemainingShowDirectiveStack();
+      } else {
         this.executeAndClearNextTickStack(rootEl);
       }
     }
@@ -1434,10 +1437,9 @@
     }
 
     executeAndClearRemainingShowDirectiveStack() {
-      if (this.showDirectiveStack.length === 0) return false; // The goal here is to start all the x-show transitions
+      // The goal here is to start all the x-show transitions
       // and build a nested promise chain so that elements
       // only hide when the children are finished hiding.
-
       this.showDirectiveStack.reverse().map(thing => {
         return new Promise(resolve => {
           thing(finish => {
@@ -1452,7 +1454,6 @@
 
       this.showDirectiveStack = [];
       this.showDirectiveLastElement = undefined;
-      return true;
     }
 
     updateElement(el, extraVars) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -631,7 +631,7 @@
     }
 
     const tick = () => {
-      component.executeAndClearNextTickStack(component.$el);
+      setTimeout(() => component.executeAndClearNextTickStack(component.$el));
     };
 
     const handle = resolve => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -303,6 +303,43 @@
                 </tr>
 
                 <tr>
+                    <td>Transitions then nextTick</td>
+                    <td>
+                        <div x-data="{ open: false }">
+                            <button x-on:click="open= ! open; if (open) $nextTick(()=>{$refs.input.focus()});">
+                                Open Modal then Focus Input
+                            </button>
+
+                            <div x-show="open"
+                                x-transition:enter="transition-medium"
+                                x-transition:leave="transition-medium">
+                                <div x-show="open"
+                                    x-transition:enter="transition-medium"
+                                    x-transition:enter-start="opacity-0"
+                                    x-transition:leave-end="opacity-0"
+                                    x-transition:leave="transition-medium"></div>
+                                <div x-show="open"
+                                    x-transition:enter-start="opacity-0 scale-90"
+                                    x-transition:enter="ease-out transition-medium"
+                                    x-transition:enter-end="opacity-100 scale-100"
+                                    x-transition:leave-start="opacity-100 scale-100"
+                                    x-transition:leave="ease-in transition-faster"
+                                    x-transition:leave-end="opacity-0 scale-90">
+                                    <div>
+                                        <input x-ref="input">
+                                    </div>
+                                    <div>
+                                        <button x-on:click="open= false" type="button">
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr>
                     <td>Transitions (with x-if)</td>
                     <td>
                         <div x-data="{ open: false }">

--- a/src/component.js
+++ b/src/component.js
@@ -180,8 +180,12 @@ export default class Component {
             el.__x = new Component(el)
         })
 
-        if (! this.executeAndClearRemainingShowDirectiveStack()) {
-            this.executeAndClearNextTickStack(rootEl)
+        // In presence of x-show directives walk through the $nextTick from inside the directive handler
+        // otherwise proceed with $nextTick
+        if (this.showDirectiveStack.length > 0) {
+            this.executeAndClearRemainingShowDirectiveStack();
+        } else {
+            this.executeAndClearNextTickStack(rootEl);
         }
     }
 
@@ -196,7 +200,6 @@ export default class Component {
     }
 
     executeAndClearRemainingShowDirectiveStack() {
-        if (this.showDirectiveStack.length === 0) return false
         // The goal here is to start all the x-show transitions
         // and build a nested promise chain so that elements
         // only hide when the children are finished hiding.
@@ -215,7 +218,6 @@ export default class Component {
         // We've processed the handler stack. let's clear it.
         this.showDirectiveStack = []
         this.showDirectiveLastElement = undefined
-        return true
     }
 
     updateElement(el, extraVars) {

--- a/src/component.js
+++ b/src/component.js
@@ -180,9 +180,9 @@ export default class Component {
             el.__x = new Component(el)
         })
 
-        this.executeAndClearRemainingShowDirectiveStack()
-
-        this.executeAndClearNextTickStack(rootEl)
+        if (! this.executeAndClearRemainingShowDirectiveStack()) {
+            this.executeAndClearNextTickStack(rootEl)
+        }
     }
 
     executeAndClearNextTickStack(el) {
@@ -196,6 +196,7 @@ export default class Component {
     }
 
     executeAndClearRemainingShowDirectiveStack() {
+        if (this.showDirectiveStack.length === 0) return false
         // The goal here is to start all the x-show transitions
         // and build a nested promise chain so that elements
         // only hide when the children are finished hiding.
@@ -214,6 +215,7 @@ export default class Component {
         // We've processed the handler stack. let's clear it.
         this.showDirectiveStack = []
         this.showDirectiveLastElement = undefined
+        return true
     }
 
     updateElement(el, extraVars) {

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -23,7 +23,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
     }
 
     const tick = () => {
-        component.executeAndClearNextTickStack(component.$el)
+        setTimeout(() => component.executeAndClearNextTickStack(component.$el))
     }
 
     const handle = (resolve) => {

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -22,12 +22,17 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         return
     }
 
+    const tick = () => {
+        component.executeAndClearNextTickStack(component.$el)
+    }
+
     const handle = (resolve) => {
         if (! value) {
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
                     resolve(() => {
                         hide()
+                        tick()
                     })
                 })
             } else {
@@ -37,6 +42,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
             if ( el.style.display !== '' ) {
                 transitionIn(el, () => {
                     show()
+                    tick()
                 })
             }
 

--- a/test/next-tick.spec.js
+++ b/test/next-tick.spec.js
@@ -44,3 +44,46 @@ test('nextTick wait for x-for to finish rendering', async () => {
 
     await wait(() => { expect(document.querySelector('p').innerText).toEqual(3) })
 })
+
+test('nextTick wait for x-show directives and transitions to start', async () => {
+    document.body.innerHTML = `
+        <div x-data="{show: false, foo: 'bar'}">
+            <div x-show="show"
+            x-transition:enter="enter"
+            x-transition:enter-start="enter-start"
+            x-transition:enter-end="enter-end">
+
+                <div x-show="show"
+                x-transition:enter="enter"
+                x-transition:enter-start="enter-start"
+                x-transition:enter-end="enter-end"></div>
+
+                <div id="modal" x-show="show"
+                x-transition:enter="enter"
+                x-transition:enter-start="enter-start"
+                x-transition:enter-end="enter-end"></div>
+
+            </div>
+
+            <button x-on:click="show = true; $nextTick(() => {foo = document.querySelector('#modal').getAttribute('style')});"></button>
+
+            <span x-text="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => {
+        expect(document.querySelector('#modal').getAttribute('style')).toEqual('display: none;')
+        expect(document.querySelector('span').innerText).toEqual('bar')
+    })
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('#modal').getAttribute('style')).toEqual(null)
+        // NextTick should run after we show the element so the style property should be null
+        // We stash the style property in a variable so we can test it without worrying about timing issues
+        expect(document.querySelector('span').innerText).toEqual(null)
+    })
+})


### PR DESCRIPTION
When using transitions, `$nextTick` is called before the DOM is updated as discussed in #491, A workaround could be to `setTimeout` inside `$nextTick` callback but it is not sufficient as the transition uses `requestAnimationFrame` and the browser will prefer to call new task set by `setTimeout` before any repainting. to get around this the user can add some milliseconds to force the browser to repaint before the callback. but it seems inconvenient for users.

This PR will delay the $nextTick after the transition show stage. Only in case of transitions.

Codepen before PR https://codepen.io/tomorrowsystem/pen/yLYQxNp
Codepen after PR https://codepen.io/tomorrowsystem/pen/LYpXJpo