### PR TITLE
Docs: Add note to chain .toString() to persist  false

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ This will add or remove the `disabled` attribute when `myVar` is true or false r
 
 Boolean attributes are supported as per the [HTML specification](https://html.spec.whatwg.org/multipage/indices.html#attributes-3:boolean-attribute), for example `disabled`, `readonly`, `required`, `checked`, `hidden`, `selected`, `open`, etc.
 
+> Note: If you need a false state to show for your attribute, such as `aria-*`, chain `.toString()` to the value while binding to the attribute. For example: `:aria-expanded="isOpen.toString()"` would persist whether  `isOpen` was `true` or `false`.
+
 **`.camel` modifier**
 **Example:** `<svg x-bind:view-box.camel="viewBox">`
 


### PR DESCRIPTION
Adding a note to the docs for `x-bind` to make it clear to chain `.toString()` to the value if you need to persist a false value on a bound attribute.