### PR TITLE
Avoid unnecessary loops

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -109,13 +109,11 @@ export function getXAttrs(el, component, type) {
         // Add x-spread directives to the pile of existing directives.
         directives = directives.concat(Object.entries(spreadObject).map(([name, value]) => parseHtmlAttribute({ name, value })))
     }
+    
+    // If no type is passed in for filtering, bypass filter
+    if (!type) return directives;
 
-    return directives.filter(i => {
-        // If no type is passed in for filtering, bypass filter
-        if (! type) return true
-
-        return i.type === type
-    })
+    return directives.filter(i => i.type === type)
 }
 
 function parseHtmlAttribute({ name, value }) {


### PR DESCRIPTION
There's no need to filter the `directives` array if type parameter is not passed into the `getXAttrs` function