### PR TITLE
Transition .delay modifier  

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ If you wish to run code AFTER Alpine has made its initial updates to the DOM (so
 | `x-show.transition.scale` | Only use the scale. |
 | `x-show.transition.scale.75` | Customize the CSS scale transform `transform: scale(.75)`. |
 | `x-show.transition.duration.200ms` | Sets the "in" transition to 200ms. The out will be set to half that (100ms). |
-| `x-show.transition.delay.200ms` | Sets the "in" transition to 200ms. The out will be set to half that (100ms). |
+| `x-show.transition.delay.200ms` | Sets 200ms delay on transition. |
 | `x-show.transition.origin.top.right` | Customize the CSS transform origin `transform-origin: top right`. |
 | `x-show.transition.in.duration.200ms.out.duration.50ms` | Different durations for "in" and "out". |
 
-> Note: All of these transition modifiers can be used in conjunction with each other. This is possible (although ridiculous lol): `x-show.transition.in.duration.100ms.origin.top.right.opacity.scale.85.out.duration.200ms.origin.bottom.left.opacity.scale.95`
+> Note: All of these transition modifiers can be used in conjunction with each other. This is possible (although ridiculous lol): `x-show.transition.in.duration.100ms.origin.top.right.opacity.scale.85.out.duration.200ms.delay.200ms.origin.bottom.left.opacity.scale.95`
 
 > Note: `x-show` will wait for any children to finish transitioning out. If you want to bypass this behavior, add the `.immediate` modifer:
 ```html

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ If you wish to run code AFTER Alpine has made its initial updates to the DOM (so
 | `x-show.transition.scale` | Only use the scale. |
 | `x-show.transition.scale.75` | Customize the CSS scale transform `transform: scale(.75)`. |
 | `x-show.transition.duration.200ms` | Sets the "in" transition to 200ms. The out will be set to half that (100ms). |
+| `x-show.transition.delay.200ms` | Sets the "in" transition to 200ms. The out will be set to half that (100ms). |
 | `x-show.transition.origin.top.right` | Customize the CSS transform origin `transform-origin: top right`. |
 | `x-show.transition.in.duration.200ms.out.duration.50ms` | Different durations for "in" and "out". |
 

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6021,6 +6021,7 @@
     // Default values inspired by: https://material.io/design/motion/speed.html#duration
     var styleValues = {
       duration: modifierValue(modifiers, 'duration', 150),
+      delay: modifierValue(modifiers, 'delay', 0),
       origin: modifierValue(modifiers, 'origin', 'center'),
       first: {
         opacity: 0,
@@ -6044,6 +6045,7 @@
     var duration = settingBothSidesOfTransition ? modifierValue(modifiers, 'duration', 150) : modifierValue(modifiers, 'duration', 150) / 2;
     var styleValues = {
       duration: duration,
+      delay: modifierValue(modifiers, 'delay', 0),
       origin: modifierValue(modifiers, 'origin', 'center'),
       first: {
         opacity: 1,
@@ -6073,7 +6075,7 @@
       if (!isNumeric(rawValue)) return fallback;
     }
 
-    if (key === 'duration') {
+    if (key === 'duration' || key === 'delay') {
       // Support x-show.transition.duration.500ms && duration.500
       var match = rawValue.match(/([0-9]+)ms/);
       if (match) return match[1];
@@ -6114,6 +6116,7 @@
       },
       during: function during() {
         if (transitionScale) el.style.transformOrigin = styleValues.origin;
+        if (styleValues.delay) el.style.transitionDelay = "".concat(styleValues.delay / 1000, "s");
         el.style.transitionProperty = [transitionOpacity ? "opacity" : "", transitionScale ? "transform" : ""].join(' ').trim();
         el.style.transitionDuration = "".concat(styleValues.duration / 1000, "s");
         el.style.transitionTimingFunction = "cubic-bezier(0.4, 0.0, 0.2, 1)";
@@ -6134,6 +6137,7 @@
         if (transitionScale) el.style.transformOrigin = transformOriginCache;
         el.style.transitionProperty = null;
         el.style.transitionDuration = null;
+        el.style.transitionDelay = null;
         el.style.transitionTimingFunction = null;
       }
     };
@@ -6293,12 +6297,15 @@
 
       // Note: Safari's transitionDuration property will list out comma separated transition durations
       // for every single transition property. Let's grab the first one and call it a day.
-      var duration = Number(getComputedStyle(el).transitionDuration.replace(/,.*/, '').replace('s', '')) * 1000;
+      var transitionDuration = Number(getComputedStyle(el).transitionDuration.replace(/,.*/, '').replace('s', ''));
+      var transitionDelay = getComputedStyle(el).transitionDelay ? Number(getComputedStyle(el).transitionDelay.replace(/,.*/, '').replace('s', '')) : 0;
 
-      if (duration === 0) {
-        duration = Number(getComputedStyle(el).animationDuration.replace('s', '')) * 1000;
+      if (transitionDuration + transitionDelay === 0) {
+        transitionDuration = Number(getComputedStyle(el).animationDuration.replace('s', ''));
+        transitionDelay = getComputedStyle(el).animationDelay ? Number(getComputedStyle(el).animationDelay.replace('s', '')) : 0;
       }
 
+      var duration = (transitionDuration + transitionDelay) * 1000;
       stages.show();
       el.__x_transition.nextFrame = requestAnimationFrame(function () {
         _newArrowCheck(this, _this15);

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -437,6 +437,17 @@ test('transition with x-show.transition helper', async () => {
         'display: none;',
     ])
 
+    await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85.duration.200ms.delay.100ms', [
+        'display: none; transform: scale(0.85); transform-origin: center; transition-delay: 0.1s; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(0.85); transform-origin: center; transition-delay: 0.1s; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(1); transform-origin: center; transition-delay: 0.1s; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        '',
+        'transform: scale(1); transform-origin: center; transition-delay: 0.1s; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(1); transform-origin: center; transition-delay: 0.1s; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(0.85); transform-origin: center; transition-delay: 0.1s; transition-property: transform; transition-duration: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'display: none;',
+    ])
+
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85.duration.200ms.origin.top', [
         'display: none; transform: scale(0.85); transform-origin: top; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.85); transform-origin: top; transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',


### PR DESCRIPTION
Currently we can not **delay** the transitions for the root or child elements where there are some reasonable use cases needs it. With this PR which uses almost the same approach as `.duration` modifier, we can delay the transitions for example like `x-show.delay.1000ms`. 

Also currently if parent element has `x-show.transition` while transitioning out, it will not wait for child to finish and just transition out and back to display block to wait child finish then hide with the child again which is seems like a bug. With this PR we are able to define a delay to wait for the child and do the transitioning for the parent as well.

Also it will open more opportunities for the `nested chain animations`. A sample codepen link down bellow if you want to check it out.

> Thanks to @SimoTod for the sample

https://codepen.io/muzafferdede/pen/jOWdZZE  