### PR TITLE
Add link to Norwegian translation in English readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Think of it like [Tailwind](https://tailwindcss.com/) for JavaScript.
 | German | [**Dokumentation in Deutsch**](./README.de.md) |
 | Indonesian | [**Dokumentasi Bahasa Indonesia**](./README.id.md) |
 | Japanese | [**日本語ドキュメント**](./README.ja.md) |
+| Norwegian | [**Dokumentasjon på norsk**](./README.no.md) |
 | Portuguese | [**Documentação em Português**](./README.pt.md) |
 | Russian | [**Документация на русском**](./README.ru.md) |
 | Spanish | [**Documentación en Español**](./README.es.md) |


### PR DESCRIPTION
Adds a link to the Norwegian translation of the documentation, in the English readme file.
Related to #1211 

The use of lowercase in the name of the language in the string is intentional, as language names in Norwegian are always typed in all lowercase.