### PR TITLE
fix(x-for): issue with range iteration and numeric arrays

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6270,7 +6270,7 @@
     }.bind(this));
   }
   function isNumeric(subject) {
-    return !isNaN(subject);
+    return !Array.isArray(subject) && !isNaN(subject);
   } // Thanks @vuejs
   // https://github.com/vuejs/vue/blob/4de4649d9637262a9b007720b59f80ac72a5620c/src/shared/util.js
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -491,7 +491,7 @@
     });
   }
   function isNumeric(subject) {
-    return !isNaN(subject);
+    return !Array.isArray(subject) && !isNaN(subject);
   } // Thanks @vuejs
   // https://github.com/vuejs/vue/blob/4de4649d9637262a9b007720b59f80ac72a5620c/src/shared/util.js
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -486,7 +486,7 @@ export function transition(el, stages, type) {
 }
 
 export function isNumeric(subject){
-    return ! isNaN(subject)
+    return ! Array.isArray(subject) && ! isNaN(subject)
 }
 
 // Thanks @vuejs

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -512,15 +512,23 @@ test('x-for with an array of numbers', async () => {
             <template x-for="i in items">
                 <span x-text="i"></span>
             </template>
-            <button @click="items.push(2)"></button>
+            <button id="push-2" @click="items.push(2)"></button>
+            <button id="push-3" @click="items.push(3)"></button>
         </div>
     `
 
     Alpine.start()
 
-    document.querySelector('button').click()
+    document.querySelector('#push-2').click()
 
     await wait(() => {
         expect(document.querySelector('span').textContent).toEqual('2')
+    })
+
+    document.querySelector('#push-3').click()
+
+    await wait(() => {
+        expect(document.querySelectorAll('span').length).toEqual(2)
+        expect(document.querySelectorAll('span')[1].textContent).toEqual('3')
     })
 })

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -505,3 +505,22 @@ test('x-for over range using i in x syntax with data property', async () => {
 
     expect(document.querySelectorAll('span').length).toEqual(10)
 })
+
+test('x-for with an array of numbers', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ items: [] }">
+            <template x-for="i in items">
+                <span x-text="i"></span>
+            </template>
+            <button @click="items.push(2)"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelector('button').click()
+
+    await wait(() => {
+        expect(document.querySelector('span').textContent).toEqual('2')
+    })
+})


### PR DESCRIPTION
Closes #839. The problem was being caused by the `isNumeric` utility using `isNaN()` on arrays. 

When an array only contains 1 item, that is numeric, it will converted to a `Number` object that holds that value of the first item, therefore passing the `isNumeric` check. This PR just changes it to check that the `subject` being passed through is **not** an array using `Array.isArray`.