### PR TITLE
Remove stale event handlers when nodes are readded to the document.

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6929,6 +6929,8 @@
       event = camelCase(event);
     }
 
+    var node_add_count = el.__x_node_add_count;
+
     var _handler2, listenerTarget;
 
     if (modifiers.includes('away')) {
@@ -6964,6 +6966,11 @@
             listenerTarget.removeEventListener(event, _handler2, options);
             return;
           }
+        }
+
+        if (el.__x_node_add_count !== node_add_count) {
+          listenerTarget.removeEventListener(event, _handler2, options);
+          return;
         }
 
         if (isKeyEvent(event)) {
@@ -7806,6 +7813,7 @@
                   return;
                 }
 
+                node.__x_node_add_count = (node.__x_node_add_count || 0) + 1;
                 this.initializeElements(node);
               }.bind(this));
             }

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -863,6 +863,7 @@
       event = camelCase(event);
     }
 
+    const node_add_count = el.__x_node_add_count;
     let handler, listenerTarget;
 
     if (modifiers.includes('away')) {
@@ -892,6 +893,11 @@
             listenerTarget.removeEventListener(event, handler, options);
             return;
           }
+        }
+
+        if (el.__x_node_add_count !== node_add_count) {
+          listenerTarget.removeEventListener(event, handler, options);
+          return;
         }
 
         if (isKeyEvent(event)) {
@@ -1805,6 +1811,7 @@
                 return;
               }
 
+              node.__x_node_add_count = (node.__x_node_add_count || 0) + 1;
               this.initializeElements(node);
             });
           }

--- a/src/component.js
+++ b/src/component.js
@@ -411,6 +411,8 @@ export default class Component {
                             return
                         }
 
+                        node.__x_node_add_count = (node.__x_node_add_count || 0) + 1
+
                         this.initializeElements(node)
                     })
                 }

--- a/src/directives/on.js
+++ b/src/directives/on.js
@@ -9,6 +9,8 @@ export function registerListener(component, el, event, modifiers, expression, ex
         event = camelCase(event);
     }
 
+    const node_add_count = el.__x_node_add_count
+
     let handler, listenerTarget
 
     if (modifiers.includes('away')) {
@@ -41,6 +43,11 @@ export function registerListener(component, el, event, modifiers, expression, ex
                     listenerTarget.removeEventListener(event, handler, options)
                     return
                 }
+            }
+
+            if (el.__x_node_add_count !== node_add_count) {
+                listenerTarget.removeEventListener(event, handler, options);
+                return
             }
 
             if (isKeyEvent(event)) {


### PR DESCRIPTION
Fixes: #1171

I'm not familiar enough with the project to know what I need to do to test this or if it's the right approach, but it does appear to resolve the problem for my simple example.