### PR TITLE
Update babel/preset-env and fix audit warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
-            "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.1.tgz",
+            "integrity": "sha512-CHvCj7So7iCkGKPRFUfryXIkU2gSBw7VSZFYLsqVhrS47269VK2Hfi9S/YcublPMW8k1u2bQBlbDruoQEm4fgw==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.8.5",
+                "browserslist": "^4.12.0",
                 "invariant": "^2.2.4",
                 "semver": "^5.5.0"
             }
@@ -60,78 +60,370 @@
             }
         },
         "@babel/helper-annotate-as-pure": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
-            "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
+            "integrity": "sha512-ewp3rvJEwLaHgyWGe4wQssC2vjks3E80WiUe2BpMb0KhreTjMROCbxXcEovTrbeGVdQct5VjQfrv9EgC+xMzCw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
-            "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
+            "integrity": "sha512-cQpVq48EkYxUU0xozpGCLla3wlkdRRqLWu1ksFMXA9CM5KQmyyRpSEsYXbao7JUkOw/tAaYKCaYyZq6HOFYtyw==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.8.3",
-                "@babel/types": "^7.8.3"
-            }
-        },
-        "@babel/helper-call-delegate": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.7.tgz",
-            "integrity": "sha512-doAA5LAKhsFCR0LAFIf+r2RSMmC+m8f/oQ+URnUET/rWeEzC0yTRmAGyWkD4sSu3xwbS7MYQ2u+xlt1V5R56KQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-hoist-variables": "^7.8.3",
-                "@babel/traverse": "^7.8.3",
-                "@babel/types": "^7.8.7"
+                "@babel/helper-explode-assignable-expression": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
-            "integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+            "version": "7.10.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.2.tgz",
+            "integrity": "sha512-hYgOhF4To2UTB4LTaZepN/4Pl9LD4gfbJx8A34mqoluT8TLbof1mhUlYuNWTEebONa8+UlCC4X0TEXu7AOUyGA==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.8.6",
-                "browserslist": "^4.9.1",
+                "@babel/compat-data": "^7.10.1",
+                "browserslist": "^4.12.0",
                 "invariant": "^2.2.4",
                 "levenary": "^1.1.1",
                 "semver": "^5.5.0"
             }
         },
-        "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
-            "integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.10.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz",
+            "integrity": "sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.8.3",
-                "@babel/helper-regex": "^7.8.3",
+                "@babel/helper-function-name": "^7.10.1",
+                "@babel/helper-member-expression-to-functions": "^7.10.1",
+                "@babel/helper-optimise-call-expression": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-replace-supers": "^7.10.1",
+                "@babel/helper-split-export-declaration": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.1.tgz",
+            "integrity": "sha512-Rx4rHS0pVuJn5pJOqaqcZR4XSgeF9G/pO/79t+4r7380tXFJdzImFnxMU19f83wjSrmKHq6myrM10pFHTGzkUA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.1",
+                "@babel/helper-regex": "^7.10.1",
                 "regexpu-core": "^4.7.0"
             }
         },
         "@babel/helper-define-map": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
-            "integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
+            "integrity": "sha512-+5odWpX+OnvkD0Zmq7panrMuAGQBu6aPUgvMzuMGo4R+jUOvealEj2hiqI6WhxgKrTpFoFj0+VdsuA8KDxHBDg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.8.3",
-                "@babel/types": "^7.8.3",
+                "@babel/helper-function-name": "^7.10.1",
+                "@babel/types": "^7.10.1",
                 "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
-            "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
+            "integrity": "sha512-vcUJ3cDjLjvkKzt6rHrl767FeE7pMEYfPanq5L16GRtrXIoznc0HykNW2aEYkcnP76P0isoqJ34dDMFZwzEpJg==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.8.3",
-                "@babel/types": "^7.8.3"
+                "@babel/traverse": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+                    "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.2",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+                    "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/generator": "^7.10.1",
+                        "@babel/helper-function-name": "^7.10.1",
+                        "@babel/helper-split-export-declaration": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-function-name": {
@@ -155,21 +447,47 @@
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
-            "integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.1.tgz",
+            "integrity": "sha512-vLm5srkU8rI6X3+aQ1rQJyfjvCBLXP8cAGeuw04zeAM2ItKb1e7pmVmLyHb4sDaAYnLL13RHOZPLEtcGZ5xvjg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-            "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
+            "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-module-imports": {
@@ -182,27 +500,108 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
-            "integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
+            "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.8.3",
-                "@babel/helper-replace-supers": "^7.8.6",
-                "@babel/helper-simple-access": "^7.8.3",
-                "@babel/helper-split-export-declaration": "^7.8.3",
-                "@babel/template": "^7.8.6",
-                "@babel/types": "^7.8.6",
+                "@babel/helper-module-imports": "^7.10.1",
+                "@babel/helper-replace-supers": "^7.10.1",
+                "@babel/helper-simple-access": "^7.10.1",
+                "@babel/helper-split-export-declaration": "^7.10.1",
+                "@babel/template": "^7.10.1",
+                "@babel/types": "^7.10.1",
                 "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/helper-module-imports": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+                    "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-            "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
+            "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-plugin-utils": {
@@ -212,47 +611,313 @@
             "dev": true
         },
         "@babel/helper-regex": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
-            "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.1.tgz",
+            "integrity": "sha512-7isHr19RsIJWWLLFn21ubFt223PjQyg1HY7CZEMRr820HttHPpVvrsIN3bUOo44DEfFV4kBXO7Abbn9KTUZV7g==",
             "dev": true,
             "requires": {
                 "lodash": "^4.17.13"
             }
         },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
-            "integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
+            "integrity": "sha512-RfX1P8HqsfgmJ6CwaXGKMAqbYdlleqglvVtht0HGPMSsy2V6MqLlOJVF/0Qyb/m2ZCi2z3q3+s6Pv7R/dQuZ6A==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.8.3",
-                "@babel/helper-wrap-function": "^7.8.3",
-                "@babel/template": "^7.8.3",
-                "@babel/traverse": "^7.8.3",
-                "@babel/types": "^7.8.3"
+                "@babel/helper-annotate-as-pure": "^7.10.1",
+                "@babel/helper-wrap-function": "^7.10.1",
+                "@babel/template": "^7.10.1",
+                "@babel/traverse": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+                    "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.2",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+                    "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/generator": "^7.10.1",
+                        "@babel/helper-function-name": "^7.10.1",
+                        "@babel/helper-split-export-declaration": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-            "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
+            "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.8.3",
-                "@babel/helper-optimise-call-expression": "^7.8.3",
-                "@babel/traverse": "^7.8.6",
-                "@babel/types": "^7.8.6"
+                "@babel/helper-member-expression-to-functions": "^7.10.1",
+                "@babel/helper-optimise-call-expression": "^7.10.1",
+                "@babel/traverse": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+                    "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.2",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+                    "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/generator": "^7.10.1",
+                        "@babel/helper-function-name": "^7.10.1",
+                        "@babel/helper-split-export-declaration": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-            "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
+            "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.8.3",
-                "@babel/types": "^7.8.3"
+                "@babel/template": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -264,16 +929,130 @@
                 "@babel/types": "^7.8.3"
             }
         },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+            "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+            "dev": true
+        },
         "@babel/helper-wrap-function": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
-            "integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.1.tgz",
+            "integrity": "sha512-C0MzRGteVDn+H32/ZgbAv5r56f2o1fZSA/rj/TYo8JEJNHg+9BdSmKBUND0shxWRztWhjlT2cvHYuynpPsVJwQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.8.3",
-                "@babel/template": "^7.8.3",
-                "@babel/traverse": "^7.8.3",
-                "@babel/types": "^7.8.3"
+                "@babel/helper-function-name": "^7.10.1",
+                "@babel/template": "^7.10.1",
+                "@babel/traverse": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+                    "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.2",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.13",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+                    "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/generator": "^7.10.1",
+                        "@babel/helper-function-name": "^7.10.1",
+                        "@babel/helper-split-export-declaration": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0",
+                        "lodash": "^4.17.13"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/helpers": {
@@ -305,84 +1084,203 @@
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
-            "integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
+            "integrity": "sha512-vzZE12ZTdB336POZjmpblWfNNRpMSua45EYnRigE2XsZxcXcIyly2ixnTJasJE4Zq3U7t2d8rRF7XRUuzHxbOw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/helper-remap-async-to-generator": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-remap-async-to-generator": "^7.10.1",
                 "@babel/plugin-syntax-async-generators": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.1.tgz",
+            "integrity": "sha512-sqdGWgoXlnOdgMXU+9MbhzwFRgxVLeiGBqTrnuS7LC2IBU31wSsESbTUreT2O418obpfPdGUR2GbEufZF1bpqw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-dynamic-import": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
-            "integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.1.tgz",
+            "integrity": "sha512-Cpc2yUVHTEGPlmiQzXj026kqwjEQAD9I4ZC16uzdbgWgitg/UHKHLffKNCQZ5+y8jpIZPJcKcwsr2HwPh+w3XA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-json-strings": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
-            "integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.1.tgz",
+            "integrity": "sha512-m8r5BmV+ZLpWPtMY2mOKN7wre6HIO4gfIiV+eOmsnZABNenrt/kzYBwrh+KOfgumSWpnlGs5F70J8afYMSJMBg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-json-strings": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-nullish-coalescing-operator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
-            "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.1.tgz",
+            "integrity": "sha512-56cI/uHYgL2C8HVuHOuvVowihhX0sxb3nnfVRzUeVHTWmRHTZrKuAh/OBIMggGU/S1g/1D2CRCXqP+3u7vX7iA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.1.tgz",
+            "integrity": "sha512-jjfym4N9HtCiNfyyLAVD8WqPYeHUrw4ihxuAynWj6zzp2gf9Ey2f7ImhFm6ikB3CLf5Z/zmcJDri6B4+9j9RsA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
-            "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
+            "integrity": "sha512-Z+Qri55KiQkHh7Fc4BW6o+QBuTagbOp9txE+4U1i79u9oWlf2npkiDx+Rf3iK3lbcHBuNy9UOkwuR5wOMH3LIQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-transform-parameters": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
-            "integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.1.tgz",
+            "integrity": "sha512-VqExgeE62YBqI3ogkGoOJp1R6u12DFZjqwJhqtKc2o5m1YTUuUWnos7bZQFBhwkxIFpWYJ7uB75U7VAPPiKETA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-optional-chaining": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
-            "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.1.tgz",
+            "integrity": "sha512-dqQj475q8+/avvok72CF3AOSV/SGEcH29zT5hhohqqvvZ2+boQoOr7iGldBG5YXTO2qgCgc2B3WvVLUdbeMlGA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-proposal-private-methods": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.1.tgz",
+            "integrity": "sha512-RZecFFJjDiQ2z6maFprLgrdnm0OzoC23Mx89xf1CcEsxmHuzuXOdniEuI+S3v7vjQG4F5sa6YtUp+19sZuSxHg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
-            "integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.1.tgz",
+            "integrity": "sha512-JjfngYRvwmPwmnbRZyNiPFI8zxCZb8euzbCG/LxyKdeTb59tVciKo9GK9bi6JYKInk1H11Dq9j/zRqIH4KigfQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.8.8",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-create-regexp-features-plugin": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -403,6 +1301,23 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.1.tgz",
+            "integrity": "sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-syntax-dynamic-import": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
@@ -410,6 +1325,23 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-import-meta": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.1.tgz",
+            "integrity": "sha512-ypC4jwfIVF72og0dgvEcFRdOM2V9Qm1tu7RGmdZOlhsccyK0wisXmMObGuWEOd5jQ+K9wcIgSNftCpk2vkjUfQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -421,6 +1353,23 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.1.tgz",
+            "integrity": "sha512-XyHIFa9kdrgJS91CUH+ccPVTnJShr8nLGc5bG2IhGXv5p1Rd+8BleGE5yzIg2Nc1QZAdHDa0Qp4m6066OL96Iw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/plugin-syntax-nullish-coalescing-operator": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
@@ -428,6 +1377,23 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.1.tgz",
+            "integrity": "sha512-uTd0OsHrpe3tH5gRPTxG8Voh99/WCU78vIm5NMRYPAqC8lR4vajt6KkCAknCHrx24vkPdd/05yfdGSB4EIY2mg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -458,196 +1424,513 @@
             }
         },
         "@babel/plugin-syntax-top-level-await": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
-            "integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.1.tgz",
+            "integrity": "sha512-hgA5RYkmZm8FTFT3yu2N9Bx7yVVOKYT6yEdXXo6j2JTm0wNxgqaGeQVaSHRjhfnQbX91DtjFB6McRFSlcJH3xQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-arrow-functions": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
-            "integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz",
+            "integrity": "sha512-6AZHgFJKP3DJX0eCNJj01RpytUa3SOGawIxweHkNX2L6PYikOZmoh5B0d7hIHaIgveMjX990IAa/xK7jRTN8OA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-async-to-generator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
-            "integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.1.tgz",
+            "integrity": "sha512-XCgYjJ8TY2slj6SReBUyamJn3k2JLUIiiR5b6t1mNCMSvv7yx+jJpaewakikp0uWFQSF7ChPPoe3dHmXLpISkg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/helper-remap-async-to-generator": "^7.8.3"
+                "@babel/helper-module-imports": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-remap-async-to-generator": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-module-imports": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+                    "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
-            "integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz",
+            "integrity": "sha512-B7K15Xp8lv0sOJrdVAoukKlxP9N59HS48V1J3U/JGj+Ad+MHq+am6xJVs85AgXrQn4LV8vaYFOB+pr/yIuzW8Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
-            "integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz",
+            "integrity": "sha512-8bpWG6TtF5akdhIm/uWTyjHqENpy13Fx8chg7pFH875aNLwX8JxIxqm08gmAT+Whe6AOmaTeLPe7dpLbXt+xUw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.10.1",
                 "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
-            "integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
+            "integrity": "sha512-P9V0YIh+ln/B3RStPoXpEQ/CoAxQIhRSUn7aXqQ+FZJ2u8+oCtjIXR3+X0vsSD8zv+mb56K7wZW1XiDTDGiDRQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.8.3",
-                "@babel/helper-define-map": "^7.8.3",
-                "@babel/helper-function-name": "^7.8.3",
-                "@babel/helper-optimise-call-expression": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/helper-replace-supers": "^7.8.6",
-                "@babel/helper-split-export-declaration": "^7.8.3",
+                "@babel/helper-annotate-as-pure": "^7.10.1",
+                "@babel/helper-define-map": "^7.10.1",
+                "@babel/helper-function-name": "^7.10.1",
+                "@babel/helper-optimise-call-expression": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-replace-supers": "^7.10.1",
+                "@babel/helper-split-export-declaration": "^7.10.1",
                 "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+                    "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-computed-properties": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
-            "integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
+            "integrity": "sha512-mqSrGjp3IefMsXIenBfGcPXxJxweQe2hEIwMQvjtiDQ9b1IBvDUjkAtV/HMXX47/vXf14qDNedXsIiNd1FmkaQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
-            "integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz",
+            "integrity": "sha512-V/nUc4yGWG71OhaTH705pU8ZSdM6c1KmmLP8ys59oOYbT7RpMYAR3MsVOt6OHL0WzG7BlTU076va9fjJyYzJMA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-dotall-regex": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
-            "integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.1.tgz",
+            "integrity": "sha512-19VIMsD1dp02RvduFUmfzj8uknaO3uiHHF0s3E1OHnVsNj8oge8EQ5RzHRbJjGSetRnkEuBYO7TG1M5kKjGLOA==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-create-regexp-features-plugin": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
-            "integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.1.tgz",
+            "integrity": "sha512-wIEpkX4QvX8Mo9W6XF3EdGttrIPZWozHfEaDTU0WJD/TDnXMvdDh30mzUl/9qWhnf7naicYartcEfUghTCSNpA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
-            "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.1.tgz",
+            "integrity": "sha512-lr/przdAbpEA2BUzRvjXdEDLrArGRRPwbaF9rvayuHRvdQ7lUTTkZnhZrJ4LE2jvgMRFF4f0YuPQ20vhiPYxtA==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-for-of": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
-            "integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz",
+            "integrity": "sha512-US8KCuxfQcn0LwSCMWMma8M2R5mAjJGsmoCBVwlMygvmDUMkTCykc84IqN1M7t+agSfOmLYTInLCHJM+RUoz+w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-function-name": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
-            "integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz",
+            "integrity": "sha512-//bsKsKFBJfGd65qSNNh1exBy5Y9gD9ZN+DvrJ8f7HXr4avE5POW6zB7Rj6VnqHV33+0vXWUwJT0wSHubiAQkw==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-function-name": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+                    "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.10.1"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+                    "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "^7.10.1",
+                        "@babel/template": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                },
+                "@babel/highlight": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+                    "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "chalk": "^2.0.0",
+                        "js-tokens": "^4.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+                    "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+                    "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.10.1",
+                        "@babel/parser": "^7.10.1",
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-literals": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
-            "integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz",
+            "integrity": "sha512-qi0+5qgevz1NHLZroObRm5A+8JJtibb7vdcPQF1KQE12+Y/xxl8coJ+TpPW9iRq+Mhw/NKLjm+5SHtAHCC7lAw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-member-expression-literals": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
-            "integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.1.tgz",
+            "integrity": "sha512-UmaWhDokOFT2GcgU6MkHC11i0NQcL63iqeufXWfRy6pUOGYeCGEKhvfFO6Vz70UfYJYHwveg62GS83Rvpxn+NA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
-            "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.1.tgz",
+            "integrity": "sha512-31+hnWSFRI4/ACFr1qkboBbrTxoBIzj7qA69qlq8HY8p7+YCzkCT6/TvQ1a4B0z27VeWtAeJd6pr5G04dc1iHw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-module-transforms": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
-            "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.1.tgz",
+            "integrity": "sha512-AQG4fc3KOah0vdITwt7Gi6hD9BtQP/8bhem7OjbaMoRNCH5Djx42O2vYMfau7QnAzQCa+RJnhJBmFFMGpQEzrg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/helper-simple-access": "^7.8.3",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-module-transforms": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-simple-access": "^7.10.1",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
-            "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.1.tgz",
+            "integrity": "sha512-ewNKcj1TQZDL3YnO85qh9zo1YF1CHgmSTlRQgHqe63oTrMI85cthKtZjAiZSsSNjPQ5NCaYo5QkbYqEw1ZBgZA==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.8.3",
-                "@babel/helper-module-transforms": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "babel-plugin-dynamic-import-node": "^2.3.0"
+                "@babel/helper-hoist-variables": "^7.10.1",
+                "@babel/helper-module-transforms": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-modules-umd": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
-            "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.1.tgz",
+            "integrity": "sha512-EIuiRNMd6GB6ulcYlETnYYfgv4AxqrswghmBRQbWLHZxN4s7mupxzglnHqk9ZiUpDI4eRWewedJJNj67PWOXKA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-module-transforms": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -660,182 +1943,354 @@
             }
         },
         "@babel/plugin-transform-new-target": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
-            "integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.1.tgz",
+            "integrity": "sha512-MBlzPc1nJvbmO9rPr1fQwXOM2iGut+JC92ku6PbiJMMK7SnQc1rytgpopveE3Evn47gzvGYeCdgfCDbZo0ecUw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-object-super": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
-            "integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz",
+            "integrity": "sha512-WnnStUDN5GL+wGQrJylrnnVlFhFmeArINIR9gjhSeYyvroGhBrSAXYg/RHsnfzmsa+onJrTJrEClPzgNmmQ4Gw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/helper-replace-supers": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-replace-supers": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-parameters": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.8.tgz",
-            "integrity": "sha512-hC4Ld/Ulpf1psQciWWwdnUspQoQco2bMzSrwU6TmzRlvoYQe4rQFy9vnCZDTlVeCQj0JPfL+1RX0V8hCJvkgBA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz",
+            "integrity": "sha512-tJ1T0n6g4dXMsL45YsSzzSDZCxiHXAQp/qHrucOq5gEHncTA3xDxnd5+sZcoQp+N1ZbieAaB8r/VUCG0gqseOg==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.8.7",
-                "@babel/helper-get-function-arity": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-get-function-arity": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-get-function-arity": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+                    "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-property-literals": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
-            "integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.1.tgz",
+            "integrity": "sha512-Kr6+mgag8auNrgEpbfIWzdXYOvqDHZOF0+Bx2xh4H2EDNwcbRb9lY6nkZg8oSjsX+DH9Ebxm9hOqtKW+gRDeNA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-regenerator": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
-            "integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
+            "integrity": "sha512-B3+Y2prScgJ2Bh/2l9LJxKbb8C8kRfsG4AdPT+n7ixBHIxJaIG8bi8tgjxUMege1+WqSJ+7gu1YeoMVO3gPWzw==",
             "dev": true,
             "requires": {
                 "regenerator-transform": "^0.14.2"
             }
         },
         "@babel/plugin-transform-reserved-words": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
-            "integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.1.tgz",
+            "integrity": "sha512-qN1OMoE2nuqSPmpTqEM7OvJ1FkMEV+BjVeZZm9V9mq/x1JLKQ4pcv8riZJMNN3u2AUGl0ouOMjRr2siecvHqUQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
-            "integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz",
+            "integrity": "sha512-AR0E/lZMfLstScFwztApGeyTHJ5u3JUKMjneqRItWeEqDdHWZwAOKycvQNCasCK/3r5YXsuNG25funcJDu7Y2g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-spread": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
-            "integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz",
+            "integrity": "sha512-8wTPym6edIrClW8FI2IoaePB91ETOtg36dOkj3bYcNe7aDMN2FXEoUa+WrmPc4xa1u2PQK46fUX2aCb+zo9rfw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-sticky-regex": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
-            "integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.1.tgz",
+            "integrity": "sha512-j17ojftKjrL7ufX8ajKvwRilwqTok4q+BjkknmQw9VNHnItTyMP5anPFzxFJdCQs7clLcWpCV3ma+6qZWLnGMA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/helper-regex": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/helper-regex": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-template-literals": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
-            "integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
+            "integrity": "sha512-t7B/3MQf5M1T9hPCRG28DNGZUuxAuDqLYS03rJrIk2prj/UV7Z6FOneijhQhnv/Xa039vidXeVbvjK2SK5f7Gg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-annotate-as-pure": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
-            "integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.1.tgz",
+            "integrity": "sha512-qX8KZcmbvA23zDi+lk9s6hC1FM7jgLHYIjuLgULgc8QtYnmB3tAVIYkNoKRQ75qWBeyzcoMoK8ZQmogGtC/w0g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-unicode-escapes": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.1.tgz",
+            "integrity": "sha512-zZ0Poh/yy1d4jeDWpx/mNwbKJVwUYJX73q+gyh4bwtG0/iUlzdEu0sLMda8yuDFS6LBQlT/ST1SJAR6zYwXWgw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/plugin-transform-unicode-regex": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
-            "integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.1.tgz",
+            "integrity": "sha512-Y/2a2W299k0VIUdbqYm9X2qS6fE0CUBhhiPpimK6byy7OJ/kORLlIX+J6UrjgNu5awvs62k+6RSslxhcvVw2Tw==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3"
+                "@babel/helper-create-regexp-features-plugin": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                }
             }
         },
         "@babel/preset-env": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.7.tgz",
-            "integrity": "sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==",
+            "version": "7.10.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.2.tgz",
+            "integrity": "sha512-MjqhX0RZaEgK/KueRzh+3yPSk30oqDKJ5HP5tqTSB1e2gzGS3PLy7K0BIpnp78+0anFuSwOeuCf1zZO7RzRvEA==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.8.6",
-                "@babel/helper-compilation-targets": "^7.8.7",
-                "@babel/helper-module-imports": "^7.8.3",
-                "@babel/helper-plugin-utils": "^7.8.3",
-                "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-                "@babel/plugin-proposal-dynamic-import": "^7.8.3",
-                "@babel/plugin-proposal-json-strings": "^7.8.3",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-proposal-optional-chaining": "^7.8.3",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+                "@babel/compat-data": "^7.10.1",
+                "@babel/helper-compilation-targets": "^7.10.2",
+                "@babel/helper-module-imports": "^7.10.1",
+                "@babel/helper-plugin-utils": "^7.10.1",
+                "@babel/plugin-proposal-async-generator-functions": "^7.10.1",
+                "@babel/plugin-proposal-class-properties": "^7.10.1",
+                "@babel/plugin-proposal-dynamic-import": "^7.10.1",
+                "@babel/plugin-proposal-json-strings": "^7.10.1",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.1",
+                "@babel/plugin-proposal-numeric-separator": "^7.10.1",
+                "@babel/plugin-proposal-object-rest-spread": "^7.10.1",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.10.1",
+                "@babel/plugin-proposal-optional-chaining": "^7.10.1",
+                "@babel/plugin-proposal-private-methods": "^7.10.1",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.10.1",
                 "@babel/plugin-syntax-async-generators": "^7.8.0",
+                "@babel/plugin-syntax-class-properties": "^7.10.1",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.0",
                 "@babel/plugin-syntax-json-strings": "^7.8.0",
                 "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.1",
                 "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
                 "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-                "@babel/plugin-syntax-top-level-await": "^7.8.3",
-                "@babel/plugin-transform-arrow-functions": "^7.8.3",
-                "@babel/plugin-transform-async-to-generator": "^7.8.3",
-                "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-                "@babel/plugin-transform-block-scoping": "^7.8.3",
-                "@babel/plugin-transform-classes": "^7.8.6",
-                "@babel/plugin-transform-computed-properties": "^7.8.3",
-                "@babel/plugin-transform-destructuring": "^7.8.3",
-                "@babel/plugin-transform-dotall-regex": "^7.8.3",
-                "@babel/plugin-transform-duplicate-keys": "^7.8.3",
-                "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-                "@babel/plugin-transform-for-of": "^7.8.6",
-                "@babel/plugin-transform-function-name": "^7.8.3",
-                "@babel/plugin-transform-literals": "^7.8.3",
-                "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-                "@babel/plugin-transform-modules-amd": "^7.8.3",
-                "@babel/plugin-transform-modules-commonjs": "^7.8.3",
-                "@babel/plugin-transform-modules-systemjs": "^7.8.3",
-                "@babel/plugin-transform-modules-umd": "^7.8.3",
+                "@babel/plugin-syntax-top-level-await": "^7.10.1",
+                "@babel/plugin-transform-arrow-functions": "^7.10.1",
+                "@babel/plugin-transform-async-to-generator": "^7.10.1",
+                "@babel/plugin-transform-block-scoped-functions": "^7.10.1",
+                "@babel/plugin-transform-block-scoping": "^7.10.1",
+                "@babel/plugin-transform-classes": "^7.10.1",
+                "@babel/plugin-transform-computed-properties": "^7.10.1",
+                "@babel/plugin-transform-destructuring": "^7.10.1",
+                "@babel/plugin-transform-dotall-regex": "^7.10.1",
+                "@babel/plugin-transform-duplicate-keys": "^7.10.1",
+                "@babel/plugin-transform-exponentiation-operator": "^7.10.1",
+                "@babel/plugin-transform-for-of": "^7.10.1",
+                "@babel/plugin-transform-function-name": "^7.10.1",
+                "@babel/plugin-transform-literals": "^7.10.1",
+                "@babel/plugin-transform-member-expression-literals": "^7.10.1",
+                "@babel/plugin-transform-modules-amd": "^7.10.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.10.1",
+                "@babel/plugin-transform-modules-systemjs": "^7.10.1",
+                "@babel/plugin-transform-modules-umd": "^7.10.1",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-                "@babel/plugin-transform-new-target": "^7.8.3",
-                "@babel/plugin-transform-object-super": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.8.7",
-                "@babel/plugin-transform-property-literals": "^7.8.3",
-                "@babel/plugin-transform-regenerator": "^7.8.7",
-                "@babel/plugin-transform-reserved-words": "^7.8.3",
-                "@babel/plugin-transform-shorthand-properties": "^7.8.3",
-                "@babel/plugin-transform-spread": "^7.8.3",
-                "@babel/plugin-transform-sticky-regex": "^7.8.3",
-                "@babel/plugin-transform-template-literals": "^7.8.3",
-                "@babel/plugin-transform-typeof-symbol": "^7.8.4",
-                "@babel/plugin-transform-unicode-regex": "^7.8.3",
-                "@babel/types": "^7.8.7",
-                "browserslist": "^4.8.5",
+                "@babel/plugin-transform-new-target": "^7.10.1",
+                "@babel/plugin-transform-object-super": "^7.10.1",
+                "@babel/plugin-transform-parameters": "^7.10.1",
+                "@babel/plugin-transform-property-literals": "^7.10.1",
+                "@babel/plugin-transform-regenerator": "^7.10.1",
+                "@babel/plugin-transform-reserved-words": "^7.10.1",
+                "@babel/plugin-transform-shorthand-properties": "^7.10.1",
+                "@babel/plugin-transform-spread": "^7.10.1",
+                "@babel/plugin-transform-sticky-regex": "^7.10.1",
+                "@babel/plugin-transform-template-literals": "^7.10.1",
+                "@babel/plugin-transform-typeof-symbol": "^7.10.1",
+                "@babel/plugin-transform-unicode-escapes": "^7.10.1",
+                "@babel/plugin-transform-unicode-regex": "^7.10.1",
+                "@babel/preset-modules": "^0.1.3",
+                "@babel/types": "^7.10.2",
+                "browserslist": "^4.12.0",
                 "core-js-compat": "^3.6.2",
                 "invariant": "^2.2.2",
                 "levenary": "^1.1.1",
                 "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "@babel/helper-module-imports": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+                    "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.10.1"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.10.1",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+                    "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.10.2",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+                    "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.1",
+                        "lodash": "^4.17.13",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/preset-modules": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+            "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
             }
         },
         "@babel/runtime": {
@@ -931,109 +2386,22 @@
             "dev": true
         },
         "@jest/console": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.1.0.tgz",
-            "integrity": "sha512-3P1DpqAMK/L07ag/Y9/Jup5iDEG9P4pRAuZiMQnU0JB3UOvCyYCjCoxr7sIA80SeyUCUKrr24fKAxVpmBgQonA==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
+            "integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
             "dev": true,
             "requires": {
-                "@jest/source-map": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "chalk": "^3.0.0",
-                "jest-util": "^25.1.0",
+                "jest-message-util": "^25.5.0",
+                "jest-util": "^25.5.0",
                 "slash": "^3.0.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "@jest/core": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-25.1.0.tgz",
-            "integrity": "sha512-iz05+NmwCmZRzMXvMo6KFipW7nzhbpEawrKrkkdJzgytavPse0biEnCNr2wRlyCsp3SmKaEY+SGv7YWYQnIdig==",
-            "dev": true,
-            "requires": {
-                "@jest/console": "^25.1.0",
-                "@jest/reporters": "^25.1.0",
-                "@jest/test-result": "^25.1.0",
-                "@jest/transform": "^25.1.0",
-                "@jest/types": "^25.1.0",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^3.0.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.3",
-                "jest-changed-files": "^25.1.0",
-                "jest-config": "^25.1.0",
-                "jest-haste-map": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-regex-util": "^25.1.0",
-                "jest-resolve": "^25.1.0",
-                "jest-resolve-dependencies": "^25.1.0",
-                "jest-runner": "^25.1.0",
-                "jest-runtime": "^25.1.0",
-                "jest-snapshot": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jest-validate": "^25.1.0",
-                "jest-watcher": "^25.1.0",
-                "micromatch": "^4.0.2",
-                "p-each-series": "^2.1.0",
-                "realpath-native": "^1.1.0",
-                "rimraf": "^3.0.0",
-                "slash": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1043,19 +2411,13 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
-                },
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -1097,15 +2459,6 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
                 },
                 "supports-color": {
                     "version": "7.1.0",
@@ -1119,20 +2472,20 @@
             }
         },
         "@jest/environment": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.1.0.tgz",
-            "integrity": "sha512-cTpUtsjU4cum53VqBDlcW0E4KbQF03Cn0jckGPW/5rrE9tb+porD3+hhLtHAwhthsqfyF+bizyodTlsRA++sHg==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+            "integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^25.1.0",
-                "@jest/types": "^25.1.0",
-                "jest-mock": "^25.1.0"
+                "@jest/fake-timers": "^25.5.0",
+                "@jest/types": "^25.5.0",
+                "jest-mock": "^25.5.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1142,9 +2495,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1203,22 +2556,22 @@
             }
         },
         "@jest/fake-timers": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.1.0.tgz",
-            "integrity": "sha512-Eu3dysBzSAO1lD7cylZd/CVKdZZ1/43SF35iYBNV1Lvvn2Undp3Grwsv8PrzvbLhqwRzDd4zxrY4gsiHc+wygQ==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+            "integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-mock": "^25.1.0",
-                "jest-util": "^25.1.0",
+                "@jest/types": "^25.5.0",
+                "jest-message-util": "^25.5.0",
+                "jest-mock": "^25.5.0",
+                "jest-util": "^25.5.0",
                 "lolex": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1228,9 +2581,93 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "@jest/globals": {
+            "version": "25.5.2",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
+            "integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^25.5.0",
+                "@jest/types": "^25.5.0",
+                "expect": "^25.5.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^3.0.0"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1289,43 +2726,42 @@
             }
         },
         "@jest/reporters": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.1.0.tgz",
-            "integrity": "sha512-ORLT7hq2acJQa8N+NKfs68ZtHFnJPxsGqmofxW7v7urVhzJvpKZG9M7FAcgh9Ee1ZbCteMrirHA3m5JfBtAaDg==",
+            "version": "25.5.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
+            "integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
             "dev": true,
             "requires": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^25.1.0",
-                "@jest/environment": "^25.1.0",
-                "@jest/test-result": "^25.1.0",
-                "@jest/transform": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/console": "^25.5.0",
+                "@jest/test-result": "^25.5.0",
+                "@jest/transform": "^25.5.1",
+                "@jest/types": "^25.5.0",
                 "chalk": "^3.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
                 "glob": "^7.1.2",
+                "graceful-fs": "^4.2.4",
                 "istanbul-lib-coverage": "^3.0.0",
                 "istanbul-lib-instrument": "^4.0.0",
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.0.0",
-                "jest-haste-map": "^25.1.0",
-                "jest-resolve": "^25.1.0",
-                "jest-runtime": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jest-worker": "^25.1.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^25.5.1",
+                "jest-resolve": "^25.5.1",
+                "jest-util": "^25.5.0",
+                "jest-worker": "^25.5.0",
                 "node-notifier": "^6.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^3.1.0",
                 "terminal-link": "^2.0.0",
-                "v8-to-istanbul": "^4.0.1"
+                "v8-to-istanbul": "^4.1.3"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1335,9 +2771,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1402,13 +2838,13 @@
             }
         },
         "@jest/source-map": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.1.0.tgz",
-            "integrity": "sha512-ohf2iKT0xnLWcIUhL6U6QN+CwFWf9XnrM2a6ybL9NXxJjgYijjLSitkYHIdzkd8wFliH73qj/+epIpTiWjRtAA==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
+            "integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0",
-                "graceful-fs": "^4.2.3",
+                "graceful-fs": "^4.2.4",
                 "source-map": "^0.6.0"
             },
             "dependencies": {
@@ -1421,22 +2857,21 @@
             }
         },
         "@jest/test-result": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.1.0.tgz",
-            "integrity": "sha512-FZzSo36h++U93vNWZ0KgvlNuZ9pnDnztvaM7P/UcTx87aPDotG18bXifkf1Ji44B7k/eIatmMzkBapnAzjkJkg==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
+            "integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
             "dev": true,
             "requires": {
-                "@jest/console": "^25.1.0",
-                "@jest/transform": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/console": "^25.5.0",
+                "@jest/types": "^25.5.0",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1446,9 +2881,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1507,45 +2942,46 @@
             }
         },
         "@jest/test-sequencer": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.1.0.tgz",
-            "integrity": "sha512-WgZLRgVr2b4l/7ED1J1RJQBOharxS11EFhmwDqknpknE0Pm87HLZVS2Asuuw+HQdfQvm2aXL2FvvBLxOD1D0iw==",
+            "version": "25.5.4",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
+            "integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^25.1.0",
-                "jest-haste-map": "^25.1.0",
-                "jest-runner": "^25.1.0",
-                "jest-runtime": "^25.1.0"
+                "@jest/test-result": "^25.5.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^25.5.1",
+                "jest-runner": "^25.5.4",
+                "jest-runtime": "^25.5.4"
             }
         },
         "@jest/transform": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.1.0.tgz",
-            "integrity": "sha512-4ktrQ2TPREVeM+KxB4zskAT84SnmG1vaz4S+51aTefyqn3zocZUnliLLm5Fsl85I3p/kFPN4CRp1RElIfXGegQ==",
+            "version": "25.5.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
+            "integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "babel-plugin-istanbul": "^6.0.0",
                 "chalk": "^3.0.0",
                 "convert-source-map": "^1.4.0",
                 "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.2.3",
-                "jest-haste-map": "^25.1.0",
-                "jest-regex-util": "^25.1.0",
-                "jest-util": "^25.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^25.5.1",
+                "jest-regex-util": "^25.2.6",
+                "jest-util": "^25.5.0",
                 "micromatch": "^4.0.2",
                 "pirates": "^4.0.1",
-                "realpath-native": "^1.1.0",
+                "realpath-native": "^2.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.1",
                 "write-file-atomic": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1555,9 +2991,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -1598,10 +3034,81 @@
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-haste-map": {
+                    "version": "25.5.1",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
+                    "integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "@types/graceful-fs": "^4.1.2",
+                        "anymatch": "^3.0.3",
+                        "fb-watchman": "^2.0.0",
+                        "fsevents": "^2.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "jest-serializer": "^25.5.0",
+                        "jest-util": "^25.5.0",
+                        "jest-worker": "^25.5.0",
+                        "micromatch": "^4.0.2",
+                        "sane": "^4.0.3",
+                        "walker": "^1.0.7",
+                        "which": "^2.0.2"
+                    }
+                },
+                "jest-regex-util": {
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+                    "integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
+                    "dev": true
+                },
+                "jest-serializer": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
+                    "integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.4"
+                    }
+                },
+                "jest-util": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+                    "integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "chalk": "^3.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "is-ci": "^2.0.0",
+                        "make-dir": "^3.0.0"
+                    }
+                },
+                "jest-worker": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+                    "integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
+                    "dev": true,
+                    "requires": {
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "realpath-native": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+                    "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
                     "dev": true
                 },
                 "source-map": {
@@ -1617,6 +3124,15 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -1680,9 +3196,9 @@
             "dev": true
         },
         "@sinonjs/commons": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-            "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+            "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
             "dev": true,
             "requires": {
                 "type-detect": "4.0.8"
@@ -1787,6 +3303,15 @@
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "dev": true
         },
+        "@types/graceful-fs": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+            "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1816,6 +3341,18 @@
             "version": "13.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
             "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+            "dev": true
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "@types/prettier": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+            "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
             "dev": true
         },
         "@types/resolve": {
@@ -1914,9 +3451,9 @@
             "dev": true
         },
         "ajv": {
-            "version": "6.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-            "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+            "version": "6.12.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+            "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -1941,6 +3478,14 @@
             "dev": true,
             "requires": {
                 "type-fest": "^0.11.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
             }
         },
         "ansi-regex": {
@@ -2069,9 +3614,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
             "dev": true
         },
         "babel-jest": {
@@ -2163,9 +3708,9 @@
             }
         },
         "babel-plugin-dynamic-import-node": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-            "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
             "dev": true,
             "requires": {
                 "object.assign": "^4.1.0"
@@ -2191,6 +3736,25 @@
             "dev": true,
             "requires": {
                 "@types/babel__traverse": "^7.0.6"
+            }
+        },
+        "babel-preset-current-node-syntax": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+            "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             }
         },
         "babel-preset-jest": {
@@ -2438,14 +4002,15 @@
             }
         },
         "browserslist": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-            "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+            "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001030",
-                "electron-to-chromium": "^1.3.363",
-                "node-releases": "^1.1.50"
+                "caniuse-lite": "^1.0.30001043",
+                "electron-to-chromium": "^1.3.413",
+                "node-releases": "^1.1.53",
+                "pkg-up": "^2.0.0"
             }
         },
         "bser": {
@@ -2499,9 +4064,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001035",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-            "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==",
+            "version": "1.0.30001084",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001084.tgz",
+            "integrity": "sha512-ftdc5oGmhEbLUuMZ/Qp3mOpzfZLCxPYKcvGv6v2dJJ+8EdqcvZRbAGOiLmkM/PV1QGta/uwBs8/nCl6sokDW6w==",
             "dev": true
         },
         "capture-exit": {
@@ -2589,9 +4154,9 @@
             "dev": true
         },
         "collect-v8-coverage": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.0.tgz",
-            "integrity": "sha512-VKIhJgvk8E1W28m5avZ2Gv2Ruv5YiF56ug2oclvaG9md69BuZImMG2sk9g7QNKLUbtYAKQjXjYxbYZVUlMMKmQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
             "dev": true
         },
         "collection-visit": {
@@ -2702,12 +4267,12 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.6.4",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
-            "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
+            "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.8.3",
+                "browserslist": "^4.8.5",
                 "semver": "7.0.0"
             },
             "dependencies": {
@@ -2777,9 +4342,9 @@
             "dev": true
         },
         "cssstyle": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
-            "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+            "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
             "dev": true,
             "requires": {
                 "cssom": "~0.3.6"
@@ -2850,6 +4415,12 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
         },
         "define-properties": {
@@ -2952,9 +4523,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.376",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.376.tgz",
-            "integrity": "sha512-cv/PYVz5szeMz192ngilmezyPNFkUjuynuL2vNdiqIrio440nfTDdc0JJU0TS2KHLSVCs9gBbt4CFqM+HcBnjw==",
+            "version": "1.3.474",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.474.tgz",
+            "integrity": "sha512-fPkSgT9IBKmVJz02XioNsIpg0WYmkPrvU1lUJblMMJALxyE7/32NGvbJQKKxpNokozPvqfqkuUqVClYsvetcLw==",
             "dev": true
         },
         "element-closest": {
@@ -2993,36 +4564,6 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "es-abstract": {
-            "version": "1.17.4",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-            "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-            "dev": true,
-            "requires": {
-                "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.5",
-                "is-regex": "^1.0.5",
-                "object-inspect": "^1.7.0",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.1",
-                "string.prototype.trimright": "^2.1.1"
-            }
-        },
-        "es-to-primitive": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "dev": true,
-            "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            }
-        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3030,9 +4571,9 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-            "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.2.tgz",
+            "integrity": "sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==",
             "dev": true,
             "requires": {
                 "esprima": "^4.0.1",
@@ -3162,23 +4703,23 @@
             }
         },
         "expect": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-25.1.0.tgz",
-            "integrity": "sha512-wqHzuoapQkhc3OKPlrpetsfueuEiMf3iWh0R8+duCu9PIjXoP7HgD5aeypwTnXUAjC8aMsiVDaWwlbJ1RlQ38g==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+            "integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "ansi-styles": "^4.0.0",
-                "jest-get-type": "^25.1.0",
-                "jest-matcher-utils": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-regex-util": "^25.1.0"
+                "jest-get-type": "^25.2.6",
+                "jest-matcher-utils": "^25.5.0",
+                "jest-message-util": "^25.5.0",
+                "jest-regex-util": "^25.2.6"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -3188,13 +4729,19 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -3232,9 +4779,9 @@
                     "dev": true
                 },
                 "diff-sequences": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
-                    "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+                    "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
                     "dev": true
                 },
                 "has-flag": {
@@ -3244,33 +4791,45 @@
                     "dev": true
                 },
                 "jest-diff": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
-                    "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+                    "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "diff-sequences": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "diff-sequences": "^25.2.6",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.5.0"
                     }
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
                 },
                 "jest-matcher-utils": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
-                    "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+                    "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "jest-diff": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "jest-diff": "^25.5.0",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.5.0"
+                    }
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -3383,9 +4942,9 @@
             "dev": true
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "fast-json-stable-stringify": {
@@ -3566,9 +5125,9 @@
             "dev": true
         },
         "graceful-fs": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
             "dev": true
         },
         "growly": {
@@ -3610,15 +5169,6 @@
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
-            }
-        },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -3719,9 +5269,9 @@
             }
         },
         "html-escaper": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-            "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
         "http-signature": {
@@ -3841,12 +5391,6 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
-        "is-callable": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-            "dev": true
-        },
         "is-ci": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -3876,12 +5420,6 @@
                 }
             }
         },
-        "is-date-object": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-            "dev": true
-        },
         "is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -3900,6 +5438,13 @@
                     "dev": true
                 }
             }
+        },
+        "is-docker": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+            "dev": true,
+            "optional": true
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -3964,29 +5509,11 @@
                 "@types/estree": "0.0.39"
             }
         },
-        "is-regex": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-            "dev": true,
-            "requires": {
-                "has": "^1.0.3"
-            }
-        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
-        },
-        "is-symbol": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-            "dev": true,
-            "requires": {
-                "has-symbols": "^1.0.1"
-            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -4007,11 +5534,14 @@
             "dev": true
         },
         "is-wsl": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
-            "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
         },
         "isarray": {
             "version": "1.0.0",
@@ -4114,9 +5644,9 @@
             }
         },
         "istanbul-reports": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-            "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+            "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
             "dev": true,
             "requires": {
                 "html-escaper": "^2.0.0",
@@ -4134,10 +5664,126 @@
                 "jest-cli": "^25.1.0"
             },
             "dependencies": {
+                "@jest/core": {
+                    "version": "25.5.4",
+                    "resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
+                    "integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^25.5.0",
+                        "@jest/reporters": "^25.5.1",
+                        "@jest/test-result": "^25.5.0",
+                        "@jest/transform": "^25.5.1",
+                        "@jest/types": "^25.5.0",
+                        "ansi-escapes": "^4.2.1",
+                        "chalk": "^3.0.0",
+                        "exit": "^0.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "jest-changed-files": "^25.5.0",
+                        "jest-config": "^25.5.4",
+                        "jest-haste-map": "^25.5.1",
+                        "jest-message-util": "^25.5.0",
+                        "jest-regex-util": "^25.2.6",
+                        "jest-resolve": "^25.5.1",
+                        "jest-resolve-dependencies": "^25.5.4",
+                        "jest-runner": "^25.5.4",
+                        "jest-runtime": "^25.5.4",
+                        "jest-snapshot": "^25.5.1",
+                        "jest-util": "^25.5.0",
+                        "jest-validate": "^25.5.0",
+                        "jest-watcher": "^25.5.0",
+                        "micromatch": "^4.0.2",
+                        "p-each-series": "^2.1.0",
+                        "realpath-native": "^2.0.0",
+                        "rimraf": "^3.0.0",
+                        "slash": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "@jest/test-result": {
+                            "version": "25.5.0",
+                            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
+                            "integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/console": "^25.5.0",
+                                "@jest/types": "^25.5.0",
+                                "@types/istanbul-lib-coverage": "^2.0.0",
+                                "collect-v8-coverage": "^1.0.0"
+                            }
+                        },
+                        "exit": {
+                            "version": "0.1.2",
+                            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+                            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+                            "dev": true
+                        },
+                        "jest-config": {
+                            "version": "25.5.4",
+                            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
+                            "integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
+                            "dev": true,
+                            "requires": {
+                                "@babel/core": "^7.1.0",
+                                "@jest/test-sequencer": "^25.5.4",
+                                "@jest/types": "^25.5.0",
+                                "babel-jest": "^25.5.1",
+                                "chalk": "^3.0.0",
+                                "deepmerge": "^4.2.2",
+                                "glob": "^7.1.1",
+                                "graceful-fs": "^4.2.4",
+                                "jest-environment-jsdom": "^25.5.0",
+                                "jest-environment-node": "^25.5.0",
+                                "jest-get-type": "^25.2.6",
+                                "jest-jasmine2": "^25.5.4",
+                                "jest-regex-util": "^25.2.6",
+                                "jest-resolve": "^25.5.1",
+                                "jest-util": "^25.5.0",
+                                "jest-validate": "^25.5.0",
+                                "micromatch": "^4.0.2",
+                                "pretty-format": "^25.5.0",
+                                "realpath-native": "^2.0.0"
+                            }
+                        },
+                        "jest-util": {
+                            "version": "25.5.0",
+                            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+                            "integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/types": "^25.5.0",
+                                "chalk": "^3.0.0",
+                                "graceful-fs": "^4.2.4",
+                                "is-ci": "^2.0.0",
+                                "make-dir": "^3.0.0"
+                            }
+                        },
+                        "jest-validate": {
+                            "version": "25.5.0",
+                            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+                            "integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
+                            "dev": true,
+                            "requires": {
+                                "@jest/types": "^25.5.0",
+                                "camelcase": "^5.3.1",
+                                "chalk": "^3.0.0",
+                                "jest-get-type": "^25.2.6",
+                                "leven": "^3.1.0",
+                                "pretty-format": "^25.5.0"
+                            }
+                        },
+                        "realpath-native": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+                            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+                            "dev": true
+                        }
+                    }
+                },
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4146,10 +5792,23 @@
                         "chalk": "^3.0.0"
                     }
                 },
+                "@types/babel__core": {
+                    "version": "7.1.8",
+                    "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
+                    "integrity": "sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.1.0",
+                        "@babel/types": "^7.0.0",
+                        "@types/babel__generator": "*",
+                        "@types/babel__template": "*",
+                        "@types/babel__traverse": "*"
+                    }
+                },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -4169,6 +5828,43 @@
                     "requires": {
                         "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
+                    }
+                },
+                "babel-jest": {
+                    "version": "25.5.1",
+                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
+                    "integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/transform": "^25.5.1",
+                        "@jest/types": "^25.5.0",
+                        "@types/babel__core": "^7.1.7",
+                        "babel-plugin-istanbul": "^6.0.0",
+                        "babel-preset-jest": "^25.5.0",
+                        "chalk": "^3.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "babel-plugin-jest-hoist": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
+                    "integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.3.3",
+                        "@babel/types": "^7.3.3",
+                        "@types/babel__traverse": "^7.0.6"
+                    }
+                },
+                "babel-preset-jest": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
+                    "integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-jest-hoist": "^25.5.0",
+                        "babel-preset-current-node-syntax": "^0.1.2"
                     }
                 },
                 "chalk": {
@@ -4226,24 +5922,55 @@
                     "dev": true
                 },
                 "jest-cli": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.1.0.tgz",
-                    "integrity": "sha512-p+aOfczzzKdo3AsLJlhs8J5EW6ffVidfSZZxXedJ0mHPBOln1DccqFmGCoO8JWd4xRycfmwy1eoQkMsF8oekPg==",
+                    "version": "25.5.4",
+                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
+                    "integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^25.1.0",
-                        "@jest/test-result": "^25.1.0",
-                        "@jest/types": "^25.1.0",
+                        "@jest/core": "^25.5.4",
+                        "@jest/test-result": "^25.5.0",
+                        "@jest/types": "^25.5.0",
                         "chalk": "^3.0.0",
                         "exit": "^0.1.2",
+                        "graceful-fs": "^4.2.4",
                         "import-local": "^3.0.2",
                         "is-ci": "^2.0.0",
-                        "jest-config": "^25.1.0",
-                        "jest-util": "^25.1.0",
-                        "jest-validate": "^25.1.0",
+                        "jest-config": "^25.5.4",
+                        "jest-util": "^25.5.0",
+                        "jest-validate": "^25.5.0",
                         "prompts": "^2.0.1",
-                        "realpath-native": "^1.1.0",
-                        "yargs": "^15.0.0"
+                        "realpath-native": "^2.0.0",
+                        "yargs": "^15.3.1"
+                    },
+                    "dependencies": {
+                        "prompts": {
+                            "version": "2.3.2",
+                            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+                            "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+                            "dev": true,
+                            "requires": {
+                                "kleur": "^3.0.3",
+                                "sisteransi": "^1.0.4"
+                            }
+                        }
+                    }
+                },
+                "jest-get-type": {
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "string-width": {
@@ -4287,9 +6014,9 @@
                     }
                 },
                 "yargs": {
-                    "version": "15.3.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
-                    "integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
+                    "version": "15.3.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+                    "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
                     "dev": true,
                     "requires": {
                         "cliui": "^6.0.0",
@@ -4302,13 +6029,13 @@
                         "string-width": "^4.2.0",
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
-                        "yargs-parser": "^18.1.0"
+                        "yargs-parser": "^18.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "18.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
-                    "integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
@@ -4318,20 +6045,20 @@
             }
         },
         "jest-changed-files": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.1.0.tgz",
-            "integrity": "sha512-bdL1aHjIVy3HaBO3eEQeemGttsq1BDlHgWcOjEOIAcga7OOEGWHD2WSu8HhL7I1F0mFFyci8VKU4tRNk+qtwDA==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
+            "integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "execa": "^3.2.0",
                 "throat": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4341,9 +6068,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -4385,9 +6112,9 @@
                     "dev": true
                 },
                 "cross-spawn": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-                    "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
                     "dev": true,
                     "requires": {
                         "path-key": "^3.1.0",
@@ -4491,34 +6218,36 @@
             }
         },
         "jest-config": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.1.0.tgz",
-            "integrity": "sha512-tLmsg4SZ5H7tuhBC5bOja0HEblM0coS3Wy5LTCb2C8ZV6eWLewHyK+3qSq9Bi29zmWQ7ojdCd3pxpx4l4d2uGw==",
+            "version": "25.5.4",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
+            "integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^25.1.0",
-                "@jest/types": "^25.1.0",
-                "babel-jest": "^25.1.0",
+                "@jest/test-sequencer": "^25.5.4",
+                "@jest/types": "^25.5.0",
+                "babel-jest": "^25.5.1",
                 "chalk": "^3.0.0",
+                "deepmerge": "^4.2.2",
                 "glob": "^7.1.1",
-                "jest-environment-jsdom": "^25.1.0",
-                "jest-environment-node": "^25.1.0",
-                "jest-get-type": "^25.1.0",
-                "jest-jasmine2": "^25.1.0",
-                "jest-regex-util": "^25.1.0",
-                "jest-resolve": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jest-validate": "^25.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-environment-jsdom": "^25.5.0",
+                "jest-environment-node": "^25.5.0",
+                "jest-get-type": "^25.2.6",
+                "jest-jasmine2": "^25.5.4",
+                "jest-regex-util": "^25.2.6",
+                "jest-resolve": "^25.5.1",
+                "jest-util": "^25.5.0",
+                "jest-validate": "^25.5.0",
                 "micromatch": "^4.0.2",
-                "pretty-format": "^25.1.0",
-                "realpath-native": "^1.1.0"
+                "pretty-format": "^25.5.0",
+                "realpath-native": "^2.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4527,14 +6256,33 @@
                         "chalk": "^3.0.0"
                     }
                 },
+                "@types/babel__core": {
+                    "version": "7.1.8",
+                    "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
+                    "integrity": "sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/parser": "^7.1.0",
+                        "@babel/types": "^7.0.0",
+                        "@types/babel__generator": "*",
+                        "@types/babel__template": "*",
+                        "@types/babel__traverse": "*"
+                    }
+                },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -4544,6 +6292,43 @@
                     "requires": {
                         "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
+                    }
+                },
+                "babel-jest": {
+                    "version": "25.5.1",
+                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
+                    "integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/transform": "^25.5.1",
+                        "@jest/types": "^25.5.0",
+                        "@types/babel__core": "^7.1.7",
+                        "babel-plugin-istanbul": "^6.0.0",
+                        "babel-preset-jest": "^25.5.0",
+                        "chalk": "^3.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "babel-plugin-jest-hoist": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
+                    "integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.3.3",
+                        "@babel/types": "^7.3.3",
+                        "@types/babel__traverse": "^7.0.6"
+                    }
+                },
+                "babel-preset-jest": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
+                    "integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-jest-hoist": "^25.5.0",
+                        "babel-preset-current-node-syntax": "^0.1.2"
                     }
                 },
                 "chalk": {
@@ -4578,10 +6363,22 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
                 },
                 "supports-color": {
                     "version": "7.1.0",
@@ -4621,31 +6418,31 @@
             }
         },
         "jest-docblock": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.1.0.tgz",
-            "integrity": "sha512-370P/mh1wzoef6hUKiaMcsPtIapY25suP6JqM70V9RJvdKLrV4GaGbfUseUVk4FZJw4oTZ1qSCJNdrClKt5JQA==",
+            "version": "25.3.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+            "integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
             "dev": true,
             "requires": {
                 "detect-newline": "^3.0.0"
             }
         },
         "jest-each": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.1.0.tgz",
-            "integrity": "sha512-R9EL8xWzoPySJ5wa0DXFTj7NrzKpRD40Jy+zQDp3Qr/2QmevJgkN9GqioCGtAJ2bW9P/MQRznQHQQhoeAyra7A==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
+            "integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "chalk": "^3.0.0",
-                "jest-get-type": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "pretty-format": "^25.1.0"
+                "jest-get-type": "^25.2.6",
+                "jest-util": "^25.5.0",
+                "pretty-format": "^25.5.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4655,13 +6452,19 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -4705,10 +6508,22 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
                 },
                 "supports-color": {
                     "version": "7.1.0",
@@ -4722,23 +6537,23 @@
             }
         },
         "jest-environment-jsdom": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.1.0.tgz",
-            "integrity": "sha512-ILb4wdrwPAOHX6W82GGDUiaXSSOE274ciuov0lztOIymTChKFtC02ddyicRRCdZlB5YSrv3vzr1Z5xjpEe1OHQ==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
+            "integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^25.1.0",
-                "@jest/fake-timers": "^25.1.0",
-                "@jest/types": "^25.1.0",
-                "jest-mock": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jsdom": "^15.1.1"
+                "@jest/environment": "^25.5.0",
+                "@jest/fake-timers": "^25.5.0",
+                "@jest/types": "^25.5.0",
+                "jest-mock": "^25.5.0",
+                "jest-util": "^25.5.0",
+                "jsdom": "^15.2.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4748,9 +6563,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -4809,22 +6624,23 @@
             }
         },
         "jest-environment-node": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.1.0.tgz",
-            "integrity": "sha512-U9kFWTtAPvhgYY5upnH9rq8qZkj6mYLup5l1caAjjx9uNnkLHN2xgZy5mo4SyLdmrh/EtB9UPpKFShvfQHD0Iw==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
+            "integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^25.1.0",
-                "@jest/fake-timers": "^25.1.0",
-                "@jest/types": "^25.1.0",
-                "jest-mock": "^25.1.0",
-                "jest-util": "^25.1.0"
+                "@jest/environment": "^25.5.0",
+                "@jest/fake-timers": "^25.5.0",
+                "@jest/types": "^25.5.0",
+                "jest-mock": "^25.5.0",
+                "jest-util": "^25.5.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4834,9 +6650,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -4881,6 +6697,12 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
                 "supports-color": {
@@ -4901,28 +6723,30 @@
             "dev": true
         },
         "jest-haste-map": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.1.0.tgz",
-            "integrity": "sha512-/2oYINIdnQZAqyWSn1GTku571aAfs8NxzSErGek65Iu5o8JYb+113bZysRMcC/pjE5v9w0Yz+ldbj9NxrFyPyw==",
+            "version": "25.5.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
+            "integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
+                "@types/graceful-fs": "^4.1.2",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
                 "fsevents": "^2.1.2",
-                "graceful-fs": "^4.2.3",
-                "jest-serializer": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jest-worker": "^25.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-serializer": "^25.5.0",
+                "jest-util": "^25.5.0",
+                "jest-worker": "^25.5.0",
                 "micromatch": "^4.0.2",
                 "sane": "^4.0.3",
-                "walker": "^1.0.7"
+                "walker": "^1.0.7",
+                "which": "^2.0.2"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4932,9 +6756,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -4989,38 +6813,47 @@
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
                 }
             }
         },
         "jest-jasmine2": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.1.0.tgz",
-            "integrity": "sha512-GdncRq7jJ7sNIQ+dnXvpKO2MyP6j3naNK41DTTjEAhLEdpImaDA9zSAZwDhijjSF/D7cf4O5fdyUApGBZleaEg==",
+            "version": "25.5.4",
+            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
+            "integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
             "dev": true,
             "requires": {
                 "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^25.1.0",
-                "@jest/source-map": "^25.1.0",
-                "@jest/test-result": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/environment": "^25.5.0",
+                "@jest/source-map": "^25.5.0",
+                "@jest/test-result": "^25.5.0",
+                "@jest/types": "^25.5.0",
                 "chalk": "^3.0.0",
                 "co": "^4.6.0",
-                "expect": "^25.1.0",
+                "expect": "^25.5.0",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^25.1.0",
-                "jest-matcher-utils": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-runtime": "^25.1.0",
-                "jest-snapshot": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "pretty-format": "^25.1.0",
+                "jest-each": "^25.5.0",
+                "jest-matcher-utils": "^25.5.0",
+                "jest-message-util": "^25.5.0",
+                "jest-runtime": "^25.5.4",
+                "jest-snapshot": "^25.5.1",
+                "jest-util": "^25.5.0",
+                "pretty-format": "^25.5.0",
                 "throat": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5030,13 +6863,19 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -5074,9 +6913,9 @@
                     "dev": true
                 },
                 "diff-sequences": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
-                    "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+                    "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
                     "dev": true
                 },
                 "has-flag": {
@@ -5086,33 +6925,45 @@
                     "dev": true
                 },
                 "jest-diff": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
-                    "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+                    "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "diff-sequences": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "diff-sequences": "^25.2.6",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.5.0"
                     }
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
                 },
                 "jest-matcher-utils": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
-                    "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+                    "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "jest-diff": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "jest-diff": "^25.5.0",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.5.0"
+                    }
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -5127,20 +6978,109 @@
             }
         },
         "jest-leak-detector": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.1.0.tgz",
-            "integrity": "sha512-3xRI264dnhGaMHRvkFyEKpDeaRzcEBhyNrOG5oT8xPxOyUAblIAQnpiR3QXu4wDor47MDTiHbiFcbypdLcLW5w==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
+            "integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
             "dev": true,
             "requires": {
-                "jest-get-type": "^25.1.0",
-                "pretty-format": "^25.1.0"
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.5.0"
             },
             "dependencies": {
-                "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                "@jest/types": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^3.0.0"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
                     "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-get-type": {
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
@@ -5171,25 +7111,25 @@
             }
         },
         "jest-message-util": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.1.0.tgz",
-            "integrity": "sha512-Nr/Iwar2COfN22aCqX0kCVbXgn8IBm9nWf4xwGr5Olv/KZh0CZ32RKgZWMVDXGdOahicM10/fgjdimGNX/ttCQ==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
+            "integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@jest/test-result": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "@types/stack-utils": "^1.0.1",
                 "chalk": "^3.0.0",
+                "graceful-fs": "^4.2.4",
                 "micromatch": "^4.0.2",
                 "slash": "^3.0.0",
                 "stack-utils": "^1.0.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5199,9 +7139,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -5260,18 +7200,18 @@
             }
         },
         "jest-mock": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.1.0.tgz",
-            "integrity": "sha512-28/u0sqS+42vIfcd1mlcg4ZVDmSUYuNvImP4X2lX5hRMLW+CN0BeiKVD4p+ujKKbSPKd3rg/zuhCF+QBLJ4vag==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+            "integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0"
+                "@jest/types": "^25.5.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5281,9 +7221,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -5348,28 +7288,32 @@
             "dev": true
         },
         "jest-regex-util": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.1.0.tgz",
-            "integrity": "sha512-9lShaDmDpqwg+xAd73zHydKrBbbrIi08Kk9YryBEBybQFg/lBWR/2BDjjiSE7KIppM9C5+c03XiDaZ+m4Pgs1w==",
+            "version": "25.2.6",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+            "integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==",
             "dev": true
         },
         "jest-resolve": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.1.0.tgz",
-            "integrity": "sha512-XkBQaU1SRCHj2Evz2Lu4Czs+uIgJXWypfO57L7JYccmAXv4slXA6hzNblmcRmf7P3cQ1mE7fL3ABV6jAwk4foQ==",
+            "version": "25.5.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
+            "integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "browser-resolve": "^1.11.3",
                 "chalk": "^3.0.0",
+                "graceful-fs": "^4.2.4",
                 "jest-pnp-resolver": "^1.2.1",
-                "realpath-native": "^1.1.0"
+                "read-pkg-up": "^7.0.1",
+                "realpath-native": "^2.0.0",
+                "resolve": "^1.17.0",
+                "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5379,9 +7323,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -5428,6 +7372,15 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
+                "resolve": {
+                    "version": "1.17.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+                    "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
                 "supports-color": {
                     "version": "7.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -5440,20 +7393,20 @@
             }
         },
         "jest-resolve-dependencies": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.1.0.tgz",
-            "integrity": "sha512-Cu/Je38GSsccNy4I2vL12ZnBlD170x2Oh1devzuM9TLH5rrnLW1x51lN8kpZLYTvzx9j+77Y5pqBaTqfdzVzrw==",
+            "version": "25.5.4",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
+            "integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
-                "jest-regex-util": "^25.1.0",
-                "jest-snapshot": "^25.1.0"
+                "@jest/types": "^25.5.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-snapshot": "^25.5.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5463,9 +7416,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -5524,36 +7477,36 @@
             }
         },
         "jest-runner": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.1.0.tgz",
-            "integrity": "sha512-su3O5fy0ehwgt+e8Wy7A8CaxxAOCMzL4gUBftSs0Ip32S0epxyZPDov9Znvkl1nhVOJNf4UwAsnqfc3plfQH9w==",
+            "version": "25.5.4",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
+            "integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
             "dev": true,
             "requires": {
-                "@jest/console": "^25.1.0",
-                "@jest/environment": "^25.1.0",
-                "@jest/test-result": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/console": "^25.5.0",
+                "@jest/environment": "^25.5.0",
+                "@jest/test-result": "^25.5.0",
+                "@jest/types": "^25.5.0",
                 "chalk": "^3.0.0",
                 "exit": "^0.1.2",
-                "graceful-fs": "^4.2.3",
-                "jest-config": "^25.1.0",
-                "jest-docblock": "^25.1.0",
-                "jest-haste-map": "^25.1.0",
-                "jest-jasmine2": "^25.1.0",
-                "jest-leak-detector": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-resolve": "^25.1.0",
-                "jest-runtime": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jest-worker": "^25.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^25.5.4",
+                "jest-docblock": "^25.3.0",
+                "jest-haste-map": "^25.5.1",
+                "jest-jasmine2": "^25.5.4",
+                "jest-leak-detector": "^25.5.0",
+                "jest-message-util": "^25.5.0",
+                "jest-resolve": "^25.5.1",
+                "jest-runtime": "^25.5.4",
+                "jest-util": "^25.5.0",
+                "jest-worker": "^25.5.0",
                 "source-map-support": "^0.5.6",
                 "throat": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5563,9 +7516,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -5624,42 +7577,43 @@
             }
         },
         "jest-runtime": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.1.0.tgz",
-            "integrity": "sha512-mpPYYEdbExKBIBB16ryF6FLZTc1Rbk9Nx0ryIpIMiDDkOeGa0jQOKVI/QeGvVGlunKKm62ywcioeFVzIbK03bA==",
+            "version": "25.5.4",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
+            "integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
             "dev": true,
             "requires": {
-                "@jest/console": "^25.1.0",
-                "@jest/environment": "^25.1.0",
-                "@jest/source-map": "^25.1.0",
-                "@jest/test-result": "^25.1.0",
-                "@jest/transform": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/console": "^25.5.0",
+                "@jest/environment": "^25.5.0",
+                "@jest/globals": "^25.5.2",
+                "@jest/source-map": "^25.5.0",
+                "@jest/test-result": "^25.5.0",
+                "@jest/transform": "^25.5.1",
+                "@jest/types": "^25.5.0",
                 "@types/yargs": "^15.0.0",
                 "chalk": "^3.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "exit": "^0.1.2",
                 "glob": "^7.1.3",
-                "graceful-fs": "^4.2.3",
-                "jest-config": "^25.1.0",
-                "jest-haste-map": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-mock": "^25.1.0",
-                "jest-regex-util": "^25.1.0",
-                "jest-resolve": "^25.1.0",
-                "jest-snapshot": "^25.1.0",
-                "jest-util": "^25.1.0",
-                "jest-validate": "^25.1.0",
-                "realpath-native": "^1.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^25.5.4",
+                "jest-haste-map": "^25.5.1",
+                "jest-message-util": "^25.5.0",
+                "jest-mock": "^25.5.0",
+                "jest-regex-util": "^25.2.6",
+                "jest-resolve": "^25.5.1",
+                "jest-snapshot": "^25.5.1",
+                "jest-util": "^25.5.0",
+                "jest-validate": "^25.5.0",
+                "realpath-native": "^2.0.0",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0",
-                "yargs": "^15.0.0"
+                "yargs": "^15.3.1"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5669,9 +7623,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -5788,9 +7742,9 @@
                     }
                 },
                 "yargs": {
-                    "version": "15.3.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
-                    "integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
+                    "version": "15.3.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+                    "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
                     "dev": true,
                     "requires": {
                         "cliui": "^6.0.0",
@@ -5803,13 +7757,13 @@
                         "string-width": "^4.2.0",
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
-                        "yargs-parser": "^18.1.0"
+                        "yargs-parser": "^18.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "18.1.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
-                    "integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
@@ -5819,36 +7773,41 @@
             }
         },
         "jest-serializer": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.1.0.tgz",
-            "integrity": "sha512-20Wkq5j7o84kssBwvyuJ7Xhn7hdPeTXndnwIblKDR2/sy1SUm6rWWiG9kSCgJPIfkDScJCIsTtOKdlzfIHOfKA==",
-            "dev": true
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
+            "integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.4"
+            }
         },
         "jest-snapshot": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.1.0.tgz",
-            "integrity": "sha512-xZ73dFYN8b/+X2hKLXz4VpBZGIAn7muD/DAg+pXtDzDGw3iIV10jM7WiHqhCcpDZfGiKEj7/2HXAEPtHTj0P2A==",
+            "version": "25.5.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
+            "integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0",
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
+                "@types/prettier": "^1.19.0",
                 "chalk": "^3.0.0",
-                "expect": "^25.1.0",
-                "jest-diff": "^25.1.0",
-                "jest-get-type": "^25.1.0",
-                "jest-matcher-utils": "^25.1.0",
-                "jest-message-util": "^25.1.0",
-                "jest-resolve": "^25.1.0",
-                "mkdirp": "^0.5.1",
+                "expect": "^25.5.0",
+                "graceful-fs": "^4.2.4",
+                "jest-diff": "^25.5.0",
+                "jest-get-type": "^25.2.6",
+                "jest-matcher-utils": "^25.5.0",
+                "jest-message-util": "^25.5.0",
+                "jest-resolve": "^25.5.1",
+                "make-dir": "^3.0.0",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^25.1.0",
-                "semver": "^7.1.1"
+                "pretty-format": "^25.5.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5858,13 +7817,19 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -5902,9 +7867,9 @@
                     "dev": true
                 },
                 "diff-sequences": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.1.0.tgz",
-                    "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+                    "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
                     "dev": true
                 },
                 "has-flag": {
@@ -5914,39 +7879,51 @@
                     "dev": true
                 },
                 "jest-diff": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.1.0.tgz",
-                    "integrity": "sha512-nepXgajT+h017APJTreSieh4zCqnSHEJ1iT8HDlewu630lSJ4Kjjr9KNzm+kzGwwcpsDE6Snx1GJGzzsefaEHw==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+                    "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "diff-sequences": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "diff-sequences": "^25.2.6",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.5.0"
                     }
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
                 },
                 "jest-matcher-utils": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.1.0.tgz",
-                    "integrity": "sha512-KGOAFcSFbclXIFE7bS4C53iYobKI20ZWleAdAFun4W1Wz1Kkej8Ng6RRbhL8leaEvIOjGXhGf/a1JjO8bkxIWQ==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+                    "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
-                        "jest-diff": "^25.1.0",
-                        "jest-get-type": "^25.1.0",
-                        "pretty-format": "^25.1.0"
+                        "jest-diff": "^25.5.0",
+                        "jest-get-type": "^25.2.6",
+                        "pretty-format": "^25.5.0"
+                    }
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "semver": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                    "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
                 "supports-color": {
@@ -5961,21 +7938,22 @@
             }
         },
         "jest-util": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.1.0.tgz",
-            "integrity": "sha512-7did6pLQ++87Qsj26Fs/TIwZMUFBXQ+4XXSodRNy3luch2DnRXsSnmpVtxxQ0Yd6WTipGpbhh2IFP1mq6/fQGw==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+            "integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "chalk": "^3.0.0",
+                "graceful-fs": "^4.2.4",
                 "is-ci": "^2.0.0",
-                "mkdirp": "^0.5.1"
+                "make-dir": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5985,9 +7963,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -6046,23 +8024,23 @@
             }
         },
         "jest-validate": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.1.0.tgz",
-            "integrity": "sha512-kGbZq1f02/zVO2+t1KQGSVoCTERc5XeObLwITqC6BTRH3Adv7NZdYqCpKIZLUgpLXf2yISzQ465qOZpul8abXA==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+            "integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^25.1.0",
+                "@jest/types": "^25.5.0",
                 "camelcase": "^5.3.1",
                 "chalk": "^3.0.0",
-                "jest-get-type": "^25.1.0",
+                "jest-get-type": "^25.2.6",
                 "leven": "^3.1.0",
-                "pretty-format": "^25.1.0"
+                "pretty-format": "^25.5.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6072,13 +8050,19 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
                     }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.2.1",
@@ -6122,10 +8106,22 @@
                     "dev": true
                 },
                 "jest-get-type": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.1.0.tgz",
-                    "integrity": "sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==",
+                    "version": "25.2.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+                    "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
                     "dev": true
+                },
+                "pretty-format": {
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+                    "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^25.5.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
                 },
                 "supports-color": {
                     "version": "7.1.0",
@@ -6139,23 +8135,23 @@
             }
         },
         "jest-watcher": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.1.0.tgz",
-            "integrity": "sha512-Q9eZ7pyaIr6xfU24OeTg4z1fUqBF/4MP6J801lyQfg7CsnZ/TCzAPvCfckKdL5dlBBEKBeHV0AdyjFZ5eWj4ig==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
+            "integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^25.1.0",
-                "@jest/types": "^25.1.0",
+                "@jest/test-result": "^25.5.0",
+                "@jest/types": "^25.5.0",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^3.0.0",
-                "jest-util": "^25.1.0",
+                "jest-util": "^25.5.0",
                 "string-length": "^3.1.0"
             },
             "dependencies": {
                 "@jest/types": {
-                    "version": "25.1.0",
-                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.1.0.tgz",
-                    "integrity": "sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==",
+                    "version": "25.5.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+                    "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
                     "dev": true,
                     "requires": {
                         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6165,9 +8161,9 @@
                     }
                 },
                 "@types/yargs": {
-                    "version": "15.0.4",
-                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
-                    "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
                     "dev": true,
                     "requires": {
                         "@types/yargs-parser": "*"
@@ -6226,9 +8222,9 @@
             }
         },
         "jest-worker": {
-            "version": "25.1.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
-            "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+            "integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
             "dev": true,
             "requires": {
                 "merge-stream": "^2.0.0",
@@ -6402,6 +8398,12 @@
                 "type-check": "~0.3.2"
             }
         },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
+        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6528,18 +8530,18 @@
             }
         },
         "mime-db": {
-            "version": "1.43.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.26",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
             "dev": true,
             "requires": {
-                "mime-db": "1.43.0"
+                "mime-db": "1.44.0"
             }
         },
         "mimic-fn": {
@@ -6587,23 +8589,6 @@
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
-                }
-            }
-        },
-        "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
-            "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
                 }
             }
         },
@@ -6680,21 +8665,10 @@
             }
         },
         "node-releases": {
-            "version": "1.1.52",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
-            "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
-            "dev": true,
-            "requires": {
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
+            "version": "1.1.58",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.58.tgz",
+            "integrity": "sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==",
+            "dev": true
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -6766,12 +8740,6 @@
                 }
             }
         },
-        "object-inspect": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-            "dev": true
-        },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -6797,16 +8765,6 @@
                 "function-bind": "^1.1.1",
                 "has-symbols": "^1.0.0",
                 "object-keys": "^1.0.11"
-            }
-        },
-        "object.getownpropertydescriptors": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-            "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
             }
         },
         "object.pick": {
@@ -6980,6 +8938,66 @@
                 "find-up": "^4.0.0"
             }
         },
+        "pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.1.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
         "pn": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -7095,16 +9113,6 @@
             "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
-        "prompts": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.1.tgz",
-            "integrity": "sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==",
-            "dev": true,
-            "requires": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.4"
-            }
-        },
         "proxy-polyfill": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/proxy-polyfill/-/proxy-polyfill-0.3.1.tgz",
@@ -7112,9 +9120,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-            "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
         },
         "pump": {
@@ -7156,14 +9164,56 @@
                 "pify": "^3.0.0"
             }
         },
-        "realpath-native": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
-            "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+        "read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
             "dev": true,
             "requires": {
-                "util.promisify": "^1.0.0"
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
+                    }
+                }
             }
+        },
+        "realpath-native": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+            "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==",
+            "dev": true
         },
         "redent": {
             "version": "3.0.0",
@@ -7176,9 +9226,9 @@
             }
         },
         "regenerate": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+            "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==",
             "dev": true
         },
         "regenerate-unicode-properties": {
@@ -7197,9 +9247,9 @@
             "dev": true
         },
         "regenerator-transform": {
-            "version": "0.14.3",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.3.tgz",
-            "integrity": "sha512-zXHNKJspmONxBViAb3ZUmFoFPnTBs3zFhCEZJiwp/gkNzxVbTqNJVjYKx6Qk1tQ1P4XLf4TbH9+KBB7wGoAaUw==",
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+            "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.8.4",
@@ -7231,9 +9281,9 @@
             }
         },
         "regjsgen": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-            "integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
             "dev": true
         },
         "regjsparser": {
@@ -7808,9 +9858,9 @@
             "dev": true
         },
         "sisteransi": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-            "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "dev": true
         },
         "slash": {
@@ -8114,26 +10164,6 @@
                 "strip-ansi": "^5.1.0"
             }
         },
-        "string.prototype.trimleft": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
-            }
-        },
-        "string.prototype.trimright": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
-            }
-        },
         "strip-ansi": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -8380,9 +10410,9 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-            "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
             "dev": true
         },
         "typedarray-to-buffer": {
@@ -8495,18 +10525,6 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "util.promisify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
-            "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.2",
-                "has-symbols": "^1.0.1",
-                "object.getownpropertydescriptors": "^2.1.0"
-            }
-        },
         "uuid": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -8514,9 +10532,9 @@
             "dev": true
         },
         "v8-to-istanbul": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz",
-            "integrity": "sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+            "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -8720,9 +10738,9 @@
             }
         },
         "ws": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-            "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+            "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
             "dev": true
         },
         "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "license": "MIT",
     "devDependencies": {
         "@babel/core": "^7.8.7",
-        "@babel/preset-env": "^7.8.7",
+        "@babel/preset-env": "^7.10.2",
         "@rollup/plugin-commonjs": "^11.0.2",
         "@rollup/plugin-multi-entry": "^3.0.0",
         "@rollup/plugin-replace": "^2.3.1",


### PR DESCRIPTION
The current build is failing. It seems there's some incompatibilities between the version of babel/preset-env we use and the latest version of node. This happened to other libraries as well (For example Laravel mix, see https://github.com/JeffreyWay/laravel-mix/issues/2383). 🤷 

Updating babel/preset-env to the most recent version fixes the build process.

I've also run 'npm audit fix' since there were a lot of low lever security warnings
`found 1523 low severity vulnerabilities in 961 scanned packages`
All fixed without any BCs.