### PR TITLE
[Proof of concept]: Alpine Lite

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5515,7 +5515,7 @@
 
     return new Function(['dataContext'].concat(_toConsumableArray(Object.keys(additionalHelperVariables))), "with(dataContext) { ".concat(expression, " }")).apply(void 0, [dataContext].concat(_toConsumableArray(Object.values(additionalHelperVariables))));
   }
-  var xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/;
+  var xAttrRE =  /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/ ;
   function isXAttr(attr) {
     var name = replaceAtAndColonWithStandardSyntax(attr.name);
     return xAttrRE.test(name);
@@ -5528,7 +5528,7 @@
 
       _newArrowCheck(this, _this2);
 
-      if (i.type === 'spread') {
+      if ( i.type === 'spread') {
         var directiveBindings = saferEval(i.expression, component.$data);
         return Object.entries(directiveBindings).map(function (_ref) {
           var _ref2 = _slicedToArray(_ref, 2),
@@ -5576,8 +5576,8 @@
   }
 
   function isBooleanAttr(attrName) {
-    // As per HTML spec table https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute
     // Array roughly ordered by estimated usage
+
     var booleanAttributes = ['disabled', 'checked', 'required', 'readonly', 'hidden', 'open', 'selected', 'autofocus', 'itemscope', 'multiple', 'novalidate', 'allowfullscreen', 'allowpaymentrequest', 'formnovalidate', 'autoplay', 'controls', 'loop', 'muted', 'playsinline', 'default', 'ismap', 'reversed', 'async', 'defer', 'nomodule'];
     return booleanAttributes.includes(attrName);
   }
@@ -5629,7 +5629,7 @@
     var _this6 = this;
 
     var forceSkip = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
-    // We don't want to transition on the initial page load.
+
     if (forceSkip) return hide();
     var attrs = getXAttrs(el, component, 'transition');
     var showAttr = getXAttrs(el, component, 'show')[0];
@@ -6155,7 +6155,7 @@
         if (el.value === value) return;
         el.value = value;
       }
-    } else if (attrName === 'class') {
+    } else if ( attrName === 'class') {
       if (Array.isArray(value)) {
         var originalClasses = el.__x_original_classes || [];
         el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '));
@@ -6368,7 +6368,7 @@
 
     var extraVars = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : {};
 
-    if (modifiers.includes('away')) {
+    if ( modifiers.includes('away')) {
       var _handler = function handler(e) {
         _newArrowCheck(this, _this);
 
@@ -6426,7 +6426,7 @@
         }
       }.bind(this);
 
-      if (modifiers.includes('debounce')) {
+      if ( modifiers.includes('debounce')) {
         var nextModifier = modifiers[modifiers.indexOf('debounce') + 1] || 'invalid-wait';
         var wait = isNumeric(nextModifier.split('ms')[0]) ? Number(nextModifier.split('ms')[0]) : 250;
         _handler2 = debounce(_handler2, wait);
@@ -6461,7 +6461,7 @@
       return !['window', 'document', 'prevent', 'stop'].includes(i);
     }.bind(this));
 
-    if (keyModifiers.includes('debounce')) {
+    if ( keyModifiers.includes('debounce')) {
       var debounceIndex = keyModifiers.indexOf('debounce');
       keyModifiers.splice(debounceIndex, isNumeric((keyModifiers[debounceIndex + 1] || 'invalid-wait').split('ms')[0]) ? 2 : 1);
     } // If no modifier is specified, we'll call it a press.
@@ -6622,8 +6622,9 @@
   });
 
   function wrap(data, mutationCallback) {
-    /* IE11-ONLY:START */
-    return wrapForIe11(data, mutationCallback);
+    {
+      return wrapForIe11(data, mutationCallback);
+    }
   }
   function unwrap(membrane, observable) {
     var _this = this;
@@ -6699,16 +6700,16 @@
       this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, {
         $el: this.$el
       });
-      /* IE11-ONLY:START */
-      // For IE11, add our magic properties to the original data for access.
-      // The Proxy polyfill does not allow properties to be added after creation.
 
-      this.unobservedData.$el = null;
-      this.unobservedData.$refs = null;
-      this.unobservedData.$nextTick = null;
-      this.unobservedData.$watch = null;
-      /* IE11-ONLY:END */
-      // Construct a Proxy-based observable. This will be used to handle reactivity.
+      {
+        // For IE11, add our magic properties to the original data for access.
+        // The Proxy polyfill does not allow properties to be added after creation.
+        this.unobservedData.$el = null;
+        this.unobservedData.$refs = null;
+        this.unobservedData.$nextTick = null;
+        this.unobservedData.$watch = null;
+      } // Construct a Proxy-based observable. This will be used to handle reactivity.
+
 
       var _this$wrapDataInObser = this.wrapDataInObservable(this.unobservedData),
           membrane = _this$wrapDataInObser.membrane,
@@ -7002,7 +7003,10 @@
               break;
 
             case 'model':
-              registerModelListener(this, el, modifiers, expression, extraVars);
+              {
+                registerModelListener(this, el, modifiers, expression, extraVars);
+              }
+
               break;
           }
         }.bind(this));
@@ -7016,7 +7020,7 @@
         var extraVars = arguments.length > 2 ? arguments[2] : undefined;
         var attrs = getXAttrs(el, this);
 
-        if (el.type !== undefined && el.type === 'radio') {
+        if ( el.type !== undefined && el.type === 'radio') {
           // If there's an x-model on a radio input, move it to end of attribute list
           // to ensure that x-bind:value (if present) is processed first.
           var modelIdx = attrs.findIndex(function (attr) {
@@ -7042,12 +7046,15 @@
 
           switch (type) {
             case 'model':
-              handleAttributeBindingDirective(this, el, 'value', expression, extraVars, type);
+              {
+                handleAttributeBindingDirective(this, el, 'value', expression, extraVars, type);
+              }
+
               break;
 
             case 'bind':
               // The :key binding on an x-for is special, ignore it.
-              if (el.tagName.toLowerCase() === 'template' && value === 'key') return;
+              if ( el.tagName.toLowerCase() === 'template' && value === 'key') return;
               handleAttributeBindingDirective(this, el, value, expression, extraVars, type);
               break;
 
@@ -7066,19 +7073,25 @@
               break;
 
             case 'if':
-              // If this element also has x-for on it, don't process x-if.
-              // We will let the "x-for" directive handle the "if"ing.
-              if (attrs.filter(function (i) {
-                _newArrowCheck(this, _this17);
+              {
+                // If this element also has x-for on it, don't process x-if.
+                // We will let the "x-for" directive handle the "if"ing.
+                if (attrs.filter(function (i) {
+                  _newArrowCheck(this, _this17);
 
-                return i.type === 'for';
-              }.bind(this)).length > 0) return;
-              var output = this.evaluateReturnExpression(el, expression, extraVars);
-              handleIfDirective(this, el, output, initialUpdate, extraVars);
+                  return i.type === 'for';
+                }.bind(this)).length > 0) return;
+                var output = this.evaluateReturnExpression(el, expression, extraVars);
+                handleIfDirective(this, el, output, initialUpdate, extraVars);
+              }
+
               break;
 
             case 'for':
-              handleForDirective(this, el, expression, initialUpdate, extraVars);
+              {
+                handleForDirective(this, el, expression, initialUpdate, extraVars);
+              }
+
               break;
 
             case 'cloak':
@@ -7190,25 +7203,25 @@
 
         var self = this;
         var refObj = {};
-        /* IE11-ONLY:START */
-        // Add any properties up-front that might be necessary for the Proxy polyfill.
 
-        refObj.$isRefsProxy = false;
-        refObj.$isAlpineProxy = false; // If we are in IE, since the polyfill needs all properties to be defined before building the proxy,
-        // we just loop on the element, look for any x-ref and create a tmp property on a fake object.
+        {
+          // Add any properties up-front that might be necessary for the Proxy polyfill.
+          refObj.$isRefsProxy = false;
+          refObj.$isAlpineProxy = false; // If we are in IE, since the polyfill needs all properties to be defined before building the proxy,
+          // we just loop on the element, look for any x-ref and create a tmp property on a fake object.
 
-        this.walkAndSkipNestedComponents(self.$el, function (el) {
-          _newArrowCheck(this, _this24);
+          this.walkAndSkipNestedComponents(self.$el, function (el) {
+            _newArrowCheck(this, _this24);
 
-          if (el.hasAttribute('x-ref')) {
-            refObj[el.getAttribute('x-ref')] = true;
-          }
-        }.bind(this));
-        /* IE11-ONLY:END */
-        // One of the goals of this is to not hold elements in memory, but rather re-evaluate
+            if (el.hasAttribute('x-ref')) {
+              refObj[el.getAttribute('x-ref')] = true;
+            }
+          }.bind(this));
+        } // One of the goals of this is to not hold elements in memory, but rather re-evaluate
         // the DOM when the system needs something from it. This way, the framework is flexible and
         // friendly to outside DOM changes from libraries like Vue/Livewire.
         // For this reason, I'm using an "on-demand" proxy to fake a "$refs" object.
+
 
         return new Proxy(refObj, {
           get: function get(object, property) {

--- a/dist/alpine-lite.js
+++ b/dist/alpine-lite.js
@@ -1,0 +1,931 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global = global || self, global.Alpine = factory());
+}(this, (function () { 'use strict';
+
+  function _defineProperty(obj, key, value) {
+    if (key in obj) {
+      Object.defineProperty(obj, key, {
+        value: value,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      });
+    } else {
+      obj[key] = value;
+    }
+
+    return obj;
+  }
+
+  function ownKeys(object, enumerableOnly) {
+    var keys = Object.keys(object);
+
+    if (Object.getOwnPropertySymbols) {
+      var symbols = Object.getOwnPropertySymbols(object);
+      if (enumerableOnly) symbols = symbols.filter(function (sym) {
+        return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+      });
+      keys.push.apply(keys, symbols);
+    }
+
+    return keys;
+  }
+
+  function _objectSpread2(target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i] != null ? arguments[i] : {};
+
+      if (i % 2) {
+        ownKeys(Object(source), true).forEach(function (key) {
+          _defineProperty(target, key, source[key]);
+        });
+      } else if (Object.getOwnPropertyDescriptors) {
+        Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+      } else {
+        ownKeys(Object(source)).forEach(function (key) {
+          Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+        });
+      }
+    }
+
+    return target;
+  }
+
+  // Thanks @stimulus:
+  // https://github.com/stimulusjs/stimulus/blob/master/packages/%40stimulus/core/src/application.ts
+  function domReady() {
+    return new Promise(resolve => {
+      if (document.readyState == "loading") {
+        document.addEventListener("DOMContentLoaded", resolve);
+      } else {
+        resolve();
+      }
+    });
+  }
+  function isTesting() {
+    return navigator.userAgent.includes("Node.js") || navigator.userAgent.includes("jsdom");
+  }
+  function kebabCase(subject) {
+    return subject.replace(/([a-z])([A-Z])/g, '$1-$2').replace(/[_\s]/, '-').toLowerCase();
+  }
+  function walk(el, callback) {
+    if (callback(el) === false) return;
+    let node = el.firstElementChild;
+
+    while (node) {
+      walk(node, callback);
+      node = node.nextElementSibling;
+    }
+  }
+  function debounce(func, wait) {
+    var timeout;
+    return function () {
+      var context = this,
+          args = arguments;
+
+      var later = function later() {
+        timeout = null;
+        func.apply(context, args);
+      };
+
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+  function saferEval(expression, dataContext, additionalHelperVariables = {}) {
+    if (typeof expression === 'function') {
+      return expression.call(dataContext);
+    }
+
+    return new Function(['$data', ...Object.keys(additionalHelperVariables)], `var __alpine_result; with($data) { __alpine_result = ${expression} }; return __alpine_result`)(dataContext, ...Object.values(additionalHelperVariables));
+  }
+  function saferEvalNoReturn(expression, dataContext, additionalHelperVariables = {}) {
+    if (typeof expression === 'function') {
+      return expression.call(dataContext);
+    } // For the cases when users pass only a function reference to the caller: `x-on:click="foo"`
+    // Where "foo" is a function. Also, we'll pass the function the event instance when we call it.
+
+
+    if (Object.keys(dataContext).includes(expression)) {
+      let methodReference = new Function(['dataContext', ...Object.keys(additionalHelperVariables)], `with(dataContext) { return ${expression} }`)(dataContext, ...Object.values(additionalHelperVariables));
+
+      if (typeof methodReference === 'function') {
+        return methodReference.call(dataContext, additionalHelperVariables['$event']);
+      }
+    }
+
+    return new Function(['dataContext', ...Object.keys(additionalHelperVariables)], `with(dataContext) { ${expression} }`)(dataContext, ...Object.values(additionalHelperVariables));
+  }
+  const xAttrRE =  /^x-(on|bind|data|text|html|show|cloak|ref)\b/;
+  function isXAttr(attr) {
+    const name = replaceAtAndColonWithStandardSyntax(attr.name);
+    return xAttrRE.test(name);
+  }
+  function getXAttrs(el, component, type) {
+    return Array.from(el.attributes).filter(isXAttr).map(parseHtmlAttribute).flatMap(i => {
+      {
+        return i;
+      }
+    }).filter(i => {
+      // If no type is passed in for filtering, bypass filter
+      if (!type) return true;
+      return i.type === type;
+    });
+  }
+
+  function parseHtmlAttribute({
+    name,
+    value
+  }) {
+    const normalizedName = replaceAtAndColonWithStandardSyntax(name);
+    const typeMatch = normalizedName.match(xAttrRE);
+    const valueMatch = normalizedName.match(/:([a-zA-Z\-:]+)/);
+    const modifiers = normalizedName.match(/\.[^.\]]+(?=[^\]]*$)/g) || [];
+    return {
+      type: typeMatch ? typeMatch[1] : null,
+      value: valueMatch ? valueMatch[1] : null,
+      modifiers: modifiers.map(i => i.replace('.', '')),
+      expression: value
+    };
+  }
+
+  function isBooleanAttr(attrName) {
+    return false; // As per HTML spec table https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute
+  }
+  function replaceAtAndColonWithStandardSyntax(name) {
+    if (name.startsWith('@')) {
+      return name.replace('@', 'x-on:');
+    } else if (name.startsWith(':')) {
+      return name.replace(':', 'x-bind:');
+    }
+
+    return name;
+  }
+  function convertClassStringToArray(classList, filterFn = Boolean) {
+    return classList.split(' ').filter(filterFn);
+  }
+  function transitionIn(el, show, component, forceSkip = false) {
+    return show();
+  }
+  function transitionOut(el, hide, component, forceSkip = false) {
+    return hide(); // We don't want to transition on the initial page load.
+  }
+
+  function handleAttributeBindingDirective(component, el, attrName, expression, extraVars, attrType) {
+    var value = component.evaluateReturnExpression(el, expression, extraVars);
+
+    if (attrName === 'value') {
+      // If nested model key is undefined, set the default value to empty string.
+      if (value === undefined && expression.match(/\./).length) {
+        value = '';
+      }
+
+      if (el.type === 'radio') {
+        // Set radio value from x-bind:value, if no "value" attribute exists.
+        // If there are any initial state values, radio will have a correct
+        // "checked" value since x-bind:value is processed before x-model.
+        if (el.attributes.value === undefined && attrType === 'bind') {
+          el.value = value;
+        } else if (attrType !== 'bind') {
+          el.checked = el.value == value;
+        }
+      } else if (el.type === 'checkbox') {
+        // If we are explicitly binding a string to the :value, set the string,
+        // If the value is a boolean, leave it alone, it will be set to "on"
+        // automatically.
+        if (typeof value === 'string' && attrType === 'bind') {
+          el.value = value;
+        } else if (attrType !== 'bind') {
+          if (Array.isArray(value)) {
+            // I'm purposely not using Array.includes here because it's
+            // strict, and because of Numeric/String mis-casting, I
+            // want the "includes" to be "fuzzy".
+            el.checked = value.some(val => val == el.value);
+          } else {
+            el.checked = !!value;
+          }
+        }
+      } else if (el.tagName === 'SELECT') {
+        updateSelect(el, value);
+      } else {
+        if (el.value === value) return;
+        el.value = value;
+      }
+    } else {
+      // If an attribute's bound value is null, undefined or false, remove the attribute
+      if ([null, undefined, false].includes(value)) {
+        el.removeAttribute(attrName);
+      } else {
+        isBooleanAttr() ? setIfChanged(el, attrName, attrName) : setIfChanged(el, attrName, value);
+      }
+    }
+  }
+
+  function setIfChanged(el, attrName, value) {
+    if (el.getAttribute(attrName) != value) {
+      el.setAttribute(attrName, value);
+    }
+  }
+
+  function updateSelect(el, value) {
+    const arrayWrappedValue = [].concat(value).map(value => {
+      return value + '';
+    });
+    Array.from(el.options).forEach(option => {
+      option.selected = arrayWrappedValue.includes(option.value || option.text);
+    });
+  }
+
+  function handleTextDirective(el, output, expression) {
+    // If nested model key is undefined, set the default value to empty string.
+    if (output === undefined && expression.match(/\./).length) {
+      output = '';
+    }
+
+    el.innerText = output;
+  }
+
+  function handleHtmlDirective(component, el, expression, extraVars) {
+    el.innerHTML = component.evaluateReturnExpression(el, expression, extraVars);
+  }
+
+  function handleShowDirective(component, el, value, modifiers, initialUpdate = false) {
+    // if value is changed resolve any previous pending transitions before starting a new one.
+    if (el.__x_transition_remaining && el.__x_transition_last_value !== value) {
+      el.__x_transition_remaining();
+    }
+
+    const hide = () => {
+      el.style.display = 'none';
+    };
+
+    const show = () => {
+      if (el.style.length === 1 && el.style.display === 'none') {
+        el.removeAttribute('style');
+      } else {
+        el.style.removeProperty('display');
+      }
+    };
+
+    if (initialUpdate === true) {
+      // Assign current value to el to check later on for preventing transition overlaps.
+      el.__x_transition_last_value = value;
+
+      if (value) {
+        show();
+      } else {
+        hide();
+      }
+
+      return;
+    }
+
+    const handle = resolve => {
+      if (value) {
+        transitionIn(el, () => {
+          show();
+        });
+        resolve(() => {});
+      } else {
+        if (el.style.display !== 'none') {
+          transitionOut(el, () => {
+            resolve(() => {
+              hide();
+            });
+          });
+        } else {
+          resolve(() => {});
+        }
+      } // Assign current value to el.
+
+
+      el.__x_transition_last_value = value;
+    }; // The working of x-show is a bit complex because we need to
+    // wait for any child transitions to finish before hiding
+    // some element. Also, this has to be done recursively.
+    // If x-show.immediate, foregoe the waiting.
+
+
+    if (modifiers.includes('immediate')) {
+      handle(finish => finish());
+      return;
+    } // x-show is encountered during a DOM tree walk. If an element
+    // we encounter is NOT a child of another x-show element we
+    // can execute the previous x-show stack (if one exists).
+
+
+    if (component.showDirectiveLastElement && !component.showDirectiveLastElement.contains(el)) {
+      component.executeAndClearRemainingShowDirectiveStack();
+    }
+
+    if (el.__x_transition_last_value !== value) {
+      // We'll push the handler onto a stack to be handled later.
+      component.showDirectiveStack.push(handle);
+      component.showDirectiveLastElement = el;
+    }
+  }
+
+  function registerListener(component, el, event, modifiers, expression, extraVars = {}) {
+    {
+      let listenerTarget = modifiers.includes('window') ? window : modifiers.includes('document') ? document : el;
+
+      let handler = e => {
+        // Remove this global event handler if the element that declared it
+        // has been removed. It's now stale.
+        if (listenerTarget === window || listenerTarget === document) {
+          if (!document.body.contains(el)) {
+            listenerTarget.removeEventListener(event, handler);
+            return;
+          }
+        }
+
+        if (isKeyEvent(event)) {
+          if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
+            return;
+          }
+        }
+
+        if (modifiers.includes('prevent')) e.preventDefault();
+        if (modifiers.includes('stop')) e.stopPropagation(); // If the .self modifier isn't present, or if it is present and
+        // the target element matches the element we are registering the
+        // event on, run the handler
+
+        if (!modifiers.includes('self') || e.target === el) {
+          const returnValue = runListenerHandler(component, expression, e, extraVars);
+
+          if (returnValue === false) {
+            e.preventDefault();
+          } else {
+            if (modifiers.includes('once')) {
+              listenerTarget.removeEventListener(event, handler);
+            }
+          }
+        }
+      };
+
+      listenerTarget.addEventListener(event, handler);
+    }
+  }
+
+  function runListenerHandler(component, expression, e, extraVars) {
+    return component.evaluateCommandExpression(e.target, expression, () => {
+      return _objectSpread2({}, extraVars(), {
+        '$event': e
+      });
+    });
+  }
+
+  function isKeyEvent(event) {
+    return ['keydown', 'keyup'].includes(event);
+  }
+
+  function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
+    let keyModifiers = modifiers.filter(i => {
+      return !['window', 'document', 'prevent', 'stop'].includes(i);
+    });
+
+
+    if (keyModifiers.length === 0) return false; // If one is passed, AND it matches the key pressed, we'll call it a press.
+
+    if (keyModifiers.length === 1 && keyModifiers[0] === keyToModifier(e.key)) return false; // The user is listening for key combinations.
+
+    const systemKeyModifiers = ['ctrl', 'shift', 'alt', 'meta', 'cmd', 'super'];
+    const selectedSystemKeyModifiers = systemKeyModifiers.filter(modifier => keyModifiers.includes(modifier));
+    keyModifiers = keyModifiers.filter(i => !selectedSystemKeyModifiers.includes(i));
+
+    if (selectedSystemKeyModifiers.length > 0) {
+      const activelyPressedKeyModifiers = selectedSystemKeyModifiers.filter(modifier => {
+        // Alias "cmd" and "super" to "meta"
+        if (modifier === 'cmd' || modifier === 'super') modifier = 'meta';
+        return e[`${modifier}Key`];
+      }); // If all the modifiers selected are pressed, ...
+
+      if (activelyPressedKeyModifiers.length === selectedSystemKeyModifiers.length) {
+        // AND the remaining key is pressed as well. It's a press.
+        if (keyModifiers[0] === keyToModifier(e.key)) return false;
+      }
+    } // We'll call it NOT a valid keypress.
+
+
+    return true;
+  }
+
+  function keyToModifier(key) {
+    switch (key) {
+      case '/':
+        return 'slash';
+
+      case ' ':
+      case 'Spacebar':
+        return 'space';
+
+      default:
+        return key && kebabCase(key);
+    }
+  }
+
+  function wrap(data, mutationCallback) {
+    {
+      return wrapForIe11(data, mutationCallback);
+    }
+  }
+  function unwrap(membrane, observable) {
+    let unwrappedData = membrane.unwrapProxy(observable);
+    let copy = {};
+    Object.keys(unwrappedData).forEach(key => {
+      if (['$el', '$refs', '$nextTick', '$watch'].includes(key)) return;
+      copy[key] = unwrappedData[key];
+    });
+    return copy;
+  }
+
+  function wrapForIe11(data, mutationCallback) {
+    const proxyHandler = {
+      set(target, key, value) {
+        // Set the value converting it to a "Deep Proxy" when required
+        // Note that if a project is not a valid object, it won't be converted to a proxy
+        const setWasSuccessful = Reflect.set(target, key, deepProxy(value, proxyHandler));
+        mutationCallback(target, key);
+        return setWasSuccessful;
+      },
+
+      get(target, key) {
+        // Provide a way to determine if this object is an Alpine proxy or not.
+        if (key === "$isAlpineProxy") return true; // Just return the flippin' value. Gawsh.
+
+        return target[key];
+      }
+
+    };
+    return {
+      data: deepProxy(data, proxyHandler),
+      membrane: {
+        unwrapProxy(proxy) {
+          return proxy;
+        }
+
+      }
+    };
+  }
+
+  function deepProxy(target, proxyHandler) {
+    // If target is null, return it.
+    if (target === null) return target; // If target is not an object, return it.
+
+    if (typeof target !== 'object') return target; // If target is a DOM node (like in the case of this.$el), return it.
+
+    if (target instanceof Node) return target; // If target is already an Alpine proxy, return it.
+
+    if (target['$isAlpineProxy']) return target; // Otherwise proxy the properties recursively.
+    // This enables reactivity on setting nested data.
+    // Note that if a project is not a valid object, it won't be converted to a proxy
+
+    for (let property in target) {
+      target[property] = deepProxy(target[property], proxyHandler);
+    }
+
+    return new Proxy(target, proxyHandler);
+  }
+
+  class Component {
+    constructor(el, seedDataForCloning = null) {
+      this.$el = el;
+      const dataAttr = this.$el.getAttribute('x-data');
+      const dataExpression = dataAttr === '' ? '{}' : dataAttr;
+      const initExpression = this.$el.getAttribute('x-init');
+      this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, {
+        $el: this.$el
+      });
+
+
+      let {
+        membrane,
+        data
+      } = this.wrapDataInObservable(this.unobservedData);
+      this.$data = data;
+      this.membrane = membrane; // After making user-supplied data methods reactive, we can now add
+      // our magic properties to the original data for access.
+
+      this.unobservedData.$el = this.$el;
+      this.unobservedData.$refs = this.getRefsProxy();
+      this.nextTickStack = [];
+
+      this.unobservedData.$nextTick = callback => {
+        this.nextTickStack.push(callback);
+      };
+
+      this.watchers = {};
+
+      this.unobservedData.$watch = (property, callback) => {
+        if (!this.watchers[property]) this.watchers[property] = [];
+        this.watchers[property].push(callback);
+      };
+
+      this.showDirectiveStack = [];
+      this.showDirectiveLastElement;
+      var initReturnedCallback; // If x-init is present AND we aren't cloning (skip x-init on clone)
+
+      if (initExpression && !seedDataForCloning) {
+        // We want to allow data manipulation, but not trigger DOM updates just yet.
+        // We haven't even initialized the elements with their Alpine bindings. I mean c'mon.
+        this.pauseReactivity = true;
+        initReturnedCallback = this.evaluateReturnExpression(this.$el, initExpression);
+        this.pauseReactivity = false;
+      } // Register all our listeners and set all our attribute bindings.
+
+
+      this.initializeElements(this.$el); // Use mutation observer to detect new elements being added within this component at run-time.
+      // Alpine's just so darn flexible amirite?
+
+      this.listenForNewElementsToInitialize();
+
+      if (typeof initReturnedCallback === 'function') {
+        // Run the callback returned from the "x-init" hook to allow the user to do stuff after
+        // Alpine's got it's grubby little paws all over everything.
+        initReturnedCallback.call(this.$data);
+      }
+    }
+
+    getUnobservedData() {
+      return unwrap(this.membrane, this.$data);
+    }
+
+    wrapDataInObservable(data) {
+      var self = this;
+      let updateDom = debounce(function () {
+        self.updateElements(self.$el);
+      }, 0);
+      return wrap(data, (target, key) => {
+        if (self.watchers[key]) {
+          // If there's a watcher for this specific key, run it.
+          self.watchers[key].forEach(callback => callback(target[key]));
+        } else {
+          // Let's walk through the watchers with "dot-notation" (foo.bar) and see
+          // if this mutation fits any of them.
+          Object.keys(self.watchers).filter(i => i.includes('.')).forEach(fullDotNotationKey => {
+            let dotNotationParts = fullDotNotationKey.split('.'); // If this dot-notation watcher's last "part" doesn't match the current
+            // key, then skip it early for performance reasons.
+
+            if (key !== dotNotationParts[dotNotationParts.length - 1]) return; // Now, walk through the dot-notation "parts" recursively to find
+            // a match, and call the watcher if one's found.
+
+            dotNotationParts.reduce((comparisonData, part) => {
+              if (Object.is(target, comparisonData)) {
+                // Run the watchers.
+                self.watchers[fullDotNotationKey].forEach(callback => callback(target[key]));
+              }
+
+              return comparisonData[part];
+            }, self.getUnobservedData());
+          });
+        } // Don't react to data changes for cases like the `x-created` hook.
+
+
+        if (self.pauseReactivity) return;
+        updateDom();
+      });
+    }
+
+    walkAndSkipNestedComponents(el, callback, initializeComponentCallback = () => {}) {
+      walk(el, el => {
+        // We've hit a component.
+        if (el.hasAttribute('x-data')) {
+          // If it's not the current one.
+          if (!el.isSameNode(this.$el)) {
+            // Initialize it if it's not.
+            if (!el.__x) initializeComponentCallback(el); // Now we'll let that sub-component deal with itself.
+
+            return false;
+          }
+        }
+
+        return callback(el);
+      });
+    }
+
+    initializeElements(rootEl, extraVars = () => {}) {
+      this.walkAndSkipNestedComponents(rootEl, el => {
+        // Don't touch spawns from for loop
+        if (el.__x_for_key !== undefined) return false; // Don't touch spawns from if directives
+
+        if (el.__x_inserted_me !== undefined) return false;
+        this.initializeElement(el, extraVars);
+      }, el => {
+        el.__x = new Component(el);
+      });
+      this.executeAndClearRemainingShowDirectiveStack();
+      this.executeAndClearNextTickStack(rootEl);
+    }
+
+    initializeElement(el, extraVars) {
+      // To support class attribute merging, we have to know what the element's
+      // original class attribute looked like for reference.
+      if (el.hasAttribute('class') && getXAttrs(el).length > 0) {
+        el.__x_original_classes = convertClassStringToArray(el.getAttribute('class'));
+      }
+
+      this.registerListeners(el, extraVars);
+      this.resolveBoundAttributes(el, true, extraVars);
+    }
+
+    updateElements(rootEl, extraVars = () => {}) {
+      this.walkAndSkipNestedComponents(rootEl, el => {
+        // Don't touch spawns from for loop (and check if the root is actually a for loop in a parent, don't skip it.)
+        if (el.__x_for_key !== undefined && !el.isSameNode(this.$el)) return false;
+        this.updateElement(el, extraVars);
+      }, el => {
+        el.__x = new Component(el);
+      });
+      this.executeAndClearRemainingShowDirectiveStack();
+      this.executeAndClearNextTickStack(rootEl);
+    }
+
+    executeAndClearNextTickStack(el) {
+      // Skip spawns from alpine directives
+      if (el === this.$el && this.nextTickStack.length > 0) {
+        // We run the tick stack after the next frame to allow any
+        // running transitions to pass the initial show stage.
+        requestAnimationFrame(() => {
+          while (this.nextTickStack.length > 0) {
+            this.nextTickStack.shift()();
+          }
+        });
+      }
+    }
+
+    executeAndClearRemainingShowDirectiveStack() {
+      // The goal here is to start all the x-show transitions
+      // and build a nested promise chain so that elements
+      // only hide when the children are finished hiding.
+      this.showDirectiveStack.reverse().map(thing => {
+        return new Promise(resolve => {
+          thing(finish => {
+            resolve(finish);
+          });
+        });
+      }).reduce((nestedPromise, promise) => {
+        return nestedPromise.then(() => {
+          return promise.then(finish => finish());
+        });
+      }, Promise.resolve(() => {})); // We've processed the handler stack. let's clear it.
+
+      this.showDirectiveStack = [];
+      this.showDirectiveLastElement = undefined;
+    }
+
+    updateElement(el, extraVars) {
+      this.resolveBoundAttributes(el, false, extraVars);
+    }
+
+    registerListeners(el, extraVars) {
+      getXAttrs(el).forEach(({
+        type,
+        value,
+        modifiers,
+        expression
+      }) => {
+        switch (type) {
+          case 'on':
+            registerListener(this, el, value, modifiers, expression, extraVars);
+            break;
+        }
+      });
+    }
+
+    resolveBoundAttributes(el, initialUpdate = false, extraVars) {
+      let attrs = getXAttrs(el);
+
+      attrs.forEach(({
+        type,
+        value,
+        modifiers,
+        expression
+      }) => {
+        switch (type) {
+          case 'model':
+
+            break;
+
+          case 'bind':
+            handleAttributeBindingDirective(this, el, value, expression, extraVars, type);
+            break;
+
+          case 'text':
+            var output = this.evaluateReturnExpression(el, expression, extraVars);
+            handleTextDirective(el, output, expression);
+            break;
+
+          case 'html':
+            handleHtmlDirective(this, el, expression, extraVars);
+            break;
+
+          case 'show':
+            var output = this.evaluateReturnExpression(el, expression, extraVars);
+            handleShowDirective(this, el, output, modifiers, initialUpdate);
+            break;
+
+          case 'if':
+            if (false) {
+              var output;
+            }
+
+            break;
+
+          case 'for':
+
+            break;
+
+          case 'cloak':
+            el.removeAttribute('x-cloak');
+            break;
+        }
+      });
+    }
+
+    evaluateReturnExpression(el, expression, extraVars = () => {}) {
+      return saferEval(expression, this.$data, _objectSpread2({}, extraVars(), {
+        $dispatch: this.getDispatchFunction(el)
+      }));
+    }
+
+    evaluateCommandExpression(el, expression, extraVars = () => {}) {
+      return saferEvalNoReturn(expression, this.$data, _objectSpread2({}, extraVars(), {
+        $dispatch: this.getDispatchFunction(el)
+      }));
+    }
+
+    getDispatchFunction(el) {
+      return (event, detail = {}) => {
+        el.dispatchEvent(new CustomEvent(event, {
+          detail,
+          bubbles: true
+        }));
+      };
+    }
+
+    listenForNewElementsToInitialize() {
+      const targetNode = this.$el;
+      const observerOptions = {
+        childList: true,
+        attributes: true,
+        subtree: true
+      };
+      const observer = new MutationObserver(mutations => {
+        for (let i = 0; i < mutations.length; i++) {
+          // Filter out mutations triggered from child components.
+          const closestParentComponent = mutations[i].target.closest('[x-data]');
+          if (!(closestParentComponent && closestParentComponent.isSameNode(this.$el))) continue;
+
+          if (mutations[i].type === 'attributes' && mutations[i].attributeName === 'x-data') {
+            const rawData = saferEval(mutations[i].target.getAttribute('x-data'), {
+              $el: this.$el
+            });
+            Object.keys(rawData).forEach(key => {
+              if (this.$data[key] !== rawData[key]) {
+                this.$data[key] = rawData[key];
+              }
+            });
+          }
+
+          if (mutations[i].addedNodes.length > 0) {
+            mutations[i].addedNodes.forEach(node => {
+              if (node.nodeType !== 1 || node.__x_inserted_me) return;
+
+              if (node.matches('[x-data]') && !node.__x) {
+                node.__x = new Component(node);
+                return;
+              }
+
+              this.initializeElements(node);
+            });
+          }
+        }
+      });
+      observer.observe(targetNode, observerOptions);
+    }
+
+    getRefsProxy() {
+      var self = this;
+      var refObj = {};
+      // the DOM when the system needs something from it. This way, the framework is flexible and
+      // friendly to outside DOM changes from libraries like Vue/Livewire.
+      // For this reason, I'm using an "on-demand" proxy to fake a "$refs" object.
+
+
+      return new Proxy(refObj, {
+        get(object, property) {
+          if (property === '$isAlpineProxy') return true;
+          var ref; // We can't just query the DOM because it's hard to filter out refs in
+          // nested components.
+
+          self.walkAndSkipNestedComponents(self.$el, el => {
+            if (el.hasAttribute('x-ref') && el.getAttribute('x-ref') === property) {
+              ref = el;
+            }
+          });
+          return ref;
+        }
+
+      });
+    }
+
+  }
+
+  const Alpine = {
+    version: "2.3.5",
+    pauseMutationObserver: false,
+    start: async function start() {
+      if (!isTesting()) {
+        await domReady();
+      }
+
+      this.discoverComponents(el => {
+        this.initializeComponent(el);
+      }); // It's easier and more performant to just support Turbolinks than listen
+      // to MutationObserver mutations at the document level.
+
+      document.addEventListener("turbolinks:load", () => {
+        this.discoverUninitializedComponents(el => {
+          this.initializeComponent(el);
+        });
+      });
+      this.listenForNewUninitializedComponentsAtRunTime(el => {
+        this.initializeComponent(el);
+      });
+    },
+    discoverComponents: function discoverComponents(callback) {
+      const rootEls = document.querySelectorAll('[x-data]');
+      rootEls.forEach(rootEl => {
+        callback(rootEl);
+      });
+    },
+    discoverUninitializedComponents: function discoverUninitializedComponents(callback, el = null) {
+      const rootEls = (el || document).querySelectorAll('[x-data]');
+      Array.from(rootEls).filter(el => el.__x === undefined).forEach(rootEl => {
+        callback(rootEl);
+      });
+    },
+    listenForNewUninitializedComponentsAtRunTime: function listenForNewUninitializedComponentsAtRunTime(callback) {
+      const targetNode = document.querySelector('body');
+      const observerOptions = {
+        childList: true,
+        attributes: true,
+        subtree: true
+      };
+      const observer = new MutationObserver(mutations => {
+        if (this.pauseMutationObserver) return;
+
+        for (let i = 0; i < mutations.length; i++) {
+          if (mutations[i].addedNodes.length > 0) {
+            mutations[i].addedNodes.forEach(node => {
+              // Discard non-element nodes (like line-breaks)
+              if (node.nodeType !== 1) return; // Discard any changes happening within an existing component.
+              // They will take care of themselves.
+
+              if (node.parentElement && node.parentElement.closest('[x-data]')) return;
+              this.discoverUninitializedComponents(el => {
+                this.initializeComponent(el);
+              }, node.parentElement);
+            });
+          }
+        }
+      });
+      observer.observe(targetNode, observerOptions);
+    },
+    initializeComponent: function initializeComponent(el) {
+      if (!el.__x) {
+        // Wrap in a try/catch so that we don't prevent other components
+        // from initializing when one component contains an error.
+        try {
+          el.__x = new Component(el);
+        } catch (error) {
+          setTimeout(() => {
+            throw error;
+          }, 0);
+        }
+      }
+    },
+    clone: function clone(component, newEl) {
+      if (!newEl.__x) {
+        newEl.__x = new Component(newEl, component.getUnobservedData());
+      }
+    }
+  };
+
+  if (!isTesting()) {
+    window.Alpine = Alpine;
+
+    if (window.deferLoadingAlpine) {
+      window.deferLoadingAlpine(function () {
+        window.Alpine.start();
+      });
+    } else {
+      window.Alpine.start();
+    }
+  }
+
+  return Alpine;
+
+})));

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -128,14 +128,14 @@
 
     return new Function(['dataContext', ...Object.keys(additionalHelperVariables)], `with(dataContext) { ${expression} }`)(dataContext, ...Object.values(additionalHelperVariables));
   }
-  const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/;
+  const xAttrRE =  /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/ ;
   function isXAttr(attr) {
     const name = replaceAtAndColonWithStandardSyntax(attr.name);
     return xAttrRE.test(name);
   }
   function getXAttrs(el, component, type) {
     return Array.from(el.attributes).filter(isXAttr).map(parseHtmlAttribute).flatMap(i => {
-      if (i.type === 'spread') {
+      if ( i.type === 'spread') {
         let directiveBindings = saferEval(i.expression, component.$data);
         return Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({
           name,
@@ -168,8 +168,8 @@
   }
 
   function isBooleanAttr(attrName) {
-    // As per HTML spec table https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute
     // Array roughly ordered by estimated usage
+
     const booleanAttributes = ['disabled', 'checked', 'required', 'readonly', 'hidden', 'open', 'selected', 'autofocus', 'itemscope', 'multiple', 'novalidate', 'allowfullscreen', 'allowpaymentrequest', 'formnovalidate', 'autoplay', 'controls', 'loop', 'muted', 'playsinline', 'default', 'ismap', 'reversed', 'async', 'defer', 'nomodule'];
     return booleanAttributes.includes(attrName);
   }
@@ -206,7 +206,7 @@
     }
   }
   function transitionOut(el, hide, component, forceSkip = false) {
-    // We don't want to transition on the initial page load.
+
     if (forceSkip) return hide();
     const attrs = getXAttrs(el, component, 'transition');
     const showAttr = getXAttrs(el, component, 'show')[0];
@@ -601,7 +601,7 @@
         if (el.value === value) return;
         el.value = value;
       }
-    } else if (attrName === 'class') {
+    } else if ( attrName === 'class') {
       if (Array.isArray(value)) {
         const originalClasses = el.__x_original_classes || [];
         el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '));
@@ -753,7 +753,7 @@
   }
 
   function registerListener(component, el, event, modifiers, expression, extraVars = {}) {
-    if (modifiers.includes('away')) {
+    if ( modifiers.includes('away')) {
       let handler = e => {
         // Don't do anything if the click came form the element or within it.
         if (el.contains(e.target)) return; // Don't do anything if this element isn't currently visible.
@@ -807,7 +807,7 @@
         }
       };
 
-      if (modifiers.includes('debounce')) {
+      if ( modifiers.includes('debounce')) {
         let nextModifier = modifiers[modifiers.indexOf('debounce') + 1] || 'invalid-wait';
         let wait = isNumeric(nextModifier.split('ms')[0]) ? Number(nextModifier.split('ms')[0]) : 250;
         handler = debounce(handler, wait);
@@ -834,7 +834,7 @@
       return !['window', 'document', 'prevent', 'stop'].includes(i);
     });
 
-    if (keyModifiers.includes('debounce')) {
+    if ( keyModifiers.includes('debounce')) {
       let debounceIndex = keyModifiers.indexOf('debounce');
       keyModifiers.splice(debounceIndex, isNumeric((keyModifiers[debounceIndex + 1] || 'invalid-wait').split('ms')[0]) ? 2 : 1);
     } // If no modifier is specified, we'll call it a press.
@@ -1338,7 +1338,7 @@
       this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, {
         $el: this.$el
       });
-      // Construct a Proxy-based observable. This will be used to handle reactivity.
+
 
       let {
         membrane,
@@ -1532,7 +1532,10 @@
             break;
 
           case 'model':
-            registerModelListener(this, el, modifiers, expression, extraVars);
+            {
+              registerModelListener(this, el, modifiers, expression, extraVars);
+            }
+
             break;
         }
       });
@@ -1541,7 +1544,7 @@
     resolveBoundAttributes(el, initialUpdate = false, extraVars) {
       let attrs = getXAttrs(el, this);
 
-      if (el.type !== undefined && el.type === 'radio') {
+      if ( el.type !== undefined && el.type === 'radio') {
         // If there's an x-model on a radio input, move it to end of attribute list
         // to ensure that x-bind:value (if present) is processed first.
         const modelIdx = attrs.findIndex(attr => attr.type === 'model');
@@ -1559,12 +1562,15 @@
       }) => {
         switch (type) {
           case 'model':
-            handleAttributeBindingDirective(this, el, 'value', expression, extraVars, type);
+            {
+              handleAttributeBindingDirective(this, el, 'value', expression, extraVars, type);
+            }
+
             break;
 
           case 'bind':
             // The :key binding on an x-for is special, ignore it.
-            if (el.tagName.toLowerCase() === 'template' && value === 'key') return;
+            if ( el.tagName.toLowerCase() === 'template' && value === 'key') return;
             handleAttributeBindingDirective(this, el, value, expression, extraVars, type);
             break;
 
@@ -1583,15 +1589,21 @@
             break;
 
           case 'if':
-            // If this element also has x-for on it, don't process x-if.
-            // We will let the "x-for" directive handle the "if"ing.
-            if (attrs.filter(i => i.type === 'for').length > 0) return;
-            var output = this.evaluateReturnExpression(el, expression, extraVars);
-            handleIfDirective(this, el, output, initialUpdate, extraVars);
+            {
+              // If this element also has x-for on it, don't process x-if.
+              // We will let the "x-for" directive handle the "if"ing.
+              if (attrs.filter(i => i.type === 'for').length > 0) return;
+              var output = this.evaluateReturnExpression(el, expression, extraVars);
+              handleIfDirective(this, el, output, initialUpdate, extraVars);
+            }
+
             break;
 
           case 'for':
-            handleForDirective(this, el, expression, initialUpdate, extraVars);
+            {
+              handleForDirective(this, el, expression, initialUpdate, extraVars);
+            }
+
             break;
 
           case 'cloak':
@@ -1666,10 +1678,10 @@
     getRefsProxy() {
       var self = this;
       var refObj = {};
-      // One of the goals of this is to not hold elements in memory, but rather re-evaluate
       // the DOM when the system needs something from it. This way, the framework is flexible and
       // friendly to outside DOM changes from libraries like Vue/Livewire.
       // For this reason, I'm using an "on-demand" proxy to fake a "$refs" object.
+
 
       return new Proxy(refObj, {
         get(object, property) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7459,76 +7459,6 @@
                 "rollup-pluginutils": "^2.8.1"
             }
         },
-        "rollup-plugin-strip-code": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-strip-code/-/rollup-plugin-strip-code-0.2.7.tgz",
-            "integrity": "sha512-+5t9u/VrHPSfiRWWKMVin+KOtFwFak337FAZxeTjxYDjB3DDoHBQRkXHQvBn713eAfW81t41mGuysqsMXiuTjw==",
-            "dev": true,
-            "requires": {
-                "magic-string": "0.25.3",
-                "rollup-pluginutils": "2.8.1"
-            },
-            "dependencies": {
-                "estree-walker": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-                    "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-                    "dev": true
-                },
-                "magic-string": {
-                    "version": "0.25.3",
-                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
-                    "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-                    "dev": true,
-                    "requires": {
-                        "sourcemap-codec": "^1.4.4"
-                    }
-                },
-                "rollup-pluginutils": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-                    "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
-                    "dev": true,
-                    "requires": {
-                        "estree-walker": "^0.6.1"
-                    }
-                }
-            }
-        },
-        "rollup-plugin-terser": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-            "integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "jest-worker": "^24.9.0",
-                "rollup-pluginutils": "^2.8.2",
-                "serialize-javascript": "^2.1.2",
-                "terser": "^4.6.2"
-            },
-            "dependencies": {
-                "jest-worker": {
-                    "version": "24.9.0",
-                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-                    "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-                    "dev": true,
-                    "requires": {
-                        "merge-stream": "^2.0.0",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "rollup-pluginutils": {
             "version": "2.8.2",
             "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -7736,12 +7666,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
-        },
-        "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
             "dev": true
         },
         "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "watch": "rollup -c -w",
-        "build": "concurrently \"rollup -c\" \"npx rollup -c rollup-ie11.config.js\"",
+        "build": "concurrently \"rollup -c\" \"rollup -c rollup-ie11.config.js\" \"rollup -c rollup-lite.config.js\"",
         "test": "npx jest",
         "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
     },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-filesize": "^6.2.1",
         "rollup-plugin-node-resolve": "^5.2.0",
-        "rollup-plugin-strip-code": "^0.2.7",
-        "rollup-plugin-terser": "^5.3.0",
         "shim-selected-options": "^1.0.1"
     },
     "dependencies": {}

--- a/rollup-ie11.config.js
+++ b/rollup-ie11.config.js
@@ -20,7 +20,8 @@ export default {
             // 'observable-membrane' uses process.env. We don't have that...
             "process.env.NODE_ENV": "'production'",
             // inject Alpine.js package version number
-            "process.env.PKG_VERSION": `"${pkg.version}"`
+            "process.env.PKG_VERSION": `"${pkg.version}"`,
+            "process.env.IE11_ONLY": "true"
         }),
         resolve(),
         filesize(),

--- a/rollup-ie11.config.js
+++ b/rollup-ie11.config.js
@@ -21,6 +21,7 @@ export default {
             "process.env.NODE_ENV": "'production'",
             // inject Alpine.js package version number
             "process.env.PKG_VERSION": `"${pkg.version}"`,
+            "process.env.LITE": "false",
             "process.env.IE11_ONLY": "true"
         }),
         resolve(),

--- a/rollup-lite.config.js
+++ b/rollup-lite.config.js
@@ -8,7 +8,7 @@ export default {
     input: 'src/index.js',
     output: {
         name: 'Alpine',
-        file: 'dist/alpine.js',
+        file: 'dist/alpine-lite.js',
         format: 'umd',
     },
     plugins: [
@@ -17,7 +17,7 @@ export default {
             "process.env.NODE_ENV": "'production'",
             // inject Alpine.js package version number
             "process.env.PKG_VERSION": `"${pkg.version}"`,
-            "process.env.LITE": "false",
+            "process.env.LITE": "true",
             "process.env.IE11_ONLY": "false"
         }),
         resolve(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import babel from 'rollup-plugin-babel';
 import filesize from 'rollup-plugin-filesize';
 import resolve from 'rollup-plugin-node-resolve';
-import stripCode from 'rollup-plugin-strip-code';
 import replace from '@rollup/plugin-replace';
 import pkg from './package.json';
 
@@ -17,16 +16,13 @@ export default {
             // 'observable-membrane' uses process.env. We don't have that...
             "process.env.NODE_ENV": "'production'",
             // inject Alpine.js package version number
-            "process.env.PKG_VERSION": `"${pkg.version}"`
+            "process.env.PKG_VERSION": `"${pkg.version}"`,
+            "process.env.IE11_ONLY": "false"
         }),
         resolve(),
         filesize(),
         babel({
             exclude: 'node_modules/**'
-        }),
-        stripCode({
-            start_comment: 'IE11-ONLY:START',
-            end_comment: 'IE11-ONLY:END'
         })
     ]
 }

--- a/src/component.js
+++ b/src/component.js
@@ -243,7 +243,7 @@ export default class Component {
 
     resolveBoundAttributes(el, initialUpdate = false, extraVars) {
         let attrs = getXAttrs(el, this)
-        if (!process.env.LITE &&el.type !== undefined && el.type === 'radio') {
+        if (!process.env.LITE && el.type !== undefined && el.type === 'radio') {
             // If there's an x-model on a radio input, move it to end of attribute list
             // to ensure that x-bind:value (if present) is processed first.
             const modelIdx = attrs.findIndex((attr) => attr.type === 'model')

--- a/src/component.js
+++ b/src/component.js
@@ -231,7 +231,9 @@ export default class Component {
                     break;
 
                 case 'model':
-                    registerModelListener(this, el, modifiers, expression, extraVars)
+                    if (!process.env.LITE) {
+                        registerModelListener(this, el, modifiers, expression, extraVars)
+                    }
                     break;
                 default:
                     break;
@@ -241,7 +243,7 @@ export default class Component {
 
     resolveBoundAttributes(el, initialUpdate = false, extraVars) {
         let attrs = getXAttrs(el, this)
-        if (el.type !== undefined && el.type === 'radio') {
+        if (!process.env.LITE &&el.type !== undefined && el.type === 'radio') {
             // If there's an x-model on a radio input, move it to end of attribute list
             // to ensure that x-bind:value (if present) is processed first.
             const modelIdx = attrs.findIndex((attr) => attr.type === 'model')
@@ -253,12 +255,14 @@ export default class Component {
         attrs.forEach(({ type, value, modifiers, expression }) => {
             switch (type) {
                 case 'model':
-                    handleAttributeBindingDirective(this, el, 'value', expression, extraVars, type)
+                    if (!process.env.LITE) {
+                        handleAttributeBindingDirective(this, el, 'value', expression, extraVars, type)
+                    }
                     break;
 
                 case 'bind':
                     // The :key binding on an x-for is special, ignore it.
-                    if (el.tagName.toLowerCase() === 'template' && value === 'key') return
+                    if (!process.env.LITE &&el.tagName.toLowerCase() === 'template' && value === 'key') return
 
                     handleAttributeBindingDirective(this, el, value, expression, extraVars, type)
                     break;
@@ -280,17 +284,21 @@ export default class Component {
                     break;
 
                 case 'if':
+                    if (!process.env.LITE) {
                     // If this element also has x-for on it, don't process x-if.
                     // We will let the "x-for" directive handle the "if"ing.
-                    if (attrs.filter(i => i.type === 'for').length > 0) return
+                        if (attrs.filter(i => i.type === 'for').length > 0) return
 
-                    var output = this.evaluateReturnExpression(el, expression, extraVars)
+                        var output = this.evaluateReturnExpression(el, expression, extraVars)
 
-                    handleIfDirective(this, el, output, initialUpdate, extraVars)
+                        handleIfDirective(this, el, output, initialUpdate, extraVars)
+                    }
                     break;
 
                 case 'for':
-                    handleForDirective(this, el, expression, initialUpdate, extraVars)
+                    if (!process.env.LITE) {
+                        handleForDirective(this, el, expression, initialUpdate, extraVars)
+                    }
                     break;
 
                 case 'cloak':

--- a/src/component.js
+++ b/src/component.js
@@ -19,14 +19,14 @@ export default class Component {
 
         this.unobservedData = seedDataForCloning ? seedDataForCloning : saferEval(dataExpression, { $el: this.$el })
 
-        /* IE11-ONLY:START */
+        if (process.env.IE11_ONLY) {
             // For IE11, add our magic properties to the original data for access.
             // The Proxy polyfill does not allow properties to be added after creation.
             this.unobservedData.$el = null
             this.unobservedData.$refs = null
             this.unobservedData.$nextTick = null
             this.unobservedData.$watch = null
-        /* IE11-ONLY:END */
+        }
 
         // Construct a Proxy-based observable. This will be used to handle reactivity.
         let { membrane, data } = this.wrapDataInObservable(this.unobservedData)
@@ -375,7 +375,7 @@ export default class Component {
 
         var refObj = {}
 
-        /* IE11-ONLY:START */
+        if (process.env.IE11_ONLY) {
             // Add any properties up-front that might be necessary for the Proxy polyfill.
             refObj.$isRefsProxy = false;
             refObj.$isAlpineProxy = false;
@@ -387,7 +387,7 @@ export default class Component {
                     refObj[el.getAttribute('x-ref')] = true
                 }
             })
-        /* IE11-ONLY:END */
+        }
 
         // One of the goals of this is to not hold elements in memory, but rather re-evaluate
         // the DOM when the system needs something from it. This way, the framework is flexible and

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -41,7 +41,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
 
             el.value = value
         }
-    } else if (attrName === 'class') {
+    } else if (!process.env.LITE && attrName === 'class') {
         if (Array.isArray(value)) {
             const originalClasses = el.__x_original_classes || []
             el.setAttribute('class', arrayUnique(originalClasses.concat(value)).join(' '))

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -1,7 +1,7 @@
 import { kebabCase, debounce, isNumeric } from '../utils'
 
 export function registerListener(component, el, event, modifiers, expression, extraVars = {}) {
-    if (modifiers.includes('away')) {
+    if (!process.env.LITE && modifiers.includes('away')) {
         let handler = e => {
             // Don't do anything if the click came form the element or within it.
             if (el.contains(e.target)) return
@@ -59,7 +59,7 @@ export function registerListener(component, el, event, modifiers, expression, ex
             }
         }
 
-        if (modifiers.includes('debounce')) {
+        if (!process.env.LITE && modifiers.includes('debounce')) {
             let nextModifier = modifiers[modifiers.indexOf('debounce')+1] || 'invalid-wait'
             let wait = isNumeric(nextModifier.split('ms')[0]) ? Number(nextModifier.split('ms')[0]) : 250
             handler = debounce(handler, wait, this)
@@ -84,7 +84,7 @@ function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
         return ! ['window', 'document', 'prevent', 'stop'].includes(i)
     })
 
-    if (keyModifiers.includes('debounce')) {
+    if (!process.env.LITE && keyModifiers.includes('debounce')) {
         let debounceIndex = keyModifiers.indexOf('debounce')
         keyModifiers.splice(debounceIndex, isNumeric((keyModifiers[debounceIndex+1] || 'invalid-wait').split('ms')[0]) ? 2 : 1)
     }

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,7 +1,7 @@
 import ObservableMembrane from 'observable-membrane'
 
 export function wrap(data, mutationCallback) {
-    if (process.env.IE11_ONLY) {
+    if (process.env.LITE || process.env.IE11_ONLY) {
         return wrapForIe11(data, mutationCallback)
     }
 

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,9 +1,9 @@
 import ObservableMembrane from 'observable-membrane'
 
 export function wrap(data, mutationCallback) {
-    /* IE11-ONLY:START */
-    return wrapForIe11(data, mutationCallback)
-    /* IE11-ONLY:END */
+    if (process.env.IE11_ONLY) {
+        return wrapForIe11(data, mutationCallback)
+    }
 
 
     let membrane = new ObservableMembrane({

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,7 +89,9 @@ export function saferEvalNoReturn(expression, dataContext, additionalHelperVaria
     )
 }
 
-const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/
+const xAttrRE = !process.env.LITE
+    ? /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/
+    : /^x-(on|bind|data|text|html|show|cloak|ref)\b/
 
 export function isXAttr(attr) {
     const name = replaceAtAndColonWithStandardSyntax(attr.name)
@@ -102,7 +104,7 @@ export function getXAttrs(el, component, type) {
         .filter(isXAttr)
         .map(parseHtmlAttribute)
         .flatMap(i => {
-            if (i.type === 'spread') {
+            if (!process.env.LITE && i.type === 'spread') {
                 let directiveBindings = saferEval(i.expression, component.$data)
 
                 return Object.entries(directiveBindings).map(([name, value]) => parseHtmlAttribute({ name, value }))
@@ -134,6 +136,8 @@ function parseHtmlAttribute({ name, value }) {
 }
 
 export function isBooleanAttr(attrName) {
+    if (process.env.LITE) return false
+
     // As per HTML spec table https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute
     // Array roughly ordered by estimated usage
     const booleanAttributes = [
@@ -162,6 +166,7 @@ export function convertClassStringToArray(classList, filterFn = Boolean) {
 }
 
 export function transitionIn(el, show, component, forceSkip = false) {
+    if (process.env.LITE) return show()
     if (forceSkip) return show()
 
     const attrs = getXAttrs(el, component, 'transition')
@@ -191,6 +196,7 @@ export function transitionIn(el, show, component, forceSkip = false) {
 }
 
 export function transitionOut(el, hide, component, forceSkip = false) {
+    if (process.env.LITE) return hide()
      // We don't want to transition on the initial page load.
     if (forceSkip) return hide()
 


### PR DESCRIPTION
Create `alpine-lite.js` weighing in under 4kb gzipped (~11kb minified)

It turns out that rollup is very good at dead code elimination so we can toggle features/code based on an variables defined in the rollup config.

Disables the following features:
- x-for
- x-if
- x-model
- x-spread
- boolean attribute detection
- transitions
- `class` attribute object/array binding
- `.away`, `.debounce` modifiers 
- observable-membrane (uses buggy hand-rolled observable but that's probably not an issue if we don't have x-for to use arrays of things)

Other things in this PR:

- refactors the IE11-Only code to use `process.env.IE11_only` (removes the need for strip-code rollup plugin)
- removes unused rollup plugins (terser was already unused, strip-code is newly unused)

**Alternative Approach(es) & Questions**

- This PR uses a single variable `LITE` to denote whether a feature is in the Lite version or not, we could go another way and add per feature, "feature toggles" eg. `X_FOR_ENABLED`, `X_IF_ENABLED`, `X_MODEL_ENABLED`, `X_TRANSITIONS_ENABLED` etc, which would mean that people can create custom builds of Alpine.js with the features they need, this would pave the way towards a Tailwind CLI style tool which can generate custom builds given a set of enabled/disabled features
  - should we go for this more granular approach?
  - should we go for `X_IF_ENABLED` or `X_IF_DISABLED` type of flags?
- What other features should we disable?
- Which currently disabled features should we re-enable?
