### PR TITLE
Attach el + expression to eval error

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -69,6 +69,7 @@ const handleError = (el, expression, error) => {
     console.warn(`Alpine Error: "${error}"\n\nExpression: "${expression}"\nElement:`, el);
 
     if (! isTesting()) {
+        Object.assign(error, { el, expression })
         throw error;
     }
 }


### PR DESCRIPTION
The error can then be read using:

```js
// might need to listen to "error" as well for non-async eval errors
window.addEventListener('unhandledrejection', (event) => {
  console.log(event.reason.el, event.reason.expression, event.reason.toString())
})
```