### PR TITLE
Fuse filter when combined with forEach, map...

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -149,8 +149,9 @@ export default class Component {
                 // Let's walk through the watchers with "dot-notation" (foo.bar) and see
                 // if this mutation fits any of them.
                 Object.keys(self.watchers)
-                    .filter(i => i.includes('.'))
                     .forEach(fullDotNotationKey => {
+                        if (!fullDotNotationKey.includes('.')) return;
+
                         let dotNotationParts = fullDotNotationKey.split('.')
 
                         // If this dot-notation watcher's last "part" doesn't match the current

--- a/src/index.js
+++ b/src/index.js
@@ -46,9 +46,8 @@ const Alpine = {
         const rootEls = (el || document).querySelectorAll('[x-data]');
 
         Array.from(rootEls)
-            .filter(el => el.__x === undefined)
-            .forEach(rootEl => {
-                callback(rootEl)
+            .forEach(el => {
+                el.__x === undefined && callback(el)
             })
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -114,7 +114,10 @@ export function isXAttr(attr) {
 }
 
 export function getXAttrs(el, component, type) {
-    let directives = Array.from(el.attributes).filter(isXAttr).map(parseHtmlAttribute)
+    let directives = Array.from(el.attributes).reduce((acc, attr) => {
+      isXAttr(attr) && acc.push(parseHtmlAttribute(attr))
+      return acc
+    }, [])
 
     // Get an object of directives from x-spread.
     let spreadDirective = directives.filter(directive => directive.type === 'spread')[0]


### PR DESCRIPTION
`.filter` calls when combined with `.forEach` or `.map` results in a 2 traversal and requires to allocate an intermediate array.

`.filter().map()` can be fused using `.reduce()`.
`.filter().forEach()` can be fused using only the `.forEach` and return if the current element don't pass the filter predicate.

In this refactor, all tests are done indirectly.