### PR TITLE
docs(x-model `.number` modifier)

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ The `camel` modifier will attach an event listener for the camel case equivalent
 **`.number` modifier**
 **Example:** `<input x-model.number="age">`
 
-The `number` modifier will convert the input's value to a number.
+The `number` modifier will convert the input's value to a number. If the value cannot be parsed as a valid number, the original value is returned.
 
 **`.debounce` modifier**
 **Example:** `<input x-model.debounce="search">`

--- a/README.md
+++ b/README.md
@@ -405,7 +405,6 @@ The `camel` modifier will attach an event listener for the camel case equivalent
 
 The `number` modifier will convert the input's value to a number.
 
-
 **`.debounce` modifier**
 **Example:** `<input x-model.debounce="search">`
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ The `camel` modifier will attach an event listener for the camel case equivalent
 
 > Note: `x-model` is smart enough to detect changes on text inputs, checkboxes, radio buttons, textareas, selects, and multiple selects. It should behave [how Vue would](https://vuejs.org/v2/guide/forms.html) in those scenarios.
 
+**`.number` modifier**
+**Example:** `<input x-model.number="age">`
+
+The `number` modifier will convert the input's value to a number.
+
+
 **`.debounce` modifier**
 **Example:** `<input x-model.debounce="search">`
 


### PR DESCRIPTION
I noticed that the `x-model.number` modifier is not mentioned anywhere, this adds a short example for it.