### PR TITLE
Polyfil SVGPathElement contains for IE11

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -8,3 +8,4 @@ import "@webcomponents/template"
 import "custom-event-polyfill"
 
 SVGElement.prototype.contains = SVGElement.prototype.contains || HTMLElement.prototype.contains
+SVGPathElement.prototype.contains = SVGPathElement.prototype.contains || HTMLElement.prototype.contains


### PR DESCRIPTION
Modeled after https://github.com/alpinejs/alpine/pull/469

Lets you do this in ie11:

```html
<div x-data="{show: true}">
  <svg class="w-10 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
    <path x-show="isOpen" fill-rule="evenodd" clip-rule="evenodd" d="M18.278 16.864a1 1 0 0 1-1.414 1.414l-4.829-4.828-4.828 4.828a1 1 0 0 1-1.414-1.414l4.828-4.829-4.828-4.828a1 1 0 0 1 1.414-1.414l4.829 4.828 4.828-4.828a1 1 0 1 1 1.414 1.414l-4.828 4.829 4.828 4.828z"/>
    <path x-show="!isOpen" fill-rule="evenodd" d="M4 5h16a1 1 0 0 1 0 2H4a1 1 0 1 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2z"/>
  </svg>
</div>
```
Here's a pen showing the intent: https://codepen.io/KevinBatdorf/pen/GRoNWVx?editors=1010