### PR TITLE
Cast x-spread expression to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ The object keys are the directives (Can be any directive including modifiers), a
 > Note: There are a couple of caveats to x-spread:
 > - When the directive being "spread" is `x-for`, you should return a normal expression string from the callback. For example: `['x-for']() { return 'item in items' }`.
 > - `x-data` and `x-init` can't be used inside a "spread" object.
+> - When using `x-ref`, you should bind it like any other attribute. For example: `['x-bind:x-ref']() { return 'foo' }`
 
 ---
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -574,7 +574,7 @@
     let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/;
     let stripParensRE = /^\(|\)$/g;
     let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/;
-    let inMatch = String(expression).match(forAliasRE);
+    let inMatch = expression.match(forAliasRE);
     if (!inMatch) return;
     let res = {};
     res.items = inMatch[2].trim();
@@ -671,7 +671,7 @@
     if (attrName === 'value') {
       if (Alpine.ignoreFocusedForValueBinding && document.activeElement.isSameNode(el)) return; // If nested model key is undefined, set the default value to empty string.
 
-      if (value === undefined && String(expression).match(/\./)) {
+      if (value === undefined && expression.match(/\./)) {
         value = '';
       }
 
@@ -754,7 +754,7 @@
 
   function handleTextDirective(el, output, expression) {
     // If nested model key is undefined, set the default value to empty string.
-    if (output === undefined && String(expression).match(/\./)) {
+    if (output === undefined && expression.match(/\./)) {
       output = '';
     }
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -574,7 +574,7 @@
     let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/;
     let stripParensRE = /^\(|\)$/g;
     let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/;
-    let inMatch = expression.match(forAliasRE);
+    let inMatch = String(expression).match(forAliasRE);
     if (!inMatch) return;
     let res = {};
     res.items = inMatch[2].trim();
@@ -671,7 +671,7 @@
     if (attrName === 'value') {
       if (Alpine.ignoreFocusedForValueBinding && document.activeElement.isSameNode(el)) return; // If nested model key is undefined, set the default value to empty string.
 
-      if (value === undefined && expression.match(/\./)) {
+      if (value === undefined && String(expression).match(/\./)) {
         value = '';
       }
 
@@ -754,7 +754,7 @@
 
   function handleTextDirective(el, output, expression) {
     // If nested model key is undefined, set the default value to empty string.
-    if (output === undefined && expression.match(/\./)) {
+    if (output === undefined && String(expression).match(/\./)) {
       output = '';
     }
 

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -8,7 +8,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         if (Alpine.ignoreFocusedForValueBinding && document.activeElement.isSameNode(el)) return
 
         // If nested model key is undefined, set the default value to empty string.
-        if (value === undefined && expression.match(/\./)) {
+        if (value === undefined && String(expression).match(/\./)) {
             value = ''
         }
 

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -8,7 +8,7 @@ export function handleAttributeBindingDirective(component, el, attrName, express
         if (Alpine.ignoreFocusedForValueBinding && document.activeElement.isSameNode(el)) return
 
         // If nested model key is undefined, set the default value to empty string.
-        if (value === undefined && String(expression).match(/\./)) {
+        if (value === undefined && expression.match(/\./)) {
             value = ''
         }
 

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -46,7 +46,7 @@ function parseForExpression(expression) {
     let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
     let stripParensRE = /^\(|\)$/g
     let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
-    let inMatch = String(expression).match(forAliasRE)
+    let inMatch = expression.match(forAliasRE)
     if (! inMatch) return
     let res = {}
     res.items = inMatch[2].trim()

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -46,7 +46,7 @@ function parseForExpression(expression) {
     let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
     let stripParensRE = /^\(|\)$/g
     let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
-    let inMatch = expression.match(forAliasRE)
+    let inMatch = String(expression).match(forAliasRE)
     if (! inMatch) return
     let res = {}
     res.items = inMatch[2].trim()

--- a/src/directives/text.js
+++ b/src/directives/text.js
@@ -1,6 +1,6 @@
 export function handleTextDirective(el, output, expression) {
     // If nested model key is undefined, set the default value to empty string.
-    if (output === undefined && expression.match(/\./)) {
+    if (output === undefined && String(expression).match(/\./)) {
         output = ''
     }
 

--- a/src/directives/text.js
+++ b/src/directives/text.js
@@ -1,6 +1,6 @@
 export function handleTextDirective(el, output, expression) {
     // If nested model key is undefined, set the default value to empty string.
-    if (output === undefined && String(expression).match(/\./)) {
+    if (output === undefined && expression.match(/\./)) {
         output = ''
     }
 

--- a/test/spread.spec.js
+++ b/test/spread.spec.js
@@ -215,3 +215,29 @@ test('x-spread event handlers defined as functions receive the event object as t
         expect(document.querySelector("div").__x.$data.eventType).toEqual("click");
     });
 });
+
+test('x-spread undefined values can fail gracefully', async () => {
+    window.data = function () {
+        return {
+            foo: {
+                ['x-text'](){
+                    return this.somethingUndefined;
+                }
+            }
+        };
+    };
+
+    document.body.innerHTML = `
+        <div x-data="window.data()">
+            <button x-text="somethingUndefined">should be empty string</button>
+            <span x-spread="foo">should be empty string<span>
+        </div>
+    `;
+
+    Alpine.start();
+
+    await wait(() => {
+        expect(document.querySelector("button").textContent).toEqual('')
+        expect(document.querySelector("span").textContent).toEqual('')
+    })
+});


### PR DESCRIPTION
This breaks because expressions are functions in x-spread, and when the output is defined, it attempts to run a String operation on it.

```js
 if (output === undefined && expression.match(/\./)) {
     output = ''
 }
```

...which causes an error. This fix will just cast the function there to a string so it won't error out.

Fixes #957 
