### PR TITLE
Feat: better (eval) error messages/context

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -48,9 +48,10 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>Broken Component</td>
+                    <td>Broken Components</td>
                     <td>
                         <div x-data="some.bad.expression()">I'm a broken component</div>
+                        <button x-data x-on:click="something()">I break on click</button>
                     </td>
                 </tr>
 

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -9,6 +9,10 @@ export function handleForDirective(component, templateEl, expression, initialUpd
 
     let items = evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, templateEl, iteratorNames, extraVars)
 
+    if (! Array.isArray(items)) {
+        throw new TypeError(`collection "${iteratorNames.items}" in x-for="${expression}" is not an array, got "${JSON.stringify(items)}"`)
+    }
+
     // As we walk the array, we'll also walk the DOM (updating/creating as we go).
     let currentEl = templateEl
     items.forEach((item, index) => {

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -1,4 +1,4 @@
-import { kebabCase, camelCase, debounce, isNumeric } from '../utils'
+import { kebabCase, camelCase, debounce, isNumeric, rethrowErrorWithContext } from '../utils'
 
 export function registerListener(component, el, event, modifiers, expression, extraVars = {}) {
     const options = {
@@ -82,6 +82,8 @@ export function registerListener(component, el, event, modifiers, expression, ex
 function runListenerHandler(component, expression, e, extraVars) {
     return component.evaluateCommandExpression(e.target, expression, () => {
         return {...extraVars(), '$event': e}
+    }).catch(error => {
+        rethrowErrorWithContext('listener', component.$el, error)
     })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Component from './component'
-import { domReady, isTesting } from './utils'
+import { domReady, isTesting, rethrowErrorWithContext } from './utils'
 
 const Alpine = {
     version: process.env.PKG_VERSION,
@@ -93,7 +93,7 @@ const Alpine = {
                 el.__x = new Component(el)
             } catch (error) {
                 setTimeout(() => {
-                    throw error
+                    rethrowErrorWithContext('initialization', el, error)
                 }, 0)
             }
         }

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -1,0 +1,89 @@
+import Alpine from 'alpinejs'
+import { wait } from '@testing-library/dom'
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+jest.spyOn(window, 'setTimeout').mockImplementation((callback) => {
+    callback()
+})
+const a = jest.fn();
+process.on('unhandledRejection', (error) => {
+    a(error)
+})
+
+test('error in x-data eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'bar' ">
+            <span x-bind:foo="foo.bar"></span>
+        </div>
+    `
+    const startPromise = Alpine.start()
+    await expect(startPromise).rejects.toThrow(`Could not run initialization on: <div x-data=\"{ foo: 'bar' \">
+            <span x-bind:foo=\"foo.bar\"></span>
+        </div>
+SyntaxError: \"{ foo: 'bar' \" is invalid due to:
+SyntaxError: Unexpected token ')'`)
+})
+
+test('error in x-bind eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: null }">
+            <span x-bind:foo="foo.bar"></span>
+        </div>
+    `
+    const startPromise = Alpine.start()
+    await expect(startPromise).rejects.toThrow(`Could not run initialization on: <div x-data=\"{ foo: null }\">
+            <span x-bind:foo=\"foo.bar\"></span>
+        </div>
+SyntaxError: \"foo.bar\" is invalid due to:
+TypeError: Cannot read property 'bar' of null`)
+})
+
+test('error in x-model eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: null }">
+            <input x-model="foo.bar">
+        </div>
+    `
+    const startPromise = Alpine.start()
+    await expect(startPromise).rejects.toThrow(`Could not run initialization on: <div x-data=\"{ foo: null }\">
+            <input x-model="foo.bar">
+        </div>
+SyntaxError: "foo.bar" is invalid due to:
+TypeError: Cannot read property 'bar' of null`)
+})
+
+test('error in x-for eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ arr: null }">
+            <template x-for="element in arr">
+                <span x-text="element"></span>
+            </template>
+        </div>
+    `
+    const startPromise = Alpine.start()
+    await expect(startPromise).rejects.toThrow(`Could not run initialization on: <div x-data=\"{ arr: null }\">
+            <template x-for=\"element in arr\">
+                <span x-text=\"element\"></span>
+            </template>
+        </div>
+TypeError: collection \"arr\" in x-for=\"element in arr\" is not an array, got "null"`)
+})
+
+// Skipped because the test fails due to an error being thrown and not being able to handle it.
+test.skip('error in x-on eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div
+            x-data="{hello: null}"
+            x-on:click="hello.world"
+        ></div>
+    `
+    await Alpine.start()
+    document.querySelector('div').click()
+    // a global error gets thrown, no way to stop it from failing the test
+    await wait(() => {
+        expect(a).toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
Closes #783 (or maybe is just a starting point to better error messages)

tl;dr: 
- surface what expression is being evaluated and why it's throwing
- surface the component from which the error is being thrown

Contents of the PR:
- handling of eval errors.
- handling of initialization errors.
- handling of listener errors.
- error unit tests.
- better error-handling for x-for (throw if collection is not an array)
- error examples (x-data and x-on)