### PR TITLE
Fix x show transition overlap

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5923,7 +5923,7 @@
 
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_remaning_transitions = function () {
+        el.__x_remaining_transitions = function () {
           _newArrowCheck(this, _this15);
 
           stages.hide(); // Adding an "isConnected" check, in case the callback
@@ -5934,15 +5934,15 @@
           } // Safe to remove transition from el since it is completed
 
 
-          delete el.__x_remaning_transitions;
+          delete el.__x_remaining_transitions;
         }.bind(this);
 
         setTimeout(function () {
           _newArrowCheck(this, _this15);
 
-          // We only want to run remaning transitions in the end if they exists
-          if (el.__x_remaning_transitions) {
-            el.__x_remaning_transitions();
+          // We only want to run remaining transitions in the end if they exists
+          if (el.__x_remaining_transitions) {
+            el.__x_remaining_transitions();
           }
         }.bind(this), duration);
       }.bind(this));
@@ -6250,8 +6250,8 @@
     var initialUpdate = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
 
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaning_transitions) {
-      el.__x_remaning_transitions();
+    if (el.__x_remaining_transitions) {
+      el.__x_remaining_transitions();
     }
 
     var hide = function hide() {
@@ -6293,7 +6293,7 @@
             _newArrowCheck(this, _this2);
 
             // If previous transitions still there, don't use resolve
-            if (el.__x_remaning_transitions) {
+            if (el.__x_remaining_transitions) {
               hide();
             } else {
               resolve(function () {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -63,7 +63,7 @@
 
   // Full polyfill for browsers with no classList support
   // Including IE < Edge missing SVGElement.classList
-  if (!("classList" in document.createElement("_"))
+  if (!("classList" in document.createElement("_")) 
   	|| document.createElementNS && !("classList" in document.createElementNS("http://www.w3.org/2000/svg","g"))) {
 
   (function (view) {
@@ -3121,7 +3121,7 @@
     // as the regeneratorRuntime namespace. Otherwise create a new empty
     // object. Either way, the resulting object will be used to initialize
     // the regeneratorRuntime variable at the top of this file.
-     module.exports
+     module.exports 
   ));
 
   try {
@@ -6253,9 +6253,8 @@
     var _this = this;
 
     var initialUpdate = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
-    // Prepare el in case we need to use transition
-    el.__x_transition = {}; // Resolve any previous pending transitions before starting a new one
 
+    // Resolve any previous pending transitions before starting a new one
     if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
       el.__x_transition_remaining();
     }
@@ -6284,10 +6283,7 @@
       }
 
       return;
-    } // Asign current value to el to check later on for preventing transition overlaps
-
-
-    el.__x_transition_last_value = value;
+    }
 
     var handle = function handle(resolve) {
       var _this2 = this;
@@ -6359,9 +6355,8 @@
 
     if (el.__x_transition_last_value !== value) {
       component.showDirectiveStack.push(handle);
+      component.showDirectiveLastElement = el;
     }
-
-    component.showDirectiveLastElement = el;
   }
 
   function handleIfDirective(component, el, expressionResult, initialUpdate, extraVars) {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6277,6 +6277,9 @@
     }.bind(this);
 
     if (initialUpdate === true) {
+      // Asign current value to el to check later on for preventing transition overlaps
+      el.__x_transition_last_value = value;
+
       if (value) {
         show();
       } else {
@@ -6318,7 +6321,7 @@
             _newArrowCheck(this, _this2);
           }.bind(this));
         }
-      } // Asign current value to el to check later on for preventing transition overlaps
+      } // Asign current value to el
 
 
       el.__x_transition_last_value = value;

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5924,7 +5924,7 @@
 
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_transition_remaining = function () {
+        el.__x_transition_remaining = once(function () {
           _newArrowCheck(this, _this15);
 
           stages.hide(); // Adding an "isConnected" check, in case the callback
@@ -5936,25 +5936,26 @@
 
 
           delete el.__x_transition_remaining;
-
-          if (el.__x_transition_timer) {
-            clearTimeout(el.__x_transition_timer);
-          }
-        }.bind(this);
-
-        el.__x_transition_timer = setTimeout(function () {
-          _newArrowCheck(this, _this15);
-
-          // We only want to run remaining transitions in the end if they exists
-          if (el.__x_transition_remaining) {
-            el.__x_transition_remaining();
-          }
-        }.bind(this), duration);
+        }.bind(this));
+        setTimeout(el.__x_transition_remaining, duration);
       }.bind(this));
     }.bind(this));
   }
   function isNumeric(subject) {
     return !isNaN(subject);
+  }
+  /**
+   * Ensure a function is called only once.
+   */
+
+  function once(fn) {
+    var called = false;
+    return function () {
+      if (!called) {
+        called = true;
+        fn.apply(this, arguments);
+      }
+    };
   }
 
   function handleForDirective(component, templateEl, expression, initialUpdate, extraVars) {

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6255,7 +6255,7 @@
 
     var initialUpdate = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : false;
 
-    // Resolve any previous pending transitions before starting a new one
+    // if value is changed resolve any previous pending transitions before starting a new one
     if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
       el.__x_transition_remaining();
     }
@@ -6291,42 +6291,33 @@
 
       _newArrowCheck(this, _this);
 
-      if (!value) {
+      if (value) {
+        transitionIn(el, function () {
+          _newArrowCheck(this, _this2);
+
+          show();
+        }.bind(this), component);
+        resolve(function () {
+          _newArrowCheck(this, _this2);
+        }.bind(this));
+      } else {
         if (el.style.display !== 'none') {
           transitionOut(el, function () {
             var _this3 = this;
 
             _newArrowCheck(this, _this2);
 
-            // If previous transitions still there, don't use resolve
-            if (el.__x_transition_remaining) {
-              hide();
-            } else {
-              resolve(function () {
-                _newArrowCheck(this, _this3);
+            resolve(function () {
+              _newArrowCheck(this, _this3);
 
-                hide();
-              }.bind(this));
-            }
+              hide();
+            }.bind(this));
           }.bind(this), component);
         } else {
           resolve(function () {
             _newArrowCheck(this, _this2);
           }.bind(this));
         }
-      } else {
-        if (el.style.display !== '') {
-          transitionIn(el, function () {
-            _newArrowCheck(this, _this2);
-
-            show();
-          }.bind(this), component);
-        } // Resolve immediately, only hold up parent `x-show`s for hiding.
-
-
-        resolve(function () {
-          _newArrowCheck(this, _this2);
-        }.bind(this));
       } // Asign current value to el to check later on for preventing transition overlaps
 
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5922,7 +5922,7 @@
 
         _newArrowCheck(this, _this14);
 
-        stages.end(); // Asign current transition to el in case we need to force it
+        stages.end(); // Assign current transition to el in case we need to force it
 
         el.__x_transition_remaining = once(function () {
           _newArrowCheck(this, _this15);
@@ -6277,7 +6277,7 @@
     }.bind(this);
 
     if (initialUpdate === true) {
-      // Asign current value to el to check later on for preventing transition overlaps
+      // Assign current value to el to check later on for preventing transition overlaps
       el.__x_transition_last_value = value;
 
       if (value) {
@@ -6321,7 +6321,7 @@
             _newArrowCheck(this, _this2);
           }.bind(this));
         }
-      } // Asign current value to el
+      } // Assign current value to el
 
 
       el.__x_transition_last_value = value;

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -672,6 +672,9 @@
     };
 
     if (initialUpdate === true) {
+      // Asign current value to el to check later on for preventing transition overlaps
+      el.__x_transition_last_value = value;
+
       if (value) {
         show();
       } else {
@@ -697,7 +700,7 @@
         } else {
           resolve(() => {});
         }
-      } // Asign current value to el to check later on for preventing transition overlaps
+      } // Asign current value to el
 
 
       el.__x_transition_last_value = value;

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -407,7 +407,7 @@
       requestAnimationFrame(() => {
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_remaining_transitions = () => {
+        el.__x_transition_remaining = () => {
           stages.hide(); // Adding an "isConnected" check, in case the callback
           // removed the element from the DOM.
 
@@ -416,7 +416,7 @@
           } // Safe to remove transition from el since it is completed
 
 
-          delete el.__x_remaining_transitions;
+          delete el.__x_transition_remaining;
 
           if (el.__x_transition_timer) {
             clearTimeout(el.__x_transition_timer);
@@ -425,8 +425,8 @@
 
         el.__x_transition_timer = setTimeout(() => {
           // We only want to run remaining transitions in the end if they exists
-          if (el.__x_remaining_transitions) {
-            el.__x_remaining_transitions();
+          if (el.__x_transition_remaining) {
+            el.__x_transition_remaining();
           }
         }, duration);
       });
@@ -652,8 +652,8 @@
 
   function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaining_transitions && el.__x_current_transition_value !== value) {
-      el.__x_remaining_transitions();
+    if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
+      el.__x_transition_remaining();
     }
 
     const hide = () => {
@@ -683,7 +683,7 @@
         if (el.style.display !== 'none') {
           transitionOut(el, () => {
             // If previous transitions still there, don't use resolve
-            if (el.__x_remaining_transitions) {
+            if (el.__x_transition_remaining) {
               hide();
             } else {
               resolve(() => {
@@ -706,7 +706,7 @@
       } // Asign current value to el to check later on for preventing transition overlaps
 
 
-      el.__x_current_transition_value = value;
+      el.__x_transition_last_value = value;
     }; // The working of x-show is a bit complex because we need to
     // wait for any child transitions to finish before hiding
     // some element. Also, this has to be done recursively.
@@ -726,11 +726,10 @@
     } // If x-show value changed from previous transition we'll push the handler onto a stack to be handled later.
 
 
-    if (el.__x_current_transition_value !== value) {
+    if (el.__x_transition_last_value !== value) {
       component.showDirectiveStack.push(handle);
+      component.showDirectiveLastElement = el;
     }
-
-    component.showDirectiveLastElement = el;
   }
 
   function handleIfDirective(component, el, expressionResult, initialUpdate, extraVars) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -654,7 +654,7 @@
   }
 
   function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
-    // Resolve any previous pending transitions before starting a new one
+    // if value is changed resolve any previous pending transitions before starting a new one
     if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
       el.__x_transition_remaining();
     }
@@ -682,30 +682,21 @@
     }
 
     const handle = resolve => {
-      if (!value) {
+      if (value) {
+        transitionIn(el, () => {
+          show();
+        }, component);
+        resolve(() => {});
+      } else {
         if (el.style.display !== 'none') {
           transitionOut(el, () => {
-            // If previous transitions still there, don't use resolve
-            if (el.__x_transition_remaining) {
+            resolve(() => {
               hide();
-            } else {
-              resolve(() => {
-                hide();
-              });
-            }
+            });
           }, component);
         } else {
           resolve(() => {});
         }
-      } else {
-        if (el.style.display !== '') {
-          transitionIn(el, () => {
-            show();
-          }, component);
-        } // Resolve immediately, only hold up parent `x-show`s for hiding.
-
-
-        resolve(() => {});
       } // Asign current value to el to check later on for preventing transition overlaps
 
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -405,7 +405,7 @@
 
       stages.show();
       requestAnimationFrame(() => {
-        stages.end(); // Asign current transition to el in case we need to force it
+        stages.end(); // Assign current transition to el in case we need to force it
 
         el.__x_transition_remaining = once(() => {
           stages.hide(); // Adding an "isConnected" check, in case the callback
@@ -672,7 +672,7 @@
     };
 
     if (initialUpdate === true) {
-      // Asign current value to el to check later on for preventing transition overlaps
+      // Assign current value to el to check later on for preventing transition overlaps
       el.__x_transition_last_value = value;
 
       if (value) {
@@ -700,7 +700,7 @@
         } else {
           resolve(() => {});
         }
-      } // Asign current value to el
+      } // Assign current value to el
 
 
       el.__x_transition_last_value = value;

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -406,7 +406,7 @@
       requestAnimationFrame(() => {
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_remaning_transitions = () => {
+        el.__x_remaining_transitions = () => {
           stages.hide(); // Adding an "isConnected" check, in case the callback
           // removed the element from the DOM.
 
@@ -415,13 +415,13 @@
           } // Safe to remove transition from el since it is completed
 
 
-          delete el.__x_remaning_transitions;
+          delete el.__x_remaining_transitions;
         };
 
         setTimeout(() => {
-          // We only want to run remaning transitions in the end if they exists
-          if (el.__x_remaning_transitions) {
-            el.__x_remaning_transitions();
+          // We only want to run remaining transitions in the end if they exists
+          if (el.__x_remaining_transitions) {
+            el.__x_remaining_transitions();
           }
         }, duration);
       });
@@ -647,8 +647,8 @@
 
   function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaning_transitions) {
-      el.__x_remaning_transitions();
+    if (el.__x_remaining_transitions) {
+      el.__x_remaining_transitions();
     }
 
     const hide = () => {
@@ -678,7 +678,7 @@
         if (el.style.display !== 'none') {
           transitionOut(el, () => {
             // If previous transitions still there, don't use resolve
-            if (el.__x_remaning_transitions) {
+            if (el.__x_remaining_transitions) {
               hide();
             } else {
               resolve(() => {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -407,7 +407,7 @@
       requestAnimationFrame(() => {
         stages.end(); // Asign current transition to el in case we need to force it
 
-        el.__x_transition_remaining = () => {
+        el.__x_transition_remaining = once(() => {
           stages.hide(); // Adding an "isConnected" check, in case the callback
           // removed the element from the DOM.
 
@@ -417,23 +417,26 @@
 
 
           delete el.__x_transition_remaining;
-
-          if (el.__x_transition_timer) {
-            clearTimeout(el.__x_transition_timer);
-          }
-        };
-
-        el.__x_transition_timer = setTimeout(() => {
-          // We only want to run remaining transitions in the end if they exists
-          if (el.__x_transition_remaining) {
-            el.__x_transition_remaining();
-          }
-        }, duration);
+        });
+        setTimeout(el.__x_transition_remaining, duration);
       });
     });
   }
   function isNumeric(subject) {
     return !isNaN(subject);
+  }
+  /**
+   * Ensure a function is called only once.
+   */
+
+  function once(fn) {
+    let called = false;
+    return function () {
+      if (!called) {
+        called = true;
+        fn.apply(this, arguments);
+      }
+    };
   }
 
   function handleForDirective(component, templateEl, expression, initialUpdate, extraVars) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,6 +38,14 @@
         <script src="/dist/alpine.js" defer></script>
     </head>
     <body>
+
+    <div x-data="{open: false}">
+        <button x-on:click="open = !open">Toggle</button>
+        <div>
+            Open : <span x-text="open"></span>
+        </div>
+        <div x-show.transition.duration.1000="open">Content</div>
+    </div>
         <table>
             <thead>
                 <tr>

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,14 +38,6 @@
         <script src="/dist/alpine.js" defer></script>
     </head>
     <body>
-
-    <div x-data="{open: false}">
-        <button x-on:click="open = !open">Toggle</button>
-        <div>
-            Open : <span x-text="open"></span>
-        </div>
-        <div x-show.transition.duration.1000="open">Content</div>
-    </div>
         <table>
             <thead>
                 <tr>

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,6 +38,12 @@
         <script src="/dist/alpine.js" defer></script>
     </head>
     <body>
+        <div x-data="{open: false, foo: ''}">
+            <div x-show.transition.duration.5000="open">test</div>
+            <button @click="open = !open">toggle</button>
+            <div x-text="open"></div>
+            <input x-model="foo">
+          </div>
         <table>
             <thead>
                 <tr>

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,12 +38,6 @@
         <script src="/dist/alpine.js" defer></script>
     </head>
     <body>
-        <div x-data="{open: false, foo: ''}">
-            <div x-show.transition.duration.5000="open">test</div>
-            <button @click="open = !open">toggle</button>
-            <div x-text="open"></div>
-            <input x-model="foo">
-          </div>
         <table>
             <thead>
                 <tr>

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -2,7 +2,7 @@ import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaining_transitions) {
+    if (el.__x_remaining_transitions && el.__x_current_transition_value !== value) {
         el.__x_remaining_transitions()
     }
 
@@ -50,9 +50,12 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
                 }, component)
             }
 
-            // Resolve immediately, only hold up parent `x-show`s for hidin.
+            // Resolve immediately, only hold up parent `x-show`s for hiding.
             resolve(() => {})
         }
+
+        // Asign current value to el to check later on for preventing transition overlaps
+        el.__x_current_transition_value = value
     }
 
     // The working of x-show is a bit complex because we need to
@@ -72,8 +75,10 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         component.executeAndClearRemainingShowDirectiveStack()
     }
 
-    // We'll push the handler onto a stack to be handled later.
-    component.showDirectiveStack.push(handle)
+    // If x-show value changed from previous transition we'll push the handler onto a stack to be handled later.
+    if (el.__x_current_transition_value !== value) {
+        component.showDirectiveStack.push(handle)
+    }
 
     component.showDirectiveLastElement = el
 }

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -28,36 +28,27 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
     }
 
     const handle = (resolve) => {
-        if (! value) {
+        if(value) {
+            transitionIn(el,() => {
+                show()
+            }, component)
+            resolve(() => {})
+        } else {
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
-                    // If there is a remaning transition
-                    // and value is changed, don't use resolve
-                    if ( el.__x_transition_remaining ) {
+                    resolve(() => {
                         hide()
-                    } else {
-                        resolve(() => {
-                            hide()
-                        })
-                    }
-                }, component)
+                    })
+                },component)
             } else {
                 resolve(() => {})
             }
-        } else {
-            if ( el.style.display !== '' ) {
-                transitionIn(el, () => {
-                    show()
-                }, component)
-            }
-
-            // Resolve immediately, only hold up parent `x-show`s for hiding.
-            resolve(() => {})
         }
 
         // Asign current value to el to check later on for preventing transition overlaps
         el.__x_transition_last_value = value
     }
+
 
     // The working of x-show is a bit complex because we need to
     // wait for any child transitions to finish before hiding

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -2,8 +2,8 @@ import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaning_transitions) {
-        el.__x_remaning_transitions()
+    if (el.__x_remaining_transitions) {
+        el.__x_remaining_transitions()
     }
 
     const hide = () => {
@@ -32,7 +32,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
                     // If previous transitions still there, don't use resolve
-                    if (el.__x_remaning_transitions) {
+                    if (el.__x_remaining_transitions) {
                         hide()
                     } else {
                         resolve(() => {

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -1,6 +1,11 @@
 import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
+    // Resolve any previous pending transitions before starting a new one
+    if (el.__x_remaning_transitions) {
+        el.__x_remaning_transitions()
+    }
+
     const hide = () => {
         el.style.display = 'none'
     }
@@ -26,9 +31,14 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         if (! value) {
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
-                    resolve(() => {
+                    // If previous transitions still there, don't use resolve
+                    if (el.__x_remaning_transitions) {
                         hide()
-                    })
+                    } else {
+                        resolve(() => {
+                            hide()
+                        })
+                    }
                 }, component)
             } else {
                 resolve(() => {})

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -19,7 +19,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
     }
 
     if (initialUpdate === true) {
-        // Asign current value to el to check later on for preventing transition overlaps
+        // Assign current value to el to check later on for preventing transition overlaps
         el.__x_transition_last_value = value
 
         if (value) {
@@ -48,7 +48,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
             }
         }
 
-        // Asign current value to el
+        // Assign current value to el
         el.__x_transition_last_value = value
     }
 

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -2,8 +2,8 @@ import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
     // Resolve any previous pending transitions before starting a new one
-    if (el.__x_remaining_transitions && el.__x_current_transition_value !== value) {
-        el.__x_remaining_transitions()
+    if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
+        el.__x_transition_remaining()
     }
 
     const hide = () => {
@@ -32,7 +32,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
                     // If previous transitions still there, don't use resolve
-                    if (el.__x_remaining_transitions) {
+                    if ( el.__x_transition_remaining ) {
                         hide()
                     } else {
                         resolve(() => {
@@ -55,7 +55,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         }
 
         // Asign current value to el to check later on for preventing transition overlaps
-        el.__x_current_transition_value = value
+        el.__x_transition_last_value = value
     }
 
     // The working of x-show is a bit complex because we need to
@@ -76,9 +76,8 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
     }
 
     // If x-show value changed from previous transition we'll push the handler onto a stack to be handled later.
-    if (el.__x_current_transition_value !== value) {
+    if (el.__x_transition_last_value !== value) {
         component.showDirectiveStack.push(handle)
+        component.showDirectiveLastElement = el
     }
-
-    component.showDirectiveLastElement = el
 }

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -19,6 +19,9 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
     }
 
     if (initialUpdate === true) {
+        // Asign current value to el to check later on for preventing transition overlaps
+        el.__x_transition_last_value = value
+
         if (value) {
             show()
         } else {
@@ -45,7 +48,7 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
             }
         }
 
-        // Asign current value to el to check later on for preventing transition overlaps
+        // Asign current value to el
         el.__x_transition_last_value = value
     }
 

--- a/src/directives/show.js
+++ b/src/directives/show.js
@@ -1,7 +1,7 @@
 import { transitionIn, transitionOut } from '../utils'
 
 export function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
-    // Resolve any previous pending transitions before starting a new one
+    // if value is changed resolve any previous pending transitions before starting a new one
     if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
         el.__x_transition_remaining()
     }
@@ -31,7 +31,8 @@ export function handleShowDirective(component, el, value, modifiers, initialUpda
         if (! value) {
             if ( el.style.display !== 'none' ) {
                 transitionOut(el, () => {
-                    // If previous transitions still there, don't use resolve
+                    // If there is a remaning transition
+                    // and value is changed, don't use resolve
                     if ( el.__x_transition_remaining ) {
                         hide()
                     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -397,13 +397,25 @@ export function transition(el, stages) {
         requestAnimationFrame(() => {
             stages.end()
 
-            setTimeout(() => {
+            // Asign current transition to el in case we need to force it
+            el.__x_remaning_transitions = () => {
+
                 stages.hide()
 
                 // Adding an "isConnected" check, in case the callback
                 // removed the element from the DOM.
                 if (el.isConnected) {
                     stages.cleanup()
+                }
+
+                // Safe to remove transition from el since it is completed
+                delete el.__x_remaning_transitions
+            }
+
+            setTimeout(() => {
+                // We only want to run remaning transitions in the end if they exists
+                if (el.__x_remaning_transitions) {
+                    el.__x_remaning_transitions()
                 }
             }, duration);
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -398,7 +398,7 @@ export function transition(el, stages) {
             stages.end()
 
             // Asign current transition to el in case we need to force it
-            el.__x_remaning_transitions = () => {
+            el.__x_remaining_transitions = () => {
 
                 stages.hide()
 
@@ -409,13 +409,13 @@ export function transition(el, stages) {
                 }
 
                 // Safe to remove transition from el since it is completed
-                delete el.__x_remaning_transitions
+                delete el.__x_remaining_transitions
             }
 
             setTimeout(() => {
-                // We only want to run remaning transitions in the end if they exists
-                if (el.__x_remaning_transitions) {
-                    el.__x_remaning_transitions()
+                // We only want to run remaining transitions in the end if they exists
+                if (el.__x_remaining_transitions) {
+                    el.__x_remaining_transitions()
                 }
             }, duration);
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -399,7 +399,7 @@ export function transition(el, stages) {
             stages.end()
 
             // Asign current transition to el in case we need to force it
-            el.__x_remaining_transitions =() => {
+            el.__x_transition_remaining =() => {
 
                 stages.hide()
 
@@ -410,7 +410,7 @@ export function transition(el, stages) {
                 }
 
                 // Safe to remove transition from el since it is completed
-                delete el.__x_remaining_transitions
+                delete el.__x_transition_remaining
                 if(el.__x_transition_timer){
                     clearTimeout(el.__x_transition_timer)
                 }
@@ -418,8 +418,8 @@ export function transition(el, stages) {
 
             el.__x_transition_timer = setTimeout(() => {
                 // We only want to run remaining transitions in the end if they exists
-                if (el.__x_remaining_transitions) {
-                    el.__x_remaining_transitions()
+                if (el.__x_transition_remaining) {
+                    el.__x_transition_remaining()
                 }
             }, duration);
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -399,8 +399,7 @@ export function transition(el, stages) {
             stages.end()
 
             // Asign current transition to el in case we need to force it
-            el.__x_transition_remaining =() => {
-
+            el.__x_transition_remaining = once(() => {
                 stages.hide()
 
                 // Adding an "isConnected" check, in case the callback
@@ -409,23 +408,28 @@ export function transition(el, stages) {
                     stages.cleanup()
                 }
 
-                // Safe to remove transition from el since it is completed
-                delete el.__x_transition_remaining
-                if(el.__x_transition_timer){
-                    clearTimeout(el.__x_transition_timer)
-                }
-            }
+                 // Safe to remove transition from el since it is completed
+                 delete el.__x_transition_remaining
+            })
 
-            el.__x_transition_timer = setTimeout(() => {
-                // We only want to run remaining transitions in the end if they exists
-                if (el.__x_transition_remaining) {
-                    el.__x_transition_remaining()
-                }
-            }, duration);
+            setTimeout(el.__x_transition_remaining, duration);
         })
     });
 }
 
 export function isNumeric(subject){
     return ! isNaN(subject)
+}
+
+/**
+ * Ensure a function is called only once.
+ */
+export function once(fn) {
+    let called = false
+    return function () {
+        if (!called) {
+            called = true
+            fn.apply(this, arguments)
+        }
+    }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -179,6 +179,7 @@ export function transitionIn(el, show, component, forceSkip = false) {
 }
 
 export function transitionOut(el, hide, component, forceSkip = false) {
+     // We don't want to transition on the initial page load.
     if (forceSkip) return hide()
 
     const attrs = getXAttrs(el, component, 'transition')
@@ -398,7 +399,7 @@ export function transition(el, stages) {
             stages.end()
 
             // Asign current transition to el in case we need to force it
-            el.__x_remaining_transitions = () => {
+            el.__x_remaining_transitions =() => {
 
                 stages.hide()
 
@@ -410,9 +411,12 @@ export function transition(el, stages) {
 
                 // Safe to remove transition from el since it is completed
                 delete el.__x_remaining_transitions
+                if(el.__x_transition_timer){
+                    clearTimeout(el.__x_transition_timer)
+                }
             }
 
-            setTimeout(() => {
+            el.__x_transition_timer = setTimeout(() => {
                 // We only want to run remaining transitions in the end if they exists
                 if (el.__x_remaining_transitions) {
                     el.__x_remaining_transitions()

--- a/src/utils.js
+++ b/src/utils.js
@@ -398,7 +398,7 @@ export function transition(el, stages) {
         requestAnimationFrame(() => {
             stages.end()
 
-            // Asign current transition to el in case we need to force it
+            // Assign current transition to el in case we need to force it
             el.__x_transition_remaining = once(() => {
                 stages.hide()
 

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -621,7 +621,7 @@ test('x-transition supports css animation', async () => {
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
 })
 
-test('remaning transitions forced to complete if they exists', async () => {
+test('remaining transitions forced to complete if they exists', async () => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
         setTimeout(callback, 0)
     });

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -621,6 +621,7 @@ test('x-transition supports css animation', async () => {
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
 })
 
+
 test('remaining transitions forced to complete if they exists', async () => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
         setTimeout(callback, 0)
@@ -650,11 +651,7 @@ test('remaining transitions forced to complete if they exists', async () => {
 
     await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
 
-    // animation in
-    document.querySelector('button').click()
-    // animation out
-    document.querySelector('button').click()
-    // animation in
+    // trigger animation in
     document.querySelector('button').click()
 
     // Wait for the first requestAnimationFrame
@@ -665,26 +662,10 @@ test('remaining transitions forced to complete if they exists', async () => {
     )
     expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
 
-    // The class should still be there since the animationDuration property is 100ms
-    await new Promise((resolve) =>
-        setTimeout(() => {
-            resolve();
-        }, 99)
-    )
-    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
-
-    // The class shouldn't be there anymore
-    await new Promise((resolve) =>
-        setTimeout(() => {
-            resolve();
-        }, 10)
-    )
-    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(false)
-
-    // animation out
+    // trigger animation out
     document.querySelector('button').click()
 
-    // Wait for the first requestAnimationFrame
+    // Wait for the next requestAnimationFrame
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
@@ -692,7 +673,36 @@ test('remaining transitions forced to complete if they exists', async () => {
     )
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
 
-    // The class should still be there since the animationDuration property is 100ms
+    // Wait for the next requestAnimationFrame
+        await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+
+    // trigger animation in
+    document.querySelector('button').click()
+
+    // Wait for the next requestAnimationFrame
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    // trigger animation out
+    document.querySelector('button').click()
+
+    // Wait for the next requestAnimationFrame
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    // The leave class should still be there since the animationDuration property is 100ms
     await new Promise((resolve) =>
         setTimeout(() => {
             resolve();
@@ -707,4 +717,4 @@ test('remaining transitions forced to complete if they exists', async () => {
         }, 10)
     )
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
-  })
+})

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -620,3 +620,91 @@ test('x-transition supports css animation', async () => {
     )
     expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
 })
+
+test('remaning transitions forced to complete if they exists', async () => {
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+        setTimeout(callback, 0)
+    });
+
+    // (hardcoding 10ms animation time for later assertions)
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
+        return {
+            transitionDuration: '0s',
+            animationDuration: '.1s'
+        }
+    });
+
+    document.body.innerHTML = `
+        <div x-data="{ show: false }">
+            <button x-on:click="show = ! show"></button>
+
+            <span
+                x-show="show"
+                x-transition:enter="animation-enter"
+                x-transition:leave="animation-leave"
+            ></span>
+        </div>
+    `
+
+    Alpine.start()
+
+    await wait(() => { expect(document.querySelector('span').getAttribute('style')).toEqual('display: none;') })
+
+    // animation in
+    document.querySelector('button').click()
+    // animation out
+    document.querySelector('button').click()
+    // animation in
+    document.querySelector('button').click()
+
+    // Wait for the first requestAnimationFrame
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    // The class should still be there since the animationDuration property is 100ms
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 99)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(true)
+
+    // The class shouldn't be there anymore
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 10)
+    )
+    expect(document.querySelector('span').classList.contains('animation-enter')).toEqual(false)
+
+    // animation out
+    document.querySelector('button').click()
+
+    // Wait for the first requestAnimationFrame
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 0)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    // The class should still be there since the animationDuration property is 100ms
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 99)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(true)
+
+    // The class shouldn't be there anymore
+    await new Promise((resolve) =>
+        setTimeout(() => {
+            resolve();
+        }, 10)
+    )
+    expect(document.querySelector('span').classList.contains('animation-leave')).toEqual(false)
+  })


### PR DESCRIPTION
Fixes #533 (tested) |  #170 (tested, need more test) | #156 (partly tested, need more test) | `you tell me`

I have to refactor transition to achieve this solution. So there is a #542 Refactored Transition PR  of this PR which has same solution + refactored transitions to let transitions has its own space so it will be easier to work on it. (it was really hard to work on existing transition code). I have explained much more on #542 since they serve almost same purpose.  

This fix is quite self explanatory. I assigned few variables to check transitions and make sure and control how they are rendered.

By this, quick clicks overlapping transitions and wrong state of display issues will be fixed. There is also a test called `remaining transitions forced to complete if they exists` which tests this bug.

Let me know if there is any room to improve. Huge thanks @SimoTod and @HugoDF for their comments. .5 x more thanks to @SimoTod for bearing with me :).