### PR TITLE
Allow integer n to be 0 in for-loop

### DIFF
--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -98,7 +98,6 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
     if (isNumeric(items)) {
         items = items > 0 ? Array.from(Array(items).keys(), i => i = 1) : []
     }
-    }
 
     return items
 }

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -95,8 +95,8 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
     let items = component.evaluateReturnExpression(el, iteratorNames.items, extraVars)
 
     // This adds support for the `i in n` syntax.
-    if (isNumeric(items)) {
-        items = items > 0 ? Array.from(Array(items).keys(), i => i = 1) : []
+    if (isNumeric(items) && items >= 0) {
+        items = Array.from(Array(items).keys(), i => i + 1)
     }
 
     return items

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -96,11 +96,8 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
 
     // This adds support for the `i in n` syntax.
     if (isNumeric(items)) {
-        if(items > 0) {
-            items = Array.from(Array(items).keys(), i => i + 1)
-        } else if(items === 0) {
-            items = []
-        }
+        items = items > 0 ? Array.from(Array(items).keys(), i => i = 1) : []
+    }
     }
 
     return items

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -95,8 +95,12 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
     let items = component.evaluateReturnExpression(el, iteratorNames.items, extraVars)
 
     // This adds support for the `i in n` syntax.
-    if (isNumeric(items) && items > 0) {
-        items = Array.from(Array(items).keys(), i => i + 1)
+    if (isNumeric(items)) {
+        if(items > 0) {
+            items = Array.from(Array(items).keys(), i => i + 1)
+        } else {
+            items = []
+        }
     }
 
     return items

--- a/src/directives/for.js
+++ b/src/directives/for.js
@@ -98,7 +98,7 @@ function evaluateItemsAndReturnEmptyIfXIfIsPresentAndFalseOnElement(component, e
     if (isNumeric(items)) {
         if(items > 0) {
             items = Array.from(Array(items).keys(), i => i + 1)
-        } else {
+        } else if(items === 0) {
             items = []
         }
     }

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -556,3 +556,24 @@ test('x-for with an array of numbers', async () => {
         expect(document.querySelectorAll('span')[1].textContent).toEqual('3')
     })
 })
+
+test('x-for over range using i in x syntax with i <= 0', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ count: 1 }">
+            <template x-for="i in count">
+                <span x-text="i"></span>
+            </template>
+            <button @click="count--"></button>
+        </div>
+    `
+
+    Alpine.start()
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(0) })
+
+    document.querySelector('button').click()
+
+    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(0) })
+})

--- a/test/for.spec.js
+++ b/test/for.spec.js
@@ -572,8 +572,4 @@ test('x-for over range using i in x syntax with i <= 0', async () => {
     document.querySelector('button').click()
 
     await wait(() => { expect(document.querySelectorAll('span').length).toEqual(0) })
-
-    document.querySelector('button').click()
-
-    await wait(() => { expect(document.querySelectorAll('span').length).toEqual(0) })
 })


### PR DESCRIPTION
Not sure if there's a specific reason why `x-for="i in n"` isn't allowed with n = 0. Allowing it to be 0 doesn't break anything, corresponds with the documentation (0 = integer), and makes if more convient to dynamically create/remove DOM elements where at some point n can become 0 and all DOM elements should get removed.

Simple example case:
```javascript
<div x-data="
    {
        maxSeats: 3,
        seats: [],

        availableSeats() {
            return this.maxSeats - this.seats.length;
        },

        takeSeat(seatNumber) {
            this.seats.push(seatNumber);
        }
    }"
>

    <template x-for="seat in seats">
        <button type="button" style="width: 70px; height: 50px; border: 2px solid red; margin: 1rem;">TAKEN</button>
    </template>
    <template x-for="i in availableSeats()">
        <button type="button" @click="takeSeat(i)" style="width: 70px; height: 50px; border: 2px solid black; margin: 1rem;">FREE</button>
    </template>
</div>
```
This currently fails once `availableSeats` is 0. Wrapping the templates with a `x-if="availableSeats()"` doesn't work either since the inner templates don't get re-rendered when 0, leaving the previous situation in place.

Even though there may be an elegant way of implementing a case like the one above, I still think it makes sense to allow 0 in a for-loop.