### PR TITLE
Fix nested alpine with nested livewire

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -7358,7 +7358,7 @@
 
       this.initializeElements(this.$el, function () {
         _newArrowCheck(this, _this);
-      }.bind(this), componentForClone ? false : true); // Use mutation observer to detect new elements being added within this component at run-time.
+      }.bind(this), componentForClone); // Use mutation observer to detect new elements being added within this component at run-time.
       // Alpine's just so darn flexible amirite?
 
       this.listenForNewElementsToInitialize();
@@ -7511,7 +7511,7 @@
         var extraVars = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {
           _newArrowCheck(this, _this10);
         }.bind(this);
-        var shouldRegisterListeners = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+        var componentForClone = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
         this.walkAndSkipNestedComponents(rootEl, function (el) {
           _newArrowCheck(this, _this10);
 
@@ -7519,11 +7519,11 @@
           if (el.__x_for_key !== undefined) return false; // Don't touch spawns from if directives
 
           if (el.__x_inserted_me !== undefined) return false;
-          this.initializeElement(el, extraVars, shouldRegisterListeners);
+          this.initializeElement(el, extraVars, componentForClone ? false : true);
         }.bind(this), function (el) {
           _newArrowCheck(this, _this10);
 
-          el.__x = new Component(el);
+          if (!componentForClone) el.__x = new Component(el);
         }.bind(this));
         this.executeAndClearRemainingShowDirectiveStack();
         this.executeAndClearNextTickStack(rootEl);

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -1514,7 +1514,7 @@
       // event listeners are registered (the mutation observer will take care of them)
 
 
-      this.initializeElements(this.$el, () => {}, componentForClone ? false : true); // Use mutation observer to detect new elements being added within this component at run-time.
+      this.initializeElements(this.$el, () => {}, componentForClone); // Use mutation observer to detect new elements being added within this component at run-time.
       // Alpine's just so darn flexible amirite?
 
       this.listenForNewElementsToInitialize();
@@ -1603,15 +1603,15 @@
       });
     }
 
-    initializeElements(rootEl, extraVars = () => {}, shouldRegisterListeners = true) {
+    initializeElements(rootEl, extraVars = () => {}, componentForClone = false) {
       this.walkAndSkipNestedComponents(rootEl, el => {
         // Don't touch spawns from for loop
         if (el.__x_for_key !== undefined) return false; // Don't touch spawns from if directives
 
         if (el.__x_inserted_me !== undefined) return false;
-        this.initializeElement(el, extraVars, shouldRegisterListeners);
+        this.initializeElement(el, extraVars, componentForClone ? false : true);
       }, el => {
-        el.__x = new Component(el);
+        if (!componentForClone) el.__x = new Component(el);
       });
       this.executeAndClearRemainingShowDirectiveStack();
       this.executeAndClearNextTickStack(rootEl);

--- a/src/component.js
+++ b/src/component.js
@@ -96,7 +96,7 @@ export default class Component {
         // Register all our listeners and set all our attribute bindings.
         // If we're cloning a component, the third parameter ensures no duplicate
         // event listeners are registered (the mutation observer will take care of them)
-        this.initializeElements(this.$el, () => {}, componentForClone ? false : true)
+        this.initializeElements(this.$el, () => {}, componentForClone)
 
         // Use mutation observer to detect new elements being added within this component at run-time.
         // Alpine's just so darn flexible amirite?
@@ -197,7 +197,7 @@ export default class Component {
         })
     }
 
-    initializeElements(rootEl, extraVars = () => {}, shouldRegisterListeners = true) {
+    initializeElements(rootEl, extraVars = () => {}, componentForClone = false) {
         this.walkAndSkipNestedComponents(rootEl, el => {
             // Don't touch spawns from for loop
             if (el.__x_for_key !== undefined) return false
@@ -205,9 +205,9 @@ export default class Component {
             // Don't touch spawns from if directives
             if (el.__x_inserted_me !== undefined) return false
 
-            this.initializeElement(el, extraVars, shouldRegisterListeners)
+            this.initializeElement(el, extraVars, componentForClone ? false : true)
         }, el => {
-            el.__x = new Component(el)
+            if(! componentForClone) el.__x = new Component(el)
         })
 
         this.executeAndClearRemainingShowDirectiveStack()


### PR DESCRIPTION
This fixes an issue where if you have a Livewire component which has an Alpine component in it, that has nested Livewire components that also have Alpine in them. Adding a new nested Livewire component dynamically triggers an Alpine error
> Uncaught (in promise) TypeError: Cannot read property '$wire' of undefined

See this Livewire PR livewire/livewire#2517, which is a failing test, and issues linked in that PR for more details.

What is happening, is Livewire calls clone on Alpine's elements in `alpinifyElementsForMorphdom()` here
[livewire/livewire/js/component/SupportAlpine.js#L129](https://github.com/livewire/livewire/blob/b647ac63378ea02bdac975f70a4e57aea84bda0b/js/component/SupportAlpine.js#L129)

But this method is called in the `onBeforeElUpdated` morphdom hook here 
[livewire/livewire/js/component/index.js#L459](https://github.com/livewire/livewire/blob/b647ac63378ea02bdac975f70a4e57aea84bda0b/js/component/index.js#L459)

When Alpine's component is cloned it then tries to initialise any nested components (which can contain $wire calls), but this happens before the nested Livewire components are ready (as it's running in the `onBeforeElUpdated` hook above). This then causes the above error.

This PR stops nested components from initialising at the clone stage, so that they are initialised later.

✅ I've run all the Alpine tests locally after this change and they all pass.
✅ I also ran all the Livewire tests (using this Alpine modification) including the failing on in PR livewire/livewire#2517 and they all passed.

I checked through both code bases and the only call to the clone method is in Livewire's `SupportAlpine.js` listed above, so I see no implications for not newing up nested component's during a clone, as the dusk test proves that they do get initialised later.

Fixes #1144 

Hope this helps!