### PR TITLE
Feat: better (eval) error messages/context

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -48,9 +48,10 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>Broken Component</td>
+                    <td>Broken Components</td>
                     <td>
                         <div x-data="some.bad.expression()">I'm a broken component</div>
+                        <button x-data x-on:click="something()">I break on click</button>
                     </td>
                 </tr>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -52,6 +52,7 @@
                     <td>
                         <div x-data="some.bad.expression()">I'm a broken component</div>
                         <button x-data x-on:click="something()">I break on click</button>
+                        <div x-data x-spread="not.good">Broken x-spread</div>
                     </td>
                 </tr>
 

--- a/src/component.js
+++ b/src/component.js
@@ -390,7 +390,8 @@ export default class Component {
                 if (! (closestParentComponent && closestParentComponent.isSameNode(this.$el))) continue
 
                 if (mutations[i].type === 'attributes' && mutations[i].attributeName === 'x-data') {
-                    const rawData = saferEval(mutations[i].target.getAttribute('x-data') || '{}', { $el: this.$el })
+                    const xAttr = mutations[i].target.getAttribute('x-data') || '{}';
+                    const rawData = tryCatch(() => saferEval(xAttr, { $el: this.$el }), { el: this.$el, xAttr })
 
                     Object.keys(rawData).forEach(key => {
                         if (this.$data[key] !== rawData[key]) {

--- a/src/component.js
+++ b/src/component.js
@@ -354,8 +354,7 @@ export default class Component {
         return tryCatch(() => saferEval(expression, this.$data, {
             ...extraVars(),
             $dispatch: this.getDispatchFunction(el),
-        }),
-        { el, expression })
+        }), { el, expression })
     }
 
     evaluateCommandExpression(el, expression, extraVars = () => {}) {

--- a/src/component.js
+++ b/src/component.js
@@ -28,9 +28,7 @@ export default class Component {
             Object.defineProperty(dataExtras, `$${name}`, { get: function () { return callback(canonicalComponentElementReference) } });
         })
 
-        tryCatch(() => {
-            this.unobservedData = componentForClone ? componentForClone.getUnobservedData() : saferEval(dataExpression, dataExtras)
-        }, { el, expression: dataExpression })
+        this.unobservedData = componentForClone ? componentForClone.getUnobservedData() : tryCatch(() => saferEval(dataExpression, dataExtras), { el, expression: dataExpression })
 
         /* IE11-ONLY:START */
             // For IE11, add our magic properties to the original data for access.

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,7 +67,7 @@ export function debounce(func, wait) {
 
 const handleError = (el, expression, error) => {
     console.error(`Alpine: error in expression "${expression}" in component:`, el, `due to "${error}"`);
-    if (!isTesting()) {
+    if (! isTesting()) {
         throw error;
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ export function debounce(func, wait) {
 }
 
 const handleError = (el, expression, error) => {
-    console.error(`Alpine: error in expression "${expression}" in component: `, el, `due to "${error}"`);
+    console.error(`Alpine: error in expression "${expression}" in component:`, el, `due to "${error}"`);
     if (!isTesting()) {
         throw error;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,6 +65,24 @@ export function debounce(func, wait) {
     }
 }
 
+const handleError = (el, expression, error) => {
+    console.error(`Alpine: error in expression "${expression}" in component: `, el, `due to "${error}"`);
+    if (!isTesting()) {
+        throw error;
+    }
+}
+
+export function tryCatch(cb, { el, expression }) {
+    try {
+        const value = cb();
+        return value instanceof Promise
+            ? value.catch((e) => handleError(el, expression, e))
+            : value;
+    } catch (e) {
+        handleError(el, expression, e)
+    }
+}
+
 export function saferEval(expression, dataContext, additionalHelperVariables = {}) {
     if (typeof expression === 'function') {
         return expression.call(dataContext)

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,8 +142,7 @@ export function getXAttrs(el, component, type) {
     let spreadDirective = directives.filter(directive => directive.type === 'spread')[0]
 
     if (spreadDirective) {
-        const { expression } = spreadDirective
-        let spreadObject = saferEval(el, expression, component.$data)
+        let spreadObject = saferEval(el, spreadDirective.expression, component.$data)
 
         // Add x-spread directives to the pile of existing directives.
         directives = directives.concat(Object.entries(spreadObject).map(([name, value]) => parseHtmlAttribute({ name, value })))

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,7 +138,8 @@ export function getXAttrs(el, component, type) {
     let spreadDirective = directives.filter(directive => directive.type === 'spread')[0]
 
     if (spreadDirective) {
-        let spreadObject = saferEval(spreadDirective.expression, component.$data)
+        const { expression } = spreadDirective
+        let spreadObject = tryCatch(() => saferEval(expression, component.$data), { expression, el })
 
         // Add x-spread directives to the pile of existing directives.
         directives = directives.concat(Object.entries(spreadObject).map(([name, value]) => parseHtmlAttribute({ name, value })))

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -1,0 +1,88 @@
+import Alpine from 'alpinejs'
+import { wait } from '@testing-library/dom'
+
+global.MutationObserver = class {
+    observe() {}
+}
+
+jest.spyOn(window, 'setTimeout').mockImplementation((callback) => {
+    callback()
+})
+
+const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+beforeEach(() => {
+    jest.clearAllMocks()
+})
+
+test('error in x-data eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'bar' ">
+            <span x-bind:foo="foo.bar"></span>
+        </div>
+    `
+    await expect(Alpine.start()).rejects.toThrow()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+        "Alpine: error in expression \"{ foo: 'bar' \" in component: ",
+        document.querySelector('[x-data]'),
+        "due to \"SyntaxError: Unexpected token ')'\""
+    )
+})
+
+test('error in x-bind eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: null }">
+            <span x-bind:foo="foo.bar"></span>
+        </div>
+    `
+    await Alpine.start()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+        "Alpine: error in expression \"foo.bar\" in component: ",
+        document.querySelector('[x-bind:foo]'),
+        "due to \"TypeError: Cannot read property 'bar' of null\""
+    )
+})
+
+test('error in x-model eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: null }">
+            <input x-model="foo.bar">
+        </div>
+    `
+    await Alpine.start()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+        "Alpine: error in expression \"foo.bar\" in component: ",
+        document.querySelector('[x-model]'),
+        "due to \"TypeError: Cannot read property 'bar' of null\""
+    )
+})
+
+test('error in x-for eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data="{}">
+            <template x-for="element in foo">
+                <span x-text="element"></span>
+            </template>
+        </div>
+    `
+    await expect(Alpine.start()).rejects.toThrow()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+        "Alpine: error in expression \"foo\" in component: ",
+        document.querySelector('[x-for]'),
+        "due to \"ReferenceError: foo is not defined\""
+    )
+})
+
+test('error in x-on eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div
+            x-data="{hello: null}"
+            x-on:click="hello.world"
+        ></div>
+    `
+    await Alpine.start()
+    document.querySelector('div').click()
+    await wait(() => {
+        expect(mockConsoleError).toHaveBeenCalled()
+    })
+})

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -29,6 +29,19 @@ test('error in x-data eval contains element, expression and original error', asy
     )
 })
 
+test('error in x-init eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data x-init="foo.bar = 'baz'">
+        </div>
+    `
+    await Alpine.start()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+        "Alpine: error in expression \"foo.bar = 'baz'\" in component:",
+        document.querySelector('[x-data]'),
+        "due to \"ReferenceError: foo is not defined\""
+    )
+})
+
 test('error in x-bind eval contains element, expression and original error', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: null }">

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -110,6 +110,10 @@ test('error in x-on eval contains element, expression and original error', async
     await Alpine.start()
     document.querySelector('div').click()
     await wait(() => {
-        expect(mockConsoleError).toHaveBeenCalled()
+        expect(mockConsoleError).toHaveBeenCalledWith(
+            "Alpine: error in expression \"hello.world\" in component:",
+            document.querySelector('[x-data]'),
+            "due to \"TypeError: Cannot read property 'world' of null\""
+        )
     })
 })

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -23,7 +23,7 @@ test('error in x-data eval contains element, expression and original error', asy
     `
     await expect(Alpine.start()).rejects.toThrow()
     expect(mockConsoleError).toHaveBeenCalledWith(
-        "Alpine: error in expression \"{ foo: 'bar' \" in component: ",
+        "Alpine: error in expression \"{ foo: 'bar' \" in component:",
         document.querySelector('[x-data]'),
         "due to \"SyntaxError: Unexpected token ')'\""
     )
@@ -37,7 +37,7 @@ test('error in x-bind eval contains element, expression and original error', asy
     `
     await Alpine.start()
     expect(mockConsoleError).toHaveBeenCalledWith(
-        "Alpine: error in expression \"foo.bar\" in component: ",
+        "Alpine: error in expression \"foo.bar\" in component:",
         document.querySelector('[x-bind:foo]'),
         "due to \"TypeError: Cannot read property 'bar' of null\""
     )
@@ -51,7 +51,7 @@ test('error in x-model eval contains element, expression and original error', as
     `
     await Alpine.start()
     expect(mockConsoleError).toHaveBeenCalledWith(
-        "Alpine: error in expression \"foo.bar\" in component: ",
+        "Alpine: error in expression \"foo.bar\" in component:",
         document.querySelector('[x-model]'),
         "due to \"TypeError: Cannot read property 'bar' of null\""
     )
@@ -67,7 +67,7 @@ test('error in x-for eval contains element, expression and original error', asyn
     `
     await expect(Alpine.start()).rejects.toThrow()
     expect(mockConsoleError).toHaveBeenCalledWith(
-        "Alpine: error in expression \"foo\" in component: ",
+        "Alpine: error in expression \"foo\" in component:",
         document.querySelector('[x-for]'),
         "due to \"ReferenceError: foo is not defined\""
     )

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -42,6 +42,20 @@ test('error in x-init eval contains element, expression and original error', asy
     )
 })
 
+test('error in x-spread eval contains element, expression and original error', async () => {
+    document.body.innerHTML = `
+        <div x-data x-spread="foo.bar">
+        </div>
+    `
+    // swallow the rendering error
+    await expect(Alpine.start()).rejects.toThrow()
+    expect(mockConsoleError).toHaveBeenCalledWith(
+        "Alpine: error in expression \"foo.bar\" in component:",
+        document.querySelector('[x-data]'),
+        "due to \"ReferenceError: foo is not defined\""
+    )
+})
+
 test('error in x-bind eval contains element, expression and original error', async () => {
     document.body.innerHTML = `
         <div x-data="{ foo: null }">


### PR DESCRIPTION
Closes #783 

from these discussion points on the other PR:
- https://github.com/alpinejs/alpine/pull/862#issuecomment-732275009 
- https://github.com/alpinejs/alpine/pull/862#issuecomment-732293276

Implement the suggestion from the latter comment.

Errors are logged as follows:

![Screenshot 2020-11-23 at 18 14 42](https://user-images.githubusercontent.com/6459679/99999250-ce662d80-2db7-11eb-8ab5-e2b904780b0c.png)
