### PR TITLE
fix: x-cloak css in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,9 @@ The object keys are the directives (Can be any directive including modifiers), a
 
 ```html
 <style>
-    [x-cloak] { display: none; }
+    [x-cloak] {
+        display: none !important;
+    }
 </style>
 ```
 


### PR DESCRIPTION
Closes #1091. Think this is a fair change since `x-cloak` should always have precedence over other CSS `display` properties. 