### PR TITLE
fix: misleading example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,13 +502,15 @@ If you want to access the array object (collection) of the iteration, use the fo
 
 ```html
 <template x-for="(item, index, collection) in items" :key="index">
-    <!-- You can also reference "collection" inside the iteration if you need. -->
-    <!-- Current item. -->
-    <div x-text="item"></div>
-    <!-- Same as above. -->
-    <div x-text="collection[index]"></div>
-    <!-- Previous item. -->
-    <div x-text="collection[index - 1]"></div>
+    <div>
+        <!-- You can also reference "collection" inside the iteration if you need. -->
+        <!-- Current item. -->
+        <div x-text="item"></div>
+        <!-- Same as above. -->
+        <div x-text="collection[index]"></div>
+        <!-- Previous item. -->
+        <div x-text="collection[index - 1]"></div>
+    </div>
 </template>
 ```
 


### PR DESCRIPTION
This resolves #830. I think it's a valid point, anybody who wants to copy and paste this example into a fiddle to see how each thing works would be given an error / warning about multiple root nodes.