### PR TITLE
Add Failing Test for Duplicate Event Handlers

### DIFF
--- a/test/on.spec.js
+++ b/test/on.spec.js
@@ -589,3 +589,36 @@ test('event handlers only fire once when nodes have been readded to the document
     })
     expect(document.querySelector('#container').lastChild).toEqual(document.querySelector('#a'))
 })
+
+test('nested event handlers only fire once when nodes have been moved in the document.', async () => {
+    document.body.innerHTML = `
+        <div id="container" x-data="{'x': 0}">
+          <span x-text="x">0</span>
+          <div id="a"><button x-on:click="x += 1; $el.appendChild(document.getElementById('a'))">A</button></div>
+          <div id="b"><button x-on:click="x += 1; $el.appendChild(document.getElementById('b'))">B</button></div>
+          <div id="c"><button x-on:click="x += 1; $el.appendChild(document.getElementById('c'))">C</button></div>
+        </div>
+    `
+    Alpine.start()
+    const span = document.querySelector('span')
+
+    expect(span.textContent).toEqual('0')
+
+    document.querySelector('#a button').click()
+    await wait(() => {
+        expect(span.textContent).toEqual('1')
+    })
+    expect(document.querySelector('#container').lastChild).toEqual(document.querySelector('#a'))
+
+    document.querySelector('#a button').click()
+    await wait(() => {
+        expect(span.textContent).toEqual('2')
+    })
+    expect(document.querySelector('#container').lastChild).toEqual(document.querySelector('#a'))
+
+    document.querySelector('#a button').click()
+    await wait(() => {
+        expect(span.textContent).toEqual('3')
+    })
+    expect(document.querySelector('#container').lastChild).toEqual(document.querySelector('#a'))
+})


### PR DESCRIPTION
This PR adds a failing test to illustrate the issue with nested nodes and their event handlers being duplicated after moving a node in the document.

It would appear that the previous solution tracks in the `listenForNewElementsToInitialize` method a  `__x_node_add_count` count but this is only being tracked on the parent node.  Moving this tracking to the `walkAndSkipNestedComponents` loop and storing it against the correct node does indeed solve the issue and make my test pass but then this causes several other tests in the suite to fail.  At this point I have ran out of time to delve deeper into this.