### PR TITLE
Add error handler override

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Component from './component'
-import { domReady, isTesting } from './utils'
+import { domReady, isTesting, setErrorHandler } from './utils'
 
 const Alpine = {
     version: process.env.PKG_VERSION,
@@ -107,6 +107,10 @@ const Alpine = {
 
     addMagicProperty: function (name, callback) {
         this.magicProperties[name] = callback
+    },
+
+    setErrorHandler: function(handler) {
+        setErrorHandler(handler);
     },
 
     onComponentInitialized: function (callback) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 
+let errorHandler = null;
+
 // Thanks @stimulus:
 // https://github.com/stimulusjs/stimulus/blob/master/packages/%40stimulus/core/src/application.ts
 export function domReady() {
@@ -65,7 +67,17 @@ export function debounce(func, wait) {
     }
 }
 
+export function setErrorHandler(handler) {
+    errorHandler = handler;
+}
+
 const handleError = (el, expression, error) => {
+    if (errorHandler !== null) {
+        errorHandler(el, expression, error);
+
+        return;
+    }
+
     console.warn(`Alpine Error: "${error}"\n\nExpression: "${expression}"\nElement:`, el);
 
     if (! isTesting()) {

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -1,4 +1,4 @@
-import Alpine from 'alpinejs'
+import Alpine from '../src/index';
 import { wait } from '@testing-library/dom'
 
 global.MutationObserver = class {
@@ -110,3 +110,25 @@ test('error in x-on eval contains element, expression and original error', async
         )
     })
 })
+
+test('error in x-on eval causes error, handled by custom error handler', async () => {
+    document.body.innerHTML = `
+        <div
+            x-data="{hello: null}"
+            x-on:click="hello.world"
+        ></div>
+    `
+
+    Alpine.setErrorHandler((el, expression, error) => {
+        console.warn('[custom alpine error]', el);
+    });
+
+    await Alpine.start()
+    document.querySelector('div').click()
+    await wait(() => {
+        expect(mockConsoleWarn).toHaveBeenCalledWith(
+            `[custom alpine error]`,
+            document.querySelector('[x-data]',)
+        )
+    })
+});

--- a/test/error.spec.js
+++ b/test/error.spec.js
@@ -119,7 +119,10 @@ test('error in x-on eval causes error, handled by custom error handler', async (
         ></div>
     `
 
+    let errorHandlerCallCount = 0;
+
     Alpine.setErrorHandler((el, expression, error) => {
+        errorHandlerCallCount++;
         console.warn('[custom alpine error]', el);
     });
 
@@ -129,6 +132,8 @@ test('error in x-on eval causes error, handled by custom error handler', async (
         expect(mockConsoleWarn).toHaveBeenCalledWith(
             `[custom alpine error]`,
             document.querySelector('[x-data]',)
-        )
+        );
+
+        expect(errorHandlerCallCount).toEqual(1);
     })
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,4 +1,4 @@
-import { arrayUnique, parseHtmlAttribute } from '../src/utils'
+import { arrayUnique, parseHtmlAttribute, setErrorHandler, saferEval } from '../src/utils'
 
 test('utils/arrayUnique', () => {
     const arrayMock = [1, 1, 2, 3, 1, 'a', 'b', 'c', 'b']
@@ -15,4 +15,20 @@ test('utils/parseHtmlAttribute', () => {
         modifiers: [],
         expression: 'x'
     });
+})
+
+test('utils/setErrorHandler', () => {
+    let handlerCallCount = 0;
+
+    const handler = (el, expression, error) => {
+        handlerCallCount++;
+    };
+
+    setErrorHandler(handler);
+
+    expect(handlerCallCount).toEqual(0);
+
+    saferEval(null, 'throw new Error("test");', {}, {});
+
+    expect(handlerCallCount).toEqual(1);
 })


### PR DESCRIPTION
This PR adds the ability to override the default error handler:
```js
const handleError = (el, expression, error) => {
    console.warn(`Alpine Error: "${error}"\n\nExpression: "${expression}"\nElement:`, el);

    if (! isTesting()) {
        Object.assign(error, { el, expression })
        throw error;
    }
}
```
Not having any way to override this error handler is an issue as I'd like to intercept the error and display it elsewhere.  Namely, within a debugging app with an [integration library for Ray](https://github.com/permafrost-dev/alpinejs-ray).

This PR adds `Alpine.setErrorHandler(handler)`, allowing external applications and scripts to use their own error handler.  Calling `Alpine.setErrorHandler(null)` causes the default error handler to be used again.

I feel that this is a worthwhile addition to alpine.js, without changing its default behavior.