### PR TITLE
Fetch x-init after running onBeforeComponentInitialized

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -16,7 +16,6 @@ export default class Component {
 
         const dataAttr = this.$el.getAttribute('x-data')
         const dataExpression = dataAttr === '' ? '{}' : dataAttr
-        const initExpression = this.$el.getAttribute('x-init')
 
         let dataExtras = {
             $el: this.$el,
@@ -82,6 +81,8 @@ export default class Component {
         this.showDirectiveLastElement
 
         componentForClone || Alpine.onBeforeComponentInitializeds.forEach(callback => callback(this))
+        
+        const initExpression = this.$el.getAttribute('x-init')
 
         var initReturnedCallback
         // If x-init is present AND we aren't cloning (skip x-init on clone)

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -106,7 +106,7 @@ test('x-init is capable of dispatching an event', async () => {
 
 test('onBeforeComponentInitialized is capable of modifying the element', async () => {
     document.body.innerHTML = `
-        <div x-data="{ init() { window.foo = 'bar' }"></div>
+        <div x-data="{ init() { window.foo = 'bar' } }"></div>
     `
     
     Alpine.onBeforeComponentInitialized(component => {

--- a/test/lifecycle.spec.js
+++ b/test/lifecycle.spec.js
@@ -103,3 +103,22 @@ test('x-init is capable of dispatching an event', async () => {
         expect(document.querySelector('span').textContent).toEqual('baz')
     })
 })
+
+test('onBeforeComponentInitialized is capable of modifying the element', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ init() { window.foo = 'bar' }"></div>
+    `
+    
+    Alpine.onBeforeComponentInitialized(component => {
+        if (! component.$el.hasAttribute('x-init') && component.$data.init)
+            component.$el.setAttribute('x-init', 'init()')
+    })
+    
+    Alpine.start()
+    
+    await wait(() => {
+        expect(document.querySelector('div').getAttribute('x-init')).toEqual('init()')
+        
+        expect(window.foo).toEqual('bar')
+    })
+})


### PR DESCRIPTION
This makes it possible to add x-init logic to all elements programmatically.

No behavior is broken or changed, we just read the attribute after running the "before initialized" callbacks.

Also makes sense for "on before initialized" to be able to affect how the initialization process works.