### PR TITLE
 fix(allow binding non string values to checkboxes)

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6466,8 +6466,8 @@
         // If we are explicitly binding a string to the :value, set the string,
         // If the value is a boolean, leave it alone, it will be set to "on"
         // automatically.
-        if (typeof value === 'string' && attrType === 'bind') {
-          el.value = value;
+        if (value && typeof value !== 'boolean' && attrType === 'bind') {
+          el.value = String(value);
         } else if (attrType !== 'bind') {
           if (Array.isArray(value)) {
             // I'm purposely not using Array.includes here because it's

--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6466,7 +6466,7 @@
         // If we are explicitly binding a string to the :value, set the string,
         // If the value is a boolean, leave it alone, it will be set to "on"
         // automatically.
-        if (value && typeof value !== 'boolean' && attrType === 'bind') {
+        if (typeof value !== 'boolean' && ![null, false, undefined].includes(value) && attrType === 'bind') {
           el.value = String(value);
         } else if (attrType !== 'bind') {
           if (Array.isArray(value)) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -647,7 +647,7 @@
         // If we are explicitly binding a string to the :value, set the string,
         // If the value is a boolean, leave it alone, it will be set to "on"
         // automatically.
-        if (value && typeof value !== 'boolean' && attrType === 'bind') {
+        if (typeof value !== 'boolean' && ![null, false, undefined].includes(value) && attrType === 'bind') {
           el.value = String(value);
         } else if (attrType !== 'bind') {
           if (Array.isArray(value)) {

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -647,8 +647,8 @@
         // If we are explicitly binding a string to the :value, set the string,
         // If the value is a boolean, leave it alone, it will be set to "on"
         // automatically.
-        if (typeof value === 'string' && attrType === 'bind') {
-          el.value = value;
+        if (value && typeof value !== 'boolean' && attrType === 'bind') {
+          el.value = String(value);
         } else if (attrType !== 'bind') {
           if (Array.isArray(value)) {
             // I'm purposely not using Array.includes here because it's

--- a/examples/index.html
+++ b/examples/index.html
@@ -110,6 +110,8 @@
                             <span x-text="JSON.stringify(checkbox)"></span>
                             <input type="checkbox" x-model="checkbox"
                                 value="foo">
+                                <input type="checkbox" x-model="checkbox"
+                                :value="0">
                             <input type="checkbox" x-model="checkbox"
                                 value="bar">
                             Radio:

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -25,7 +25,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             // If we are explicitly binding a string to the :value, set the string,
             // If the value is a boolean, leave it alone, it will be set to "on"
             // automatically.
-            if (value && typeof value !== 'boolean' && attrType === 'bind') {
+            if (typeof value !== 'boolean' && ! [null, undefined].includes(value) && attrType === 'bind') {
                 el.value = String(value)
             } else if (attrType !== 'bind') {
                 if (Array.isArray(value)) {

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -25,8 +25,8 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             // If we are explicitly binding a string to the :value, set the string,
             // If the value is a boolean, leave it alone, it will be set to "on"
             // automatically.
-            if (typeof value === 'string' && attrType === 'bind') {
-                el.value = value
+            if (value && typeof value !== 'boolean' && attrType === 'bind') {
+                el.value = String(value)
             } else if (attrType !== 'bind') {
                 if (Array.isArray(value)) {
                     // I'm purposely not using Array.includes here because it's

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -28,14 +28,14 @@ export function handleAttributeBindingDirective(component, el, attrName, express
             if (typeof value === 'string' && attrType === 'bind') {
                 el.value = value
             } else if (attrType !== 'bind') {
-               if (Array.isArray(value)) {
-                // I'm purposely not using Array.includes here because it's
-                // strict, and because of Numeric/String mis-casting, I
-                // want the "includes" to be "fuzzy".
-                el.checked = value.some(val => val == el.value)
-              } else {
-                el.checked = !! value
-              }
+                if (Array.isArray(value)) {
+                    // I'm purposely not using Array.includes here because it's
+                    // strict, and because of Numeric/String mis-casting, I
+                    // want the "includes" to be "fuzzy".
+                    el.checked = value.some(val => val == el.value)
+                } else {
+                    el.checked = !!value
+                }
             }
         } else if (el.tagName === 'SELECT') {
             updateSelect(el, value)
@@ -78,7 +78,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
 }
 
 function setIfChanged(el, attrName, value) {
-    if (el.getAttribute(attrName) != value){
+    if (el.getAttribute(attrName) != value) {
         el.setAttribute(attrName, value)
     }
 }

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -509,3 +509,19 @@ test('attribute binding names can contain numbers', async () => {
     expect(document.querySelector('line').getAttribute('x2')).toEqual('3');
     expect(document.querySelector('line').getAttribute('y2')).toEqual('4');
 })
+
+test('non-string and non-boolean attributes are cast to string when bound to checkbox', () => {
+    document.body.innerHTML = `
+        <div x-data="{ number: 100, bool: true, nullProp: null }">
+            <input type="checkbox" id="number" :value="number">
+            <input type="checkbox" id="boolean" :value="bool">
+            <input type="checkbox" id="null" :value="nullProp">
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('#number').value).toEqual('100')
+    expect(document.querySelector('#boolean').value).toEqual('on')
+    expect(document.querySelector('#null').value).toEqual('on')
+})

--- a/test/bind.spec.js
+++ b/test/bind.spec.js
@@ -512,8 +512,9 @@ test('attribute binding names can contain numbers', async () => {
 
 test('non-string and non-boolean attributes are cast to string when bound to checkbox', () => {
     document.body.innerHTML = `
-        <div x-data="{ number: 100, bool: true, nullProp: null }">
+        <div x-data="{ number: 100, zero: 0, bool: true, nullProp: null }">
             <input type="checkbox" id="number" :value="number">
+            <input type="checkbox" id="zero" :value="zero">
             <input type="checkbox" id="boolean" :value="bool">
             <input type="checkbox" id="null" :value="nullProp">
         </div>
@@ -522,6 +523,7 @@ test('non-string and non-boolean attributes are cast to string when bound to che
     Alpine.start()
 
     expect(document.querySelector('#number').value).toEqual('100')
+    expect(document.querySelector('#zero').value).toEqual('0')
     expect(document.querySelector('#boolean').value).toEqual('on')
     expect(document.querySelector('#null').value).toEqual('on')
 })


### PR DESCRIPTION
This PR fixes an issue where non-string values couldn't be bound to a checkbox's value. An example would be trying to bind an integer / number:

<input type="checkbox" x-data :value="100">

The value of the checkbox would actually be "on" due to the typeof value === 'string' check inside of the checkbox handler. This PR replaces that check with a value truth check and makes sure that it's not a boolean, then casts the value to a string using String(value).

This could be done in user-land using x-bind:value="String(100)" or template literals x-bind:value="${value}" but I'd say that it's a bit of a bug with the framework.