### PR TITLE
x-bind:aria-* booleans enabled for true and false

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,22 @@ This will add or remove the `disabled` attribute when `myVar` is true or false r
 
 Boolean attributes are supported as per the [HTML specification](https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute), for example `disabled`, `readonly`, `required`, `checked`, `hidden`, `selected`, `open`, etc.
 
+**`x-bind` for `aria-*` booleans attributes**
+Booleans for `aria-*` attributes require a `false` to exist so screen readers can understand the state of an object as per [W3C Recommendations](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def).
+
+For example:
+
+```html
+<!-- Given: -->
+<button x-bind:aria-expanded="myVar">Click me</button>
+
+<!-- When myVar == true: -->
+<button aria-expanded="true">Click me</button>
+
+<!-- When myVar == false: -->
+<button aria-expanded="false">Click me</button>
+```
+
 **`.camel` modifier**
 **Example:** `<svg x-bind:view-box.camel="viewBox">`
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ This will add or remove the `disabled` attribute when `myVar` is true or false r
 Boolean attributes are supported as per the [HTML specification](https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute), for example `disabled`, `readonly`, `required`, `checked`, `hidden`, `selected`, `open`, etc.
 
 **`x-bind` for `aria-*` booleans attributes**
+
 Booleans for `aria-*` attributes require a `false` to exist so screen readers can understand the state of an object as per [W3C Recommendations](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def).
 
 For example:

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -68,7 +68,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
     } else {
         attrName = modifiers.includes('camel') ? camelCase(attrName) : attrName
 
-        // If an attribute's bound value is null, undefined or false and does not include aria, remove the attribute
+        // If an attribute's bound value is null, undefined or false and does not start with aria, remove the attribute
         if ([null, undefined, false].includes(value) && !attrName.startsWith('aria')) {
             el.removeAttribute(attrName)
         } else {

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -69,7 +69,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         attrName = modifiers.includes('camel') ? camelCase(attrName) : attrName
 
         // If an attribute's bound value is null, undefined or false and does not include aria, remove the attribute
-        if ([null, undefined, false].includes(value) && !attrName.includes('aria')) {
+        if ([null, undefined, false].includes(value) && !attrName.startsWith('aria')) {
             el.removeAttribute(attrName)
         } else {
             isBooleanAttr(attrName) ? setIfChanged(el, attrName, attrName) : setIfChanged(el, attrName, value)

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -68,8 +68,8 @@ export function handleAttributeBindingDirective(component, el, attrName, express
     } else {
         attrName = modifiers.includes('camel') ? camelCase(attrName) : attrName
 
-        // If an attribute's bound value is null, undefined or false, remove the attribute
-        if ([null, undefined, false].includes(value)) {
+        // If an attribute's bound value is null, undefined or false and does not include aria, remove the attribute
+        if ([null, undefined, false].includes(value) && !attrName.includes('aria')) {
             el.removeAttribute(attrName)
         } else {
             isBooleanAttr(attrName) ? setIfChanged(el, attrName, attrName) : setIfChanged(el, attrName, value)


### PR DESCRIPTION
This PR fixes an issue where `x-bind` is used on an `aria-*` attribute as a boolean and the `false` state is removed.

Booleans for `aria-*` attributes require a `false` to exist so screen readers can understand the state of an object as per [W3C Recommendations](https://www.w3.org/TR/wai-aria-1.1/#state_prop_def).

#### `false` Inspector Screenshot
![aria false example](https://user-images.githubusercontent.com/1840132/93836440-6c1e6e80-fc48-11ea-89b6-aaa04f3d4e47.png)
