### PR TITLE
new `x-bind` to object: fix transitions + tests

### DIFF
--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -36,7 +36,7 @@ export function handleForDirective(component, templateEl, expression, initialUpd
         currentEl.__x_for_key = currentKey
     })
 
-    removeAnyLeftOverElementsFromPreviousUpdate(currentEl)
+    removeAnyLeftOverElementsFromPreviousUpdate(currentEl, component)
 }
 
 // This was taken from VueJS 2.* core. Thanks Vue!
@@ -126,7 +126,7 @@ function lookAheadForMatchingKeyedElementAndMoveItIfFound(nextEl, currentKey) {
     }
 }
 
-function removeAnyLeftOverElementsFromPreviousUpdate(currentEl) {
+function removeAnyLeftOverElementsFromPreviousUpdate(currentEl, component) {
     var nextElementFromOldLoop = (currentEl.nextElementSibling && currentEl.nextElementSibling.__x_for_key !== undefined) ? currentEl.nextElementSibling : false
 
     while (nextElementFromOldLoop) {

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -449,10 +449,10 @@ test('can bind an object of directives', async () => {
         return {
             show: false,
             trigger: {
-                '@click'() { this.show = ! this.show }
+                '@click': function () { this.show = ! this.show }
             },
             dialogue: {
-                'x-show'() { return this.show }
+                ['x-show']() { return this.show }
             },
         }
     }


### PR DESCRIPTION
2 issues:
1. missing `component` in call to internal transition function
2. invalid JS in the `object x-bind` test