### PR TITLE
Allow x-init on child nodes

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -343,6 +343,13 @@ export default class Component {
                 case 'cloak':
                     el.removeAttribute('x-cloak')
                     break;
+                    
+                case 'init':
+                    // x-init on the root element needs to be handled differently, so skip
+                    // them, and only call init on component children during the initial render. 
+                    if (!initialUpdate || el.hasAttribute('x-data')) return;
+                    this.evaluateReturnExpression(el, expression, extraVars);
+                    break;
 
                 default:
                     break;

--- a/src/utils.js
+++ b/src/utils.js
@@ -128,7 +128,7 @@ export function saferEvalNoReturn(el, expression, dataContext, additionalHelperV
     }, { el, expression })
 }
 
-const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread)\b/
+const xAttrRE = /^x-(on|bind|data|text|html|model|if|for|show|cloak|transition|ref|spread|init)\b/
 
 export function isXAttr(attr) {
     const name = replaceAtAndColonWithStandardSyntax(attr.name)

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -103,3 +103,20 @@ test('x-init is capable of dispatching an event', async () => {
         expect(document.querySelector('span').textContent).toEqual('baz')
     })
 })
+
+test('x-init is called on component children', async () => {
+    window.parentValue = null
+    window.childValue = null
+    window.initIndex = 0
+    
+    document.body.innerHTML = `
+        <div x-data="{ foo: 'bar' }" x-init="window.parentValue = window.initIndex++">
+            <div x-init="window.childValue = window.initIndex++"></div>
+        </div>
+    `
+    
+    Alpine.start()
+    
+    expect(window.parentValue).toEqual(0)
+    expect(window.childValue).toEqual(1)
+})


### PR DESCRIPTION
Right now `x-init` only fires on root components (i.e. DOM nodes with `x-data` attributes). This PR lets child nodes also add `x-init` calls.

The primary use-case is when Alpine code is being generated by a templating language, like [Blade](https://laravel.com/docs/8.x/blade). Typically an Alpine component would just initialize all of its state in one `x-init` or `x-data` statement, but if you're composing functionality with templates, your initial state may be spread through the entire DOM tree.

The real-world use-case is that I'm working on an [Algolia InstantSearch](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/) implementation in Blade and Alpine. Here's a sample of the API:

```xml
<x-instantsearch :application-id="demo">

  <!-- This needs to call addWidget() once and only once per <x-instantsearch> instance -->
  <x-instantsearch-refinement-list attribute="language" />

  <x-instantsearch-hits>
    <div x-text="hit.packageName"></div>
  </x-instantsearch-hits>

</x-instantsearch>
```

If `x-init` was called on all sub-components, the resulting code could look like:

```xml
<div x-data="{applicationId: 'demo'}" x-init="initInstantSearch">

  <div x-init="search.addWidget(instantsearch.connectors.connectRefinementList( ... ))">
    <!-- Any additional markup -->
  </div>

  <template x-for="hit in hits" :key="hit">
    <div x-text="hit.packageName"></div>
  </template>

</div>
```