### PR TITLE
Add support for `data-x` attributes

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5396,7 +5396,7 @@
 
     return new Function(['dataContext'].concat(_toConsumableArray(Object.keys(additionalHelperVariables))), "with(dataContext) { ".concat(expression, " }")).apply(void 0, [dataContext].concat(_toConsumableArray(Object.values(additionalHelperVariables))));
   }
-  var xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/;
+  var xAttrRE = /^(data-x|x)-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/;
   function isXAttr(attr) {
     var name = replaceAtAndColonWithStandardSyntax(attr.name);
     return xAttrRE.test(name);
@@ -5414,7 +5414,7 @@
       var valueMatch = name.match(/:([a-zA-Z\-:]+)/);
       var modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || [];
       return {
-        type: typeMatch ? typeMatch[1] : null,
+        type: typeMatch ? typeMatch[2] : null,
         value: valueMatch ? valueMatch[1] : null,
         modifiers: modifiers.map(function (i) {
           _newArrowCheck(this, _this3);

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6520,8 +6520,18 @@
 
       this.$el = el;
       var dataAttr = this.$el.getAttribute('x-data');
+
+      if (!dataAttr && this.$el.getAttribute('data-x-data')) {
+        dataAttr = this.$el.getAttribute('data-x-data');
+      }
+
       var dataExpression = dataAttr === '' ? '{}' : dataAttr;
       var initExpression = this.$el.getAttribute('x-init');
+
+      if (!initExpression && this.$el.getAttribute('data-x-init')) {
+        initExpression = this.$el.getAttribute('data-x-init');
+      }
+
       this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, {});
       /* IE11-ONLY:START */
       // For IE11, add our magic properties to the original data for access.
@@ -6666,7 +6676,7 @@
           _newArrowCheck(this, _this6);
 
           // We've hit a component.
-          if (el.hasAttribute('x-data')) {
+          if (el.hasAttribute('x-data') || el.dataset.xData) {
             // If it's not the current one.
             if (!el.isSameNode(this.$el)) {
               // Initialize it if it's not.
@@ -6900,6 +6910,7 @@
 
             case 'cloak':
               el.removeAttribute('x-cloak');
+              el.removeAttribute('data-x-cloak');
               break;
           }
         }.bind(this));
@@ -6962,14 +6973,15 @@
 
           for (var i = 0; i < mutations.length; i++) {
             // Filter out mutations triggered from child components.
-            var closestParentComponent = mutations[i].target.closest('[x-data]');
+            var closestParentComponent = mutations[i].target.closest('[x-data], [data-x-data]');
             if (!(closestParentComponent && closestParentComponent.isSameNode(this.$el))) continue;
 
-            if (mutations[i].type === 'attributes' && mutations[i].attributeName === 'x-data') {
+            if (mutations[i].type === 'attributes' && (mutations[i].attributeName === 'x-data' || mutations[i].attributeName === 'data-x-data')) {
               (function () {
                 var _this22 = this;
 
-                var rawData = saferEval(mutations[i].target.getAttribute('x-data'), {});
+                var dataExpression = mutations[i].attributeName === 'x-data' ? mutations[i].target.getAttribute('x-data') : mutations[i].target.dataset.xData;
+                var rawData = saferEval(dataExpression, {});
                 Object.keys(rawData).forEach(function (key) {
                   _newArrowCheck(this, _this22);
 
@@ -6986,7 +6998,7 @@
 
                 if (node.nodeType !== 1 || node.__x_inserted_me) return;
 
-                if (node.matches('[x-data]')) {
+                if (node.matches('[x-data], [data-x-data]')) {
                   node.__x = new Component(node);
                   return;
                 }
@@ -7017,6 +7029,10 @@
 
           if (el.hasAttribute('x-ref')) {
             refObj[el.getAttribute('x-ref')] = true;
+          }
+
+          if (el.hasAttribute('data-x-ref') && !refObj[el.getAttribute('data-x-ref')]) {
+            refObj[el.getAttribute('data-x-ref')] = true;
           }
         }.bind(this));
         /* IE11-ONLY:END */
@@ -7109,7 +7125,7 @@
     discoverComponents: function discoverComponents(callback) {
       var _this3 = this;
 
-      var rootEls = document.querySelectorAll('[x-data]');
+      var rootEls = document.querySelectorAll('[x-data], [data-x-data]');
       rootEls.forEach(function (rootEl) {
         _newArrowCheck(this, _this3);
 
@@ -7120,7 +7136,7 @@
       var _this4 = this;
 
       var el = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : null;
-      var rootEls = (el || document).querySelectorAll('[x-data]');
+      var rootEls = (el || document).querySelectorAll('[x-data], [data-x-data]');
       Array.from(rootEls).filter(function (el) {
         _newArrowCheck(this, _this4);
 
@@ -7156,7 +7172,7 @@
               if (node.nodeType !== 1) return; // Discard any changes happening within an existing component.
               // They will take care of themselves.
 
-              if (node.parentElement && node.parentElement.closest('[x-data]')) return;
+              if (node.parentElement && node.parentElement.closest('[x-data], [data-x-data]')) return;
               this.discoverUninitializedComponents(function (el) {
                 _newArrowCheck(this, _this7);
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -7029,9 +7029,7 @@
 
           if (el.hasAttribute('x-ref')) {
             refObj[el.getAttribute('x-ref')] = true;
-          }
-
-          if (el.hasAttribute('data-x-ref') && !refObj[el.getAttribute('data-x-ref')]) {
+          } else if (el.hasAttribute('data-x-ref')) {
             refObj[el.getAttribute('data-x-ref')] = true;
           }
         }.bind(this));

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -113,7 +113,7 @@
 
     return new Function(['dataContext', ...Object.keys(additionalHelperVariables)], `with(dataContext) { ${expression} }`)(dataContext, ...Object.values(additionalHelperVariables));
   }
-  const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/;
+  const xAttrRE = /^(data-x|x)-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/;
   function isXAttr(attr) {
     const name = replaceAtAndColonWithStandardSyntax(attr.name);
     return xAttrRE.test(name);
@@ -125,7 +125,7 @@
       const valueMatch = name.match(/:([a-zA-Z\-:]+)/);
       const modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || [];
       return {
-        type: typeMatch ? typeMatch[1] : null,
+        type: typeMatch ? typeMatch[2] : null,
         value: valueMatch ? valueMatch[1] : null,
         modifiers: modifiers.map(i => i.replace('.', '')),
         expression: attr.value

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1269,15 +1269,15 @@
       this.$el = el;
       let dataAttr = this.$el.getAttribute('x-data');
 
-      if (!dataAttr && this.$el.dataset.xData) {
-        dataAttr = this.$el.dataset.xData;
+      if (!dataAttr && this.$el.getAttribute('data-x-data')) {
+        dataAttr = this.$el.getAttribute('data-x-data');
       }
 
       const dataExpression = dataAttr === '' ? '{}' : dataAttr;
       let initExpression = this.$el.getAttribute('x-init');
 
-      if (!initExpression && this.$el.dataset.xInit) {
-        initExpression = this.$el.dataset.xInit;
+      if (!initExpression && this.$el.getAttribute('data-x-init')) {
+        initExpression = this.$el.getAttribute('data-x-init');
       }
 
       this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, {});
@@ -1536,6 +1536,7 @@
 
           case 'cloak':
             el.removeAttribute('x-cloak');
+            el.removeAttribute('data-x-cloak');
             break;
         }
       });

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1620,6 +1620,8 @@
           self.walkAndSkipNestedComponents(self.$el, el => {
             if (el.hasAttribute('x-ref') && el.getAttribute('x-ref') === property) {
               ref = el;
+            } else if (el.hasAttribute('data-x-ref') && el.getAttribute('data-x-ref') === property) {
+              ref = el;
             }
           });
           return ref;

--- a/src/component.js
+++ b/src/component.js
@@ -415,6 +415,8 @@ export default class Component {
                 self.walkAndSkipNestedComponents(self.$el, el => {
                     if (el.hasAttribute('x-ref') && el.getAttribute('x-ref') === property) {
                         ref = el
+                    } else if (el.hasAttribute('data-x-ref') && el.getAttribute('data-x-ref') === property) {
+                        ref = el
                     }
                 })
 

--- a/src/component.js
+++ b/src/component.js
@@ -15,16 +15,16 @@ export default class Component {
 
         let dataAttr = this.$el.getAttribute('x-data')
 
-        if (! dataAttr && this.$el.dataset.xData) {
-            dataAttr = this.$el.dataset.xData
+        if (! dataAttr && this.$el.getAttribute('data-x-data')) {
+            dataAttr = this.$el.getAttribute('data-x-data')
         }
 
         const dataExpression = dataAttr === '' ? '{}' : dataAttr
 
         let initExpression = this.$el.getAttribute('x-init')
 
-        if (! initExpression && this.$el.dataset.xInit) {
-            initExpression = this.$el.dataset.xInit
+        if (! initExpression && this.$el.getAttribute('data-x-init')) {
+            initExpression = this.$el.getAttribute('data-x-init')
         }
 
         this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, {})
@@ -302,6 +302,7 @@ export default class Component {
 
                 case 'cloak':
                     el.removeAttribute('x-cloak')
+                    el.removeAttribute('data-x-cloak')
                     break;
 
                 default:
@@ -393,6 +394,8 @@ export default class Component {
             this.walkAndSkipNestedComponents(self.$el, el => {
                 if (el.hasAttribute('x-ref')) {
                     refObj[el.getAttribute('x-ref')] = true
+                } else if (el.hasAttribute('data-x-ref')) {
+                    refObj[el.getAttribute('data-x-ref')] = true
                 }
             })
         /* IE11-ONLY:END */

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const Alpine = {
     },
 
     discoverComponents: function (callback) {
-        const rootEls = document.querySelectorAll('[x-data]');
+        const rootEls = document.querySelectorAll('[x-data], [data-x-data]');
 
         rootEls.forEach(rootEl => {
             callback(rootEl)
@@ -34,7 +34,7 @@ const Alpine = {
     },
 
     discoverUninitializedComponents: function (callback, el = null) {
-        const rootEls = (el || document).querySelectorAll('[x-data]');
+        const rootEls = (el || document).querySelectorAll('[x-data], [data-x-data]');
 
         Array.from(rootEls)
             .filter(el => el.__x === undefined)
@@ -61,7 +61,7 @@ const Alpine = {
 
                         // Discard any changes happening within an existing component.
                         // They will take care of themselves.
-                        if (node.parentElement && node.parentElement.closest('[x-data]')) return
+                        if (node.parentElement && node.parentElement.closest('[x-data], [data-x-data]')) return
 
                         this.discoverUninitializedComponents((el) => {
                             this.initializeComponent(el)

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,7 @@ export function saferEvalNoReturn(expression, dataContext, additionalHelperVaria
     )
 }
 
-const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/
+const xAttrRE = /^(data-x|x)-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref)\b/
 
 export function isXAttr(attr) {
     const name = replaceAtAndColonWithStandardSyntax(attr.name)
@@ -91,7 +91,7 @@ export function getXAttrs(el, type) {
             const modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || []
 
             return {
-                type: typeMatch ? typeMatch[1] : null,
+                type: typeMatch ? typeMatch[2] : null,
                 value: valueMatch ? valueMatch[1] : null,
                 modifiers: modifiers.map(i => i.replace('.', '')),
                 expression: attr.value,

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -17,6 +17,18 @@ test('attribute bindings are set on initialize', async () => {
     expect(document.querySelector('span').getAttribute('foo')).toEqual('bar')
 })
 
+test('data attribute bindings are set on initialize', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }">
+            <span data-x-bind:foo="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').getAttribute('foo')).toEqual('bar')
+})
+
 test('class attribute bindings are merged by string syntax', async () => {
     document.body.innerHTML = `
         <div x-data="{ isOn: false }">

--- a/test/cloak.spec.js
+++ b/test/cloak.spec.js
@@ -18,3 +18,17 @@ test('x-cloak is removed', async () => {
 
     await wait(() => { expect(document.querySelector('span').getAttribute('x-cloak')).toBeNull() })
 })
+
+test('data-x-cloak is removed', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ hidden: true }">
+            <span data-x-cloak></span>
+        </div>
+    `
+
+    expect(document.querySelector('span').getAttribute('data-x-cloak')).not.toBeNull()
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('data-x-cloak')).toBeNull() })
+})

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -35,6 +35,39 @@ test('auto-detect new components at the top level', async () => {
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
 
+test('auto-detect new data-x components at the top level', async () => {
+    var runObservers = []
+
+    global.MutationObserver = class {
+        constructor(callback) { runObservers.push(callback) }
+        observe() {}
+    }
+
+    document.body.innerHTML = `
+        <section></section>
+    `
+
+    Alpine.start()
+
+    document.querySelector('section').innerHTML = `
+        <div data-x-data="{ foo: '' }">
+            <input data-x-model="foo">
+            <span data-x-text="foo"></span>
+        </div>
+    `
+    runObservers[0]([
+        {
+            target: document.querySelector('section'),
+            type: 'childList',
+            addedNodes: [ document.querySelector('div') ],
+        }
+    ])
+
+    fireEvent.input(document.querySelector('input'), { target: { value: 'bar' }})
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+})
+
 test('auto-detect nested new components at the top level', async () => {
     var runObservers = []
 

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -19,6 +19,20 @@ test('data manipulated on component object is reactive', async () => {
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('baz') })
 })
 
+test('data-x data manipulated on component object is reactive', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }">
+            <span data-x-text="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelector('div').__x.$data.foo = 'baz'
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('baz') })
+})
+
 test('x-data attribute value is optional', async () => {
     document.body.innerHTML = `
         <div x-data>

--- a/test/debounce.spec.js
+++ b/test/debounce.spec.js
@@ -37,6 +37,37 @@ test('x-on with debounce modifier', async () => {
     expect(document.querySelector('span').innerText).toEqual(1)
 })
 
+test('data-x-on with debounce modifier', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{foo: 0}">
+          <input data-x-on:input.debounce="foo++" />
+          <span data-x-text="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    fireEvent.input(document.querySelector('input'), { target: { value: 1 }})
+
+    await timeout(10)
+
+    fireEvent.input(document.querySelector('input'), { target: { value: 1 }})
+    expect(document.querySelector('span').innerText).toEqual(0)
+
+    await timeout(10)
+
+    fireEvent.input(document.querySelector('input'), { target: { value: 1 }})
+    expect(document.querySelector('span').innerText).toEqual(0)
+
+    await timeout(249)
+
+    expect(document.querySelector('span').innerText).toEqual(0)
+
+    await timeout(20)
+
+    expect(document.querySelector('span').innerText).toEqual(1)
+})
+
 test('x-on with debounce modifier and specified wait', async () => {
     document.body.innerHTML = `
         <div x-data="{foo: 0}">

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -29,6 +29,30 @@ test('x-for', async () => {
     expect(document.querySelectorAll('span')[1].innerText).toEqual('bar')
 })
 
+test('data-x-for', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ items: ['foo'] }">
+            <button data-x-on:click="items = ['foo', 'bar']"></button>
+
+            <template data-x-for="item in items">
+                <span data-x-text="item"></span>
+            </template>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelectorAll('span').length).toEqual(1)
+    expect(document.querySelectorAll('span')[0].innerText).toEqual('foo')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(2) })
+
+    expect(document.querySelectorAll('span')[0].innerText).toEqual('foo')
+    expect(document.querySelectorAll('span')[1].innerText).toEqual('bar')
+})
+
 test('removes all elements when array is empty and previously had one item', async () => {
     document.body.innerHTML = `
         <div x-data="{ items: ['foo'] }">

--- a/test/html.spec.js
+++ b/test/html.spec.js
@@ -17,6 +17,18 @@ test('x-html on init', async () => {
     await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>') })
 })
 
+test('data-x-html on init', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: '<h1>bar</h1>' }">
+            <span data-x-html="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerHTML).toEqual('<h1>bar</h1>') })
+})
+
 test('x-html on triggered update', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: '' }">

--- a/test/if.spec.js
+++ b/test/if.spec.js
@@ -25,6 +25,26 @@ test('x-if', async () => {
     await wait(() => { expect(document.querySelector('p')).toBeTruthy() })
 })
 
+test('data-x-if', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ show: false }">
+            <button data-x-on:click="show = ! show"></button>
+
+            <template data-x-if="show">
+                <p></p>
+            </template>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('p')).toBeFalsy()
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('p')).toBeTruthy() })
+})
+
 test('elements inside x-if are still reactive', async () => {
     document.body.innerHTML = `
         <div x-data="{ show: false, foo: 'bar' }">

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -22,6 +22,23 @@ test('x-init', async () => {
     expect(spanValue).toEqual('baz')
 })
 
+test('data-x-init', async () => {
+    var spanValue
+    window.setSpanValue = (el) => {
+        spanValue = el.innerHTML
+    }
+
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }" data-x-init="window.setSpanValue($refs.foo)">
+            <span data-x-text="foo" data-x-ref="foo">baz</span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(spanValue).toEqual('baz')
+})
+
 test('x-init from data function with callback return for "x-mounted" functionality', async () => {
     var valueA
     var valueB

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -17,6 +17,18 @@ test('x-model has value binding when initialized', async () => {
     expect(document.querySelector('input').value).toEqual('bar')
 })
 
+test('data-x-model has value binding when initialized', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }">
+            <input data-x-model="foo"></input>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('input').value).toEqual('bar')
+})
+
 test('x-model updates value when updated via input event', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: 'bar' }">

--- a/test/nesting.spec.js
+++ b/test/nesting.spec.js
@@ -28,6 +28,28 @@ test('can nest components', async () => {
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
 
+test('can nest data-x components', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }">
+            <span data-x-text="foo"></span>
+
+            <div data-x-data="{ foo: 'bob' }">
+                <button data-x-on:click="foo = 'baz'">Something</button>
+            </div>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual('bar')
+
+    document.querySelector('button').click()
+
+    await timeout(20)
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+})
+
 test('can access parent properties after nested components', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: 'bar' }">

--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -24,6 +24,24 @@ test('data modified in event listener updates affected attribute bindings', asyn
     await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
 })
 
+test('data modified in data-x event listener updates affected attribute bindings', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }">
+            <button data-x-on:click="foo = 'baz'"></button>
+
+            <span data-x-bind:foo="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').getAttribute('foo')).toEqual('bar')
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('foo')).toEqual('baz') })
+})
+
 test('nested data modified in event listener updates affected attribute bindings', async () => {
     document.body.innerHTML = `
         <div x-data="{ nested: { foo: 'bar' } }">

--- a/test/ref.spec.js
+++ b/test/ref.spec.js
@@ -23,6 +23,24 @@ test('can reference elements from event listeners', async () => {
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('lob') })
 })
 
+test('can reference data-x-ref elements from event listeners', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{}">
+            <span data-x-ref="bob"></span>
+
+            <button data-x-on:click="$refs['bob'].innerText = 'lob'"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').innerText).toEqual(undefined)
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('lob') })
+})
+
 test('can reference elements from data object methods', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo() { this.$refs.bob.innerText = 'lob' } }">

--- a/test/show.spec.js
+++ b/test/show.spec.js
@@ -23,6 +23,24 @@ test('x-show toggles display: none; with no other style attributes', async () =>
     await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
 })
 
+test('data-x-show toggles display: none; with no other style attributes', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ show: true }">
+            <span data-x-show="show"></span>
+
+            <button data-x-on:click="show = false"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('span').getAttribute('style')).toEqual(null)
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+})
+
 test('x-show toggles display: none; with other style attributes', async () => {
     document.body.innerHTML = `
         <div x-data="{ show: true }">

--- a/test/text.spec.js
+++ b/test/text.spec.js
@@ -17,6 +17,18 @@ test('x-text on init', async () => {
     await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
 })
 
+test('data-x-text on init', async () => {
+    document.body.innerHTML = `
+        <div data-x-data="{ foo: 'bar' }">
+            <span data-x-text="foo"></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').innerText).toEqual('bar') })
+})
+
 test('x-text on triggered update', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: '' }">


### PR DESCRIPTION
Closes #464 alongside previous issues and discussions regarding Alpine's "non-compliant" directives.

All existing tests are passing. I'm not sure whether we should add tests for each directives `data-x` counterpart, maybe just a single test to ensure they behave the same at the most basic level.

In terms of performance, the overhead will be minimal but this will definitely help developers who using Alpine who need to make sure their HTML attributes are compliant.

/cc @calebporzio @SimoTod @HugoDF 