### PR TITLE
Remove flatMap since not supported by Edge 18

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -101,15 +101,15 @@ export function getXAttrs(el, component, type) {
     return Array.from(el.attributes)
         .filter(isXAttr)
         .map(parseHtmlAttribute)
-        .flatMap(i => {
-            if (i.type === 'spread') {
-                let directiveBindings = saferEval(i.expression, component.$data)
+        .reduce((accumulator, currentValue) => {
+            if (currentValue.type === 'spread') {
+                let directiveBindings = saferEval(currentValue.expression, component.$data)
 
-                return Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({ name, value }))
+                return accumulator.concat(Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({ name, value })))
             } else {
-                return i
+                return accumulator.concat(currentValue)
             }
-        })
+        }, [])
         .filter(i => {
             // If no type is passed in for filtering, bypass filter
             if (! type) return true


### PR DESCRIPTION
flatMap is not supported in Edge 18 (market share 2.8%) but that version does support the module/nomodule syntax so it won't use the IE11 version of Alpine providing a polyfill.

As a result, the upcoming release would break when used with old Edge versions.

It's safer to use reduce in this case: `FlatMap` is just syntax sugar for `map+flat` and `flat` is syntax sugar for `reduce+concat` so the following are equivalent

```javascript
        .flatMap(i => {
            if (i.type === 'spread') {
                let directiveBindings = saferEval(i.expression, component.$data)

                return Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({ name, value }))
            } else {
                return i
            }
        })
```
```javascript
        .map(currentValue => {
            if (currentValue.type === 'spread') {
                let directiveBindings = saferEval(currentValue.expression, component.$data)

                return Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({ name, value }))
            } else {
                return currentValue
            }
        })
        .reduce((accumulator, currentValue) => accumulator.concat(currentValue), [])
```
```javascript
        .reduce((accumulator, currentValue) => {
            if (currentValue.type === 'spread') {
                let directiveBindings = saferEval(currentValue.expression, component.$data)

                return accumulator.concat(Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({ name, value })))
            } else {
                return accumulator.concat(currentValue)
            }
        }, [])
```

Closes #576