### PR TITLE
x-show transition overlap fix

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5923,7 +5923,7 @@
 
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_remaning_transitions = function () {
+        el.__x_remaining_transitions = function () {
           _newArrowCheck(this, _this15);
 
           stages.hide(); // Adding an "isConnected" check, in case the callback
@@ -5934,15 +5934,15 @@
           } // Safe to remove transition from el since it is completed
 
 
-          delete el.__x_remaning_transitions;
+          delete el.__x_remaining_transitions;
         }.bind(this);
 
         setTimeout(function () {
           _newArrowCheck(this, _this15);
 
-          // We only want to run remaning transitions in the end if they exists
-          if (el.__x_remaning_transitions) {
-            el.__x_remaning_transitions();
+          // We only want to run remaining transitions in the end if they exists
+          if (el.__x_remaining_transitions) {
+            el.__x_remaining_transitions();
           }
         }.bind(this), duration);
       }.bind(this));
@@ -6250,8 +6250,8 @@
     var initialUpdate = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
 
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaning_transitions) {
-      el.__x_remaning_transitions();
+    if (el.__x_remaining_transitions) {
+      el.__x_remaining_transitions();
     }
 
     var hide = function hide() {
@@ -6293,7 +6293,7 @@
             _newArrowCheck(this, _this2);
 
             // If previous transitions still there, don't use resolve
-            if (el.__x_remaning_transitions) {
+            if (el.__x_remaining_transitions) {
               hide();
             } else {
               resolve(function () {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -406,7 +406,7 @@
       requestAnimationFrame(() => {
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_remaning_transitions = () => {
+        el.__x_remaining_transitions = () => {
           stages.hide(); // Adding an "isConnected" check, in case the callback
           // removed the element from the DOM.
 
@@ -415,13 +415,13 @@
           } // Safe to remove transition from el since it is completed
 
 
-          delete el.__x_remaning_transitions;
+          delete el.__x_remaining_transitions;
         };
 
         setTimeout(() => {
-          // We only want to run remaning transitions in the end if they exists
-          if (el.__x_remaning_transitions) {
-            el.__x_remaning_transitions();
+          // We only want to run remaining transitions in the end if they exists
+          if (el.__x_remaining_transitions) {
+            el.__x_remaining_transitions();
           }
         }, duration);
       });
@@ -647,8 +647,8 @@
 
   function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaning_transitions) {
-      el.__x_remaning_transitions();
+    if (el.__x_remaining_transitions) {
+      el.__x_remaining_transitions();
     }
 
     const hide = () => {
@@ -678,7 +678,7 @@
         if (el.style.display !== 'none') {
           transitionOut(el, () => {
             // If previous transitions still there, don't use resolve
-            if (el.__x_remaning_transitions) {
+            if (el.__x_remaining_transitions) {
               hide();
             } else {
               resolve(() => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,6 +38,14 @@
         <script src="/dist/alpine.js" defer></script>
     </head>
     <body>
+
+    <div x-data="{open: false}">
+        <button x-on:click="open = !open">Toggle</button>
+        <div>
+            Open : <span x-text="open"></span>
+        </div>
+        <div x-show.transition.duration.1000="open">Content</div>
+    </div>
         <table>
             <thead>
                 <tr>

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,14 +38,6 @@
         <script src="/dist/alpine.js" defer></script>
     </head>
     <body>
-
-    <div x-data="{open: false}">
-        <button x-on:click="open = !open">Toggle</button>
-        <div>
-            Open : <span x-text="open"></span>
-        </div>
-        <div x-show.transition.duration.1000="open">Content</div>
-    </div>
         <table>
             <thead>
                 <tr>

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -2,8 +2,8 @@ import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaning_transitions) {
-        el.__x_remaning_transitions()
+    if (el.__x_remaining_transitions) {
+        el.__x_remaining_transitions()
     }
 
     const hide = () => {
@@ -32,7 +32,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
                     // If previous transitions still there, don't use resolve
-                    if (el.__x_remaning_transitions) {
+                    if (el.__x_remaining_transitions) {
                         hide()
                     } else {
                         resolve(() => {

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -1,6 +1,11 @@
 import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
+    // Resolve any previous pending transitions before starting a new one
+    if (el.__x_remaning_transitions) {
+        el.__x_remaning_transitions()
+    }
+
     const hide = () => {
         el.style.display = 'none'
     }
@@ -26,9 +31,14 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         if (! value) {
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
-                    resolve(() => {
+                    // If previous transitions still there, don't use resolve
+                    if (el.__x_remaning_transitions) {
                         hide()
-                    })
+                    } else {
+                        resolve(() => {
+                            hide()
+                        })
+                    }
                 }, component)
             } else {
                 resolve(() => {})

--- a/src/utils.js
+++ b/src/utils.js
@@ -397,13 +397,25 @@ export function transition(el, stages) {
         requestAnimationFrame(() => {
             stages.end()
 
-            setTimeout(() => {
+            // Asign current transition to el in case we need to force it
+            el.__x_remaning_transitions = () => {
+
                 stages.hide()
 
                 // Adding an "isConnected" check, in case the callback
                 // removed the element from the DOM.
                 if (el.isConnected) {
                     stages.cleanup()
+                }
+
+                // Safe to remove transition from el since it is completed
+                delete el.__x_remaning_transitions
+            }
+
+            setTimeout(() => {
+                // We only want to run remaning transitions in the end if they exists
+                if (el.__x_remaning_transitions) {
+                    el.__x_remaning_transitions()
                 }
             }, duration);
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -398,7 +398,7 @@ export function transition(el, stages) {
             stages.end()
 
             // Asign current transition to el in case we need to force it
-            el.__x_remaning_transitions = () => {
+            el.__x_remaining_transitions = () => {
 
                 stages.hide()
 
@@ -409,13 +409,13 @@ export function transition(el, stages) {
                 }
 
                 // Safe to remove transition from el since it is completed
-                delete el.__x_remaning_transitions
+                delete el.__x_remaining_transitions
             }
 
             setTimeout(() => {
-                // We only want to run remaning transitions in the end if they exists
-                if (el.__x_remaning_transitions) {
-                    el.__x_remaning_transitions()
+                // We only want to run remaining transitions in the end if they exists
+                if (el.__x_remaining_transitions) {
+                    el.__x_remaining_transitions()
                 }
             }, duration);
         })

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -621,7 +621,7 @@ test('x-transition supports css animation', async () => {
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
 })
 
-test('remaning transitions forced to complete if they exists', async () => {
+test('remaining transitions forced to complete if they exists', async () => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
         setTimeout(callback, 0)
     });

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -620,3 +620,91 @@ test('x-transition supports css animation', async () => {
     )
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
 })
+
+test('remaning transitions forced to complete if they exists', async () => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+        setTimeout(callback, 0)
+    });
+
+    // (hardcoding 10ms animation time for later assertions)
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
+        return {
+            transitionDuration: '0s',
+            animationDuration: '.1s'
+        }
+    });
+
+    document.body.innerHTML = `
+        <div x-data="{ show: false }">
+            <button x-on:click="show = ! show"></button>
+
+            <span
+                x-show="show"
+                x-transition:enter="animation-enter"
+                x-transition:leave="animation-leave"
+            ></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+
+    // animation in
+    document.querySelector('button').click()
+    // animation out
+    document.querySelector('button').click()
+    // animation in
+    document.querySelector('button').click()
+
+    // Wait for the first requestAnimationFrame
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    // The class should still be there since the animationDuration property is 100ms
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 99)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    // The class shouldn't be there anymore
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 10)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(false)
+
+    // animation out
+    document.querySelector('button').click()
+
+    // Wait for the first requestAnimationFrame
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    // The class should still be there since the animationDuration property is 100ms
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 99)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    // The class shouldn't be there anymore
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 10)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
+  })


### PR DESCRIPTION
Fixes #533 

> Not sure if this is a solid fix. It is working ~perfectly~ in my use case. I would like to test it other than manually via tests but also not sure how/what to test. I would like to know your thoughts. 

> I did a check right before alpine decides starting the transition. If there is an already transition going on the element, do not add new transition and just resolve, if there is no any transition, add show/hide transition depending on the value. 

> P.S
I don't know why but when i pull from master and build without any change, i saw some changes which is out of nowhere. So i am confused if the master is the build version. Since it has some changes not in compiled to `alpine.js`,  so i just included the files i changed without building it. I also notice @calebporzio merges source files only so probably all good. 

Instead of making a new PR for this issue I just force pushed the changes to this existing PR. 

I have to refactored transition to achieve this solution. So there is a `Refactored Transition` PR of this issue which has same solution + refactored transitions to let transitions has its own space so it will be easier to work on it. (it was really hard to work on existing transition code) 

This fix is quite self explanatory. I assigned current transitions to el as `el.__x_remaining_transitions` and make sure they are completed before next one starts. 

By this, quick clicks overlapping transitions and wrong state of display issues will be fixed. There is also a test called `remaining transitions forced to complete if they exists` which tests this bug. 

Let me know if there is any room to improve. Huge thanks @SimoTod and @HugoDF for their comments. .5 x more thanks to @SimoTod for bearing with me :). 
