### PR TITLE
Support pjax and swup in addition to Turbolinks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,15 @@ const Alpine = {
             this.initializeComponent(el)
         })
 
-        // It's easier and more performant to just support Turbolinks than listen
-        // to MutationObserver mutations at the document level.
-        document.addEventListener("turbolinks:load", () => {
-            this.discoverUninitializedComponents(el => {
-                this.initializeComponent(el)
+        // It's easier and more performant to just support Turbolinks, Swup and pjax 
+        // than listen to MutationObserver mutations at the document level.
+        ["turbolinks:load", "swup:contentReplaced", "pjax:complete"].forEach(event => 
+            document.addEventListener(event, () => {
+                this.discoverUninitializedComponents(el => {
+                    this.initializeComponent(el)
+                })
             })
-        })
+        )
 
         this.listenForNewUninitializedComponentsAtRunTime(el => {
             this.initializeComponent(el)


### PR DESCRIPTION
Fixes #96 

I use Alpine on an InstantClick-powered website and it felt weird to trigger a `turbolinks:load` event even though my app doesn’t run Turbolinks.

Adding more general-purpose events like `swup:contentReplaced` and `pjax:complete` will make Alpine work out of the box with more page navigation libraries.