### PR TITLE
Don't modify attribute if set to the current value

### DIFF
--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -66,11 +66,15 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         // If an attribute's bound value is null, undefined or false, remove the attribute
         if ([null, undefined, false].includes(value)) {
             el.removeAttribute(attrName)
-        } else if (isBooleanAttr(attrName)) {
-            el.setAttribute(attrName, attrName)
-        } else if(el.getAttribute(attrName) !== value){
-            el.setAttribute(attrName, value)
-        }
+        } else {
+            isBooleanAttr(attrName) ? setIfChanged(el, attrName, attrName) : setIfChanged(el, attrName, value)
+        } 
+    }
+}
+
+function setIfChanged(el, attrName, value) {
+    if(el.getAttribute(attrName) != value){
+        el.setAttribute(attrName, value)
     }
 }
 

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -66,8 +66,10 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         // If an attribute's bound value is null, undefined or false, remove the attribute
         if ([null, undefined, false].includes(value)) {
             el.removeAttribute(attrName)
-        } else {
-            isBooleanAttr(attrName) ? el.setAttribute(attrName, attrName) : el.setAttribute(attrName, value)
+        } else if (isBooleanAttr(attrName)) {
+            el.setAttribute(attrName, attrName)
+        } else if(el.getAttribute(attrName) !== value){
+            el.setAttribute(attrName, value)
         }
     }
 }


### PR DESCRIPTION
Some dom elments change their internal state when an attribute is modified.

Namely the `audio` element stops playing if you modify it's `src` attribute even if it's value does not change. Therefor in the following example

```html
<div x-data="{ src: '...', i: 0 }>
<audio x-bind:src:"src" controls></audio>
<button x-on:click="i++">clicking this should not effect the audio</button>
</div>
```

the audio will stop playing every time the button is clicked.

This PR removes this unexpected behavior by only setting an attribute if it's value is changing.