### PR TITLE
Helpers to receive access to cloned component

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -22,10 +22,8 @@ export default class Component {
             $el: this.$el,
         }
 
-        let canonicalComponentElementReference = componentForClone ? componentForClone.$el : this.$el
-
         Object.entries(Alpine.magicProperties).forEach(([name, callback]) => {
-            Object.defineProperty(dataExtras, `$${name}`, { get: function () { return callback(canonicalComponentElementReference) } });
+            Object.defineProperty(dataExtras, `$${name}`, { get: function () { return callback(this.$el) } });
         })
 
         this.unobservedData = componentForClone ? componentForClone.getUnobservedData() : saferEval(dataExpression, dataExtras)
@@ -41,7 +39,7 @@ export default class Component {
             // to be defined after the proxy object is created so,
             // for IE only, we need to define our helpers earlier.
             Object.entries(Alpine.magicProperties).forEach(([name, callback]) => {
-                Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(canonicalComponentElementReference) } });
+                Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(this.$el) } });
             })
         /* IE11-ONLY:END */
 
@@ -74,7 +72,7 @@ export default class Component {
 
         // Register custom magic properties.
         Object.entries(Alpine.magicProperties).forEach(([name, callback]) => {
-            Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(canonicalComponentElementReference) } });
+            Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(this.$el) } });
         })
         /* MODERN-ONLY:END */
 

--- a/src/component.js
+++ b/src/component.js
@@ -41,7 +41,7 @@ export default class Component {
             // to be defined after the proxy object is created so,
             // for IE only, we need to define our helpers earlier.
             Object.entries(Alpine.magicProperties).forEach(([name, callback]) => {
-                Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(this.$el) } });
+                Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(canonicalComponentElementReference, this.$el) } });
             })
         /* IE11-ONLY:END */
 
@@ -74,7 +74,7 @@ export default class Component {
 
         // Register custom magic properties.
         Object.entries(Alpine.magicProperties).forEach(([name, callback]) => {
-            Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(this.$el) } });
+            Object.defineProperty(this.unobservedData, `$${name}`, { get: function () { return callback(canonicalComponentElementReference, this.$el) } });
         })
         /* MODERN-ONLY:END */
 

--- a/src/component.js
+++ b/src/component.js
@@ -22,8 +22,10 @@ export default class Component {
             $el: this.$el,
         }
 
+        let canonicalComponentElementReference = componentForClone ? componentForClone.$el : this.$el
+
         Object.entries(Alpine.magicProperties).forEach(([name, callback]) => {
-            Object.defineProperty(dataExtras, `$${name}`, { get: function () { return callback(this.$el) } });
+            Object.defineProperty(dataExtras, `$${name}`, { get: function () { return callback(canonicalComponentElementReference) } });
         })
 
         this.unobservedData = componentForClone ? componentForClone.getUnobservedData() : saferEval(dataExpression, dataExtras)


### PR DESCRIPTION
Opening this PR to make it easier to understand my intent of #835 

The `canonicalComponentElementReference` may be needed to compute the initial state but it doesn't seem needed after that. More importantly, magic helpers in some cases need access to the most current cloned component, not the canonical component (which is about to be deleted).

Relevant part of the code:
https://github.com/alpinejs/alpine/blob/master/src/component.js#L25