### PR TITLE
docs: switch li to div

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -62,12 +62,12 @@ Da obige Schema wird als [module/nomodule pattern](https://philipwalton.com/arti
 <div x-data="{ open: false }">
     <button @click="open = true">Öffne Dropdown</button>
 
-    <ul
+    <div
         x-show="open"
         @click.away="open = false"
     >
         Dropdown Inhalt
-    </ul>
+    </div>
 </div>
 ```
 

--- a/README.es.md
+++ b/README.es.md
@@ -51,12 +51,12 @@ El patrón de arriba es el [module/nomodule pattern](https://philipwalton.com/ar
 <div x-data="{ open: false }">
     <button @click="open = true">Abrir Desplegable</button>
 
-    <ul
+    <div
         x-show="open"
         @click.away="open = false"
     >
         Cuerpo del Desplegable
-    </ul>
+    </div>
 </div>
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,12 +42,12 @@ IE11 では、ポリフィルを提供する必要があります。次のスク
 <div x-data="{ open: false }">
     <button @click="open = true">Open Dropdown</button>
 
-    <ul
+    <div
         x-show="open"
         @click.away="open = false"
     >
         Dropdown Body
-    </ul>
+    </div>
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ The pattern above is the [module/nomodule pattern](https://philipwalton.com/arti
 <div x-data="{ open: false }">
     <button @click="open = true">Open Dropdown</button>
 
-    <ul
+    <div
         x-show="open"
         @click.away="open = false"
     >
         Dropdown Body
-    </ul>
+    </div>
 </div>
 ```
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -58,9 +58,9 @@ _Dropdown/Modal_
 <div x-data="{ open: false }">
     <button @click="open = true">Open Dropdown</button>
 
-    <ul x-show="open" @click.away="open = false">
+    <div x-show="open" @click.away="open = false">
         Corpo do Dropdown
-    </ul>
+    </div>
 </div>
 ```
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -52,12 +52,12 @@ import 'alpinejs'
 <div x-data="{ open: false }">
     <button @click="open = true">Открыть дропдаун</button>
 
-    <ul
+    <div
         x-show="open"
         @click.away="open = false"
     >
         Содержимое дропдаун
-    </ul>
+    </div>
 </div>
 ```
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -52,12 +52,12 @@ import 'alpinejs'
 <div x-data="{ open: false }">
     <button @click="open = true">展開下拉選單</button>
 
-    <ul
+    <div
         x-show="open"
         @click.away="open = false"
     >
         下拉選單內容
-    </ul>
+    </div>
 </div>
 ```
 


### PR DESCRIPTION
The example for a modal uses a `ul`, with content, but with no children `li` wrapping the content. As far as I know this is invalid HTML/semantics. Swapped out the `ul` for a `div`. 