### PR TITLE
Add charset meta tag to the examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8"/>
         <style>
             .hidden { display: none; }
             [x-cloak] { display: none; }

--- a/examples/tags.html
+++ b/examples/tags.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8"/>
         <style>
         .tags-input {
         display: flex;


### PR DESCRIPTION
Due to the missing charset meta tag, the browser (Firefox in my case) throws this error:
`The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.`

[Here's an explanation](https://www.w3.org/International/questions/qa-html-encoding-declarations) from W3C regarding declaring the `charset` meta tag.

