### PR TITLE
Docs: point out that x-init and x-data can't be "spread"

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -576,7 +576,9 @@ Estas, funcionan exactamente igual que las directivas de transición de VueJS co
 
 Las claves del objeto son las directivas (puede ser cualquiera, incluyendo modificadores), y los valores son *callbacks* a evaluar por Alpine.
 
-> Note: La única anomalía con x-spread ocurre cuando se usa junto a `x-for`. Cuando la directiva a extender es `x-for`, es necesario retornar una expresion en formato de *string* en el *callback*. Por ejemplo: `['x-for']() { return 'item in items' }`.
+> Note: Excepciónes con `x-spread`:
+> - Cuando la directiva a extender es `x-for`, es necesario retornar una expresion en formato de *string* en el *callback*. Por ejemplo: `['x-for']() { return 'item in items' }`.
+> - `x-init` y `x-data` no se pueden usar dentro de un objeto para "spread"
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -612,7 +612,9 @@ These behave exactly like VueJs's transition directives, except they have differ
 
 The object keys are the directives (Can be any directive including modifiers), and the values are callbacks to be evaluated by Alpine.
 
-> Note: The only anomaly with x-spread is when used with `x-for`. When the directive being "spread" is `x-for`, you should return a normal expression string from the callback. For example: `['x-for']() { return 'item in items' }`.
+> Note: There are a couple of caveats to x-spread:
+> - When the directive being "spread" is `x-for`, you should return a normal expression string from the callback. For example: `['x-for']() { return 'item in items' }`.
+> - `x-data` and `x-init` can't be used inside a "spread" object
 
 ---
 


### PR DESCRIPTION
A couple of people in the Discord came in wondering why code where `x-init` was defined inside an `x-spread` object wasn't working as intended.

Clarify this in the README.

Unfortunately my Japanese, Russian, Portuguese and Chinese chops aren't up to scratch 😄 so only updated in Spanish/English.