### PR TITLE
Correct wording of warning message

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ export function warnIfMalformedTemplate(el, directive) {
     if (el.tagName.toLowerCase() !== 'template') {
         console.warn(`Alpine: [${directive}] directive should only be added to <template> tags. See https://github.com/alpinejs/alpine#${directive}`)
     } else if (el.content.childElementCount !== 1) {
-        console.warn(`Alpine: <template> tag with [${directive}] encountered with multiple element roots. Make sure <template> only has a single child node.`)
+        console.warn(`Alpine: <template> tag with [${directive}] encountered with multiple element roots. Make sure <template> only has a single child element.`)
     }
 }
 


### PR DESCRIPTION
This warning message is a bit misleading, the template[x-if] tag requires a single child element, not a single child node (because text nodes are also nodes)

- It can have some empty text nodes around the single child element
- It's not good if it has a single text node as a child.