### PR TITLE
remove unecessary directive ordering clause

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "alpinejs",
-    "version": "2.4.1",
+    "version": "2.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/component.js
+++ b/src/component.js
@@ -256,15 +256,6 @@ export default class Component {
 
     resolveBoundAttributes(el, initialUpdate = false, extraVars) {
         let attrs = getXAttrs(el, this)
-        if (el.type !== undefined && el.type === 'radio') {
-            // If there's an x-model on a radio input, move it to end of attribute list
-            // to ensure that x-bind:value (if present) is processed first.
-            const modelIdx = attrs.findIndex((attr) => attr.type === 'model')
-            if (modelIdx > -1) {
-                attrs.push(attrs.splice(modelIdx, 1)[0])
-            }
-        }
-
         attrs.forEach(({ type, value, modifiers, expression }) => {
             switch (type) {
                 case 'model':


### PR DESCRIPTION
Some changes that were part of https://github.com/alpinejs/alpine/pull/315/files aren't needed any more.

The relevant use-case's tests still pass without the guard since it's a specific instance of "bind should be evaluated before model"