### PR TITLE
Missing transition delay + bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,11 @@ If you wish to run code AFTER Alpine has made its initial updates to the DOM (so
 | `x-show.transition.scale` | Only use the scale. |
 | `x-show.transition.scale.75` | Customize the CSS scale transform `transform: scale(.75)`. |
 | `x-show.transition.duration.200ms` | Sets the "in" transition to 200ms. The out will be set to half that (100ms). |
+| `x-show.transition.delay.200ms` | Sets 200ms delay on transition. |
 | `x-show.transition.origin.top.right` | Customize the CSS transform origin `transform-origin: top right`. |
 | `x-show.transition.in.duration.200ms.out.duration.50ms` | Different durations for "in" and "out". |
 
-> Note: All of these transition modifiers can be used in conjunction with each other. This is possible (although ridiculous lol): `x-show.transition.in.duration.100ms.origin.top.right.opacity.scale.85.out.duration.200ms.origin.bottom.left.opacity.scale.95`
+> Note: All of these transition modifiers can be used in conjunction with each other. This is possible (although ridiculous lol): `x-show.transition.in.duration.100ms.origin.top.right.opacity.scale.85.out.duration.200ms.delay.200ms.origin.bottom.left.opacity.scale.95`
 
 > Note: `x-show` will wait for any children to finish transitioning out. If you want to bypass this behavior, add the `.immediate` modifer:
 ```html

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -5995,7 +5995,7 @@
     }
 
     if (key === 'duration' || key === 'delay') {
-      // Support x-show.transition.duration.500ms && duration.500
+      // Support x-show.transition duration & delay with/out 'ms'
       var match = rawValue.match(/([0-9]+)ms/);
       if (match) return match[1];
     }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -312,7 +312,7 @@
     }
 
     if (key === 'duration' || key === 'delay') {
-      // Support x-show.transition.duration.500ms && duration.500
+      // Support x-show.transition duration & delay with/out 'ms'
       let match = rawValue.match(/([0-9]+)ms/);
       if (match) return match[1];
     }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -477,8 +477,8 @@
     el.__x_transition.nextFrame = requestAnimationFrame(() => {
       // Note: Safari's transitionDuration property will list out comma separated transition durations
       // for every single transition property. Let's grab the first one and call it a day.
-      var computedStyles = getComputedStyle(el);
-      var duration = extractTime(computedStyles.transitionDuration) + extractTime(computedStyles.transitionDelay);
+      const computedStyles = getComputedStyle(el);
+      let duration = extractTime(computedStyles.transitionDuration) + extractTime(computedStyles.transitionDelay);
 
       if (duration === 0) {
         duration = extractTime(computedStyles.animationDuration) + extractTime(computedStyles.animationDelay);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "alpinejs",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -312,7 +312,7 @@ function modifierValue(modifiers, key, fallback) {
     }
 
     if (key === 'duration' || key === 'delay') {
-        // Support x-show.transition.duration.500ms && duration.500
+        // Support x-show.transition duration & delay with/out 'ms'
         let match = rawValue.match(/([0-9]+)ms/)
         if (match) return match[1]
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -469,9 +469,9 @@ export function transition(el, stages, type) {
     el.__x_transition.nextFrame = requestAnimationFrame(() => {
         // Note: Safari's transitionDuration property will list out comma separated transition durations
         // for every single transition property. Let's grab the first one and call it a day.
-        var computedStyles = getComputedStyle(el)
+        const computedStyles = getComputedStyle(el)
 
-        var duration = extractTime(computedStyles.transitionDuration) + extractTime(computedStyles.transitionDelay)
+        let duration = extractTime(computedStyles.transitionDuration) + extractTime(computedStyles.transitionDelay)
 
         if (duration === 0) {
             duration = extractTime(computedStyles.animationDuration) + extractTime(computedStyles.animationDelay)

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -3,7 +3,7 @@ import { wait } from '@testing-library/dom'
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 global.MutationObserver = class {
-    observe() {}
+    observe() { }
 }
 
 test('transition in', async () => {
@@ -415,6 +415,18 @@ test('transition with x-show.transition helper', async () => {
         'display: none;',
     ])
 
+
+    await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.delay.100', [
+        'display: none; transform: scale(0.95); transform-origin: center; transition-property: transform; transition-duration: 0.15s; transition-delay: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(0.95); transform-origin: center; transition-property: transform; transition-duration: 0.15s; transition-delay: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.15s; transition-delay: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        '',
+        'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-delay: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(1); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-delay: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'transform: scale(0.95); transform-origin: center; transition-property: transform; transition-duration: 0.075s; transition-delay: 0.1s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
+        'display: none;',
+    ])
+
     await assertTransitionHelperStyleAttributeValues('x-show.transition.scale.85', [
         'display: none; transform: scale(0.85); transform-origin: center; transition-property: transform; transition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
         'transform: scale(0.85); transform-origin: center; transition-property: transform; transition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0.0, 0.2, 1);',
@@ -508,7 +520,7 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[index])
 
-    while(frameStack.length) {
+    while (frameStack.length) {
         frameStack.pop()()
         expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
     }
@@ -524,7 +536,7 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
 
-    while(frameStack.length) {
+    while (frameStack.length) {
         frameStack.pop()()
         expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
     }

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -753,9 +753,9 @@ test('x-transition supports delay', async () => {
     // (hardcoding 10ms animation and delay time for later assertions)
     jest.spyOn(window, 'getComputedStyle').mockImplementation(el => {
         return {
-            transitionDuration: '0s',
+            transitionDuration: '.1s',
             animationDuration: '.1s',
-            transitionDelay: '0s',
+            transitionDelay: '.1s',
             animationDelay: '.1s'
         }
     });

--- a/test/transition.spec.js
+++ b/test/transition.spec.js
@@ -3,7 +3,7 @@ import { wait } from '@testing-library/dom'
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 global.MutationObserver = class {
-    observe() { }
+    observe() {}
 }
 
 test('transition in', async () => {
@@ -520,7 +520,7 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[index])
 
-    while (frameStack.length) {
+    while(frameStack.length){
         frameStack.pop()()
         expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
     }
@@ -536,7 +536,7 @@ async function assertTransitionHelperStyleAttributeValues(xShowDirective, styleA
 
     expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
 
-    while (frameStack.length) {
+    while(frameStack.length){
         frameStack.pop()()
         expect(document.querySelector('span').getAttribute('style')).toEqual(styleAttributeExpectations[++index])
     }


### PR DESCRIPTION
This PR adds support for transition delay. Currently **transitions break** if the element has a **delay** defined [as in this sample](https://codepen.io/muzafferdede/pen/GRZjEry)
The code just adds the **transitionDelay** to the timeout value from the inline `.delay` modifier or computed styles, allowing transitions to complete after a delay.

You can check this [sample](https://codepen.io/muzafferdede/pen/bGpwRrm) which fixes bug with the new code **without any breaking changes**

- adds `.delay` modifier ex: `x-show.transition.delay.500`
- supports css class defined delays ex: `class="delay-500"`
- has inline and x-transition tests
- adds related info to docs
- uses almost same approach as `.duration`
- improved extracting time related computed properties for better performance