### PR TITLE
feature(x for over range)

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,8 +516,6 @@ Alpine supports the `i in n` syntax, where `n` is an integer, allowing you to it
 </template>
 ```
 
-This will output 10 spans, starting with an `i` value of 0.
-
 ---
 
 ### `x-transition`

--- a/README.md
+++ b/README.md
@@ -506,6 +506,18 @@ You can nest `x-for` loops, but you MUST wrap each loop in an element. For examp
 </template>
 ```
 
+#### Iterating over a range
+
+Alpine supports the `i in n` syntax, where `n` is an integer, allowing you to iterate over a fixed range of elements.
+
+```html
+<template x-for="i in 10">
+    <span x-text="i"></span>
+</template>
+```
+
+This will output 10 spans, starting with an `i` value of 0.
+
 ---
 
 ### `x-transition`

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -23,11 +23,10 @@
   	return module = { exports: {} }, fn(module, module.exports), module.exports;
   }
 
-  (function(){function n(){function v(){return null}function l(a){return a?"object"===typeof a||"function"===typeof a:!1}function p(a){if(null!==a&&!l(a))throw new TypeError("Object prototype may only be an Object or null: "+a);}var q=null,e=Object,w=!!e.create||!({__proto__:null}instanceof e),A=e.create||(w?function(a){p(a);return {__proto__:a}}:function(a){function c(){}p(a);if(null===a)throw new SyntaxError("Native Object.create is required to create objects with null prototype");c.prototype=a;return new c}),
-  B=e.getPrototypeOf||([].__proto__===Array.prototype?function(a){a=a.__proto__;return l(a)?a:null}:v);var m=function(a,c){function k(){}if(void 0===(this&&this instanceof m?this.constructor:void 0))throw new TypeError("Constructor Proxy requires 'new'");if(!l(a)||!l(c))throw new TypeError("Cannot create proxy with a non-object as target or handler");q=function(){a=null;k=function(b){throw new TypeError("Cannot perform '"+b+"' on a proxy that has been revoked");};};setTimeout(function(){q=null;},0);var g=
-  c;c={get:null,set:null,apply:null,construct:null};for(var h in g){if(!(h in c))throw new TypeError("Proxy polyfill does not support trap '"+h+"'");c[h]=g[h];}"function"===typeof g&&(c.apply=g.apply.bind(g));g=B(a);var r=!1,t=!1;if("function"===typeof a){var f=function(){var b=this&&this.constructor===f,d=Array.prototype.slice.call(arguments);k(b?"construct":"apply");return b&&c.construct?c.construct.call(this,a,d):!b&&c.apply?c.apply(a,this,d):b?(d.unshift(a),new (a.bind.apply(a,d))):a.apply(this,
-  d)};r=!0;}else a instanceof Array?(f=[],t=!0):f=w||null!==g?A(g):{};var x=c.get?function(b){k("get");return c.get(this,b,f)}:function(b){k("get");return this[b]},C=c.set?function(b,d){k("set");c.set(this,b,d,f);}:function(b,d){k("set");this[b]=d;},y={};e.getOwnPropertyNames(a).forEach(function(b){if(!((r||t)&&b in f)){var d=e.getOwnPropertyDescriptor(a,b);e.defineProperty(f,b,{enumerable:!!d.enumerable,get:x.bind(a,b),set:C.bind(a,b)});y[b]=!0;}});h=!0;if(r||t){var D=e.setPrototypeOf||([].__proto__===
-  Array.prototype?function(b,d){p(d);b.__proto__=d;return b}:v);g&&D(f,g)||(h=!1);}if(c.get||!h)for(var u in a)y[u]||e.defineProperty(f,u,{get:x.bind(a,u)});e.seal(a);e.seal(f);return f};m.revocable=function(a,c){return {proxy:new m(a,c),revoke:q}};return m}var z="undefined"!==typeof process&&"[object process]"==={}.toString.call(process)||"undefined"!==typeof navigator&&"ReactNative"===navigator.product?commonjsGlobal:self;z.Proxy||(z.Proxy=n(),z.Proxy.revocable=z.Proxy.revocable);})();
+  (function(){function k(){function p(a){return a?"object"===typeof a||"function"===typeof a:!1}var l=null;var n=function(a,c){function g(){}if(!p(a)||!p(c))throw new TypeError("Cannot create proxy with a non-object as target or handler");l=function(){a=null;g=function(b){throw new TypeError("Cannot perform '"+b+"' on a proxy that has been revoked");};};setTimeout(function(){l=null;},0);var f=c;c={get:null,set:null,apply:null,construct:null};for(var h in f){if(!(h in c))throw new TypeError("Proxy polyfill does not support trap '"+
+  h+"'");c[h]=f[h];}"function"===typeof f&&(c.apply=f.apply.bind(f));var d=this,q=!1,r=!1;"function"===typeof a?(d=function(){var b=this&&this.constructor===d,e=Array.prototype.slice.call(arguments);g(b?"construct":"apply");return b&&c.construct?c.construct.call(this,a,e):!b&&c.apply?c.apply(a,this,e):b?(e.unshift(a),new (a.bind.apply(a,e))):a.apply(this,e)},q=!0):a instanceof Array&&(d=[],r=!0);var t=c.get?function(b){g("get");return c.get(this,b,d)}:function(b){g("get");return this[b]},w=c.set?function(b,
+  e){g("set");c.set(this,b,e,d);}:function(b,e){g("set");this[b]=e;},u={};Object.getOwnPropertyNames(a).forEach(function(b){if(!((q||r)&&b in d)){var e={enumerable:!!Object.getOwnPropertyDescriptor(a,b).enumerable,get:t.bind(a,b),set:w.bind(a,b)};Object.defineProperty(d,b,e);u[b]=!0;}});f=!0;Object.setPrototypeOf?Object.setPrototypeOf(d,Object.getPrototypeOf(a)):d.__proto__?d.__proto__=a.__proto__:f=!1;if(c.get||!f)for(var m in a)u[m]||Object.defineProperty(d,m,{get:t.bind(a,m)});Object.seal(a);Object.seal(d);
+  return d};n.revocable=function(a,c){return {proxy:new n(a,c),revoke:l}};return n}var v="undefined"!==typeof process&&"[object process]"==={}.toString.call(process)||"undefined"!==typeof navigator&&"ReactNative"===navigator.product?commonjsGlobal:self;v.Proxy||(v.Proxy=k(),v.Proxy.revocable=v.Proxy.revocable);})();
 
   !function(e){var t=e.Element.prototype;"function"!=typeof t.matches&&(t.matches=t.msMatchesSelector||t.mozMatchesSelector||t.webkitMatchesSelector||function(e){for(var t=(this.document||this.ownerDocument).querySelectorAll(e),o=0;t[o]&&t[o]!==this;)++o;return Boolean(t[o])}),"function"!=typeof t.closest&&(t.closest=function(e){for(var t=this;t&&1===t.nodeType;){if(t.matches(e))return t;t=t.parentNode;}return null});}(window);
 
@@ -6365,6 +6364,11 @@
 
     if (ifAttribute && !component.evaluateReturnExpression(el, ifAttribute.expression)) {
       return [];
+    } // This adds support for the `i in 10` syntax.
+
+
+    if (isNumeric(iteratorNames.items)) {
+      return _toConsumableArray(Array(parseInt(iteratorNames.items)).keys());
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars);

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6360,15 +6360,21 @@
   }
 
   function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, el, iteratorNames, extraVars) {
+    var _this4 = this;
+
     var ifAttribute = getXAttrs(el, component, 'if')[0];
 
     if (ifAttribute && !component.evaluateReturnExpression(el, ifAttribute.expression)) {
       return [];
-    } // This adds support for the `i in 10` syntax.
+    } // This adds support for the `i in n` syntax.
 
 
     if (isNumeric(iteratorNames.items)) {
-      return _toConsumableArray(Array(parseInt(iteratorNames.items, 10)).keys());
+      return Array.from(Array(parseInt(iteratorNames.items, 10)).keys(), function (i) {
+        _newArrowCheck(this, _this4);
+
+        return i + 1;
+      }.bind(this));
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars);
@@ -6401,12 +6407,12 @@
     var nextElementFromOldLoop = currentEl.nextElementSibling && currentEl.nextElementSibling.__x_for_key !== undefined ? currentEl.nextElementSibling : false;
 
     var _loop = function _loop() {
-      var _this4 = this;
+      var _this5 = this;
 
       var nextElementFromOldLoopImmutable = nextElementFromOldLoop;
       var nextSibling = nextElementFromOldLoop.nextElementSibling;
       transitionOut(nextElementFromOldLoop, function () {
-        _newArrowCheck(this, _this4);
+        _newArrowCheck(this, _this5);
 
         nextElementFromOldLoopImmutable.remove();
       }.bind(this), component);

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6368,7 +6368,7 @@
 
 
     if (isNumeric(iteratorNames.items)) {
-      return _toConsumableArray(Array(parseInt(iteratorNames.items)).keys());
+      return _toConsumableArray(Array(parseInt(iteratorNames.items, 10)).keys());
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars);

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -577,6 +577,11 @@
 
     if (ifAttribute && !component.evaluateReturnExpression(el, ifAttribute.expression)) {
       return [];
+    } // This adds support for the `i in 10` syntax.
+
+
+    if (isNumeric(iteratorNames.items)) {
+      return [...Array(parseInt(iteratorNames.items)).keys()];
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars);

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -581,7 +581,7 @@
 
 
     if (isNumeric(iteratorNames.items)) {
-      return [...Array(parseInt(iteratorNames.items)).keys()];
+      return [...Array(parseInt(iteratorNames.items, 10)).keys()];
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars);

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -577,11 +577,11 @@
 
     if (ifAttribute && !component.evaluateReturnExpression(el, ifAttribute.expression)) {
       return [];
-    } // This adds support for the `i in 10` syntax.
+    } // This adds support for the `i in n` syntax.
 
 
     if (isNumeric(iteratorNames.items)) {
-      return [...Array(parseInt(iteratorNames.items, 10)).keys()];
+      return Array.from(Array(parseInt(iteratorNames.items, 10)).keys(), i => i + 1);
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars);

--- a/examples/index.html
+++ b/examples/index.html
@@ -305,6 +305,17 @@
                 </tr>
 
                 <tr>
+                    <td>x-for over a range using <code>i in 10</code> syntax</td>
+                    <td>
+                        <div x-data>
+                            <template x-for="i in 10" :key="i">
+                                <span x-text="i"></span>
+                            </template>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr>
                     <td>Transitions</td>
                     <td>
                         <div x-data="{ open: false }">

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -1,4 +1,4 @@
-import { transitionIn, transitionOut, getXAttrs, warnIfMalformedTemplate } from '../utils'
+import { transitionIn, transitionOut, getXAttrs, warnIfMalformedTemplate, isNumeric } from '../utils'
 
 export function handleForDirective(component, templateEl, expression, initialUpdate, extraVars) {
     warnIfMalformedTemplate(templateEl, 'x-for')
@@ -90,6 +90,11 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
 
     if (ifAttribute && ! component.evaluateReturnExpression(el, ifAttribute.expression)) {
         return []
+    }
+
+    // This adds support for the `i in 10` syntax.
+    if (isNumeric(iteratorNames.items)) {
+        return [...Array(parseInt(iteratorNames.items)).keys()]
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars)

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -92,9 +92,9 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
         return []
     }
 
-    // This adds support for the `i in 10` syntax.
+    // This adds support for the `i in n` syntax.
     if (isNumeric(iteratorNames.items)) {
-        return [...Array(parseInt(iteratorNames.items, 10)).keys()]
+        return Array.from(Array(parseInt(iteratorNames.items, 10)).keys(), i => i + 1)
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars)

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -94,7 +94,7 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
 
     // This adds support for the `i in 10` syntax.
     if (isNumeric(iteratorNames.items)) {
-        return [...Array(parseInt(iteratorNames.items)).keys()]
+        return [...Array(parseInt(iteratorNames.items, 10)).keys()]
     }
 
     return component.evaluateReturnExpression(el, iteratorNames.items, extraVars)

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -477,3 +477,17 @@ test('make sure new elements with different keys added to the beginning of a loo
 
     expect(clickCount).toEqual(2)
 })
+
+test('x-for over range using i in x syntax', async () => {
+    document.body.innerHTML = `
+        <div x-data>
+            <template x-for="i in 10">
+                <span x-text="i"></span>
+            </template>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelectorAll('span').length).toEqual(10)
+})


### PR DESCRIPTION
This PR adds support for the `x-for="i in 10"` syntax that can be found in Vue. Lots of people have come to us with questions lately about how to replicate this in userland, but honestly the syntax is quite verbose and ugly.

The equivalent of `i in 10` would be `i in [...Array(10).keys()]` which, in my opinion, isn't too nice to look at and a bit of a pain. 

The only thing to note is how it compares to Vue, **Vue will start the count at 1**. So, the first value of `i` in `i in 10` would be `1`. 

~~With this implementation in Alpine, **the first value of `i` will be `0`**, since the `Array` itself starts at `0`. Happy to change this though and make it more in line with Vue's implementation if it means that the PR will get merged, I can imagine a lot of people being happy with this syntax in the core.~~

The first item in the loop would be the **number 1**, up through 10. 

* [x] Implement `i in 10` syntax
* [x] Add note to docs about new syntax