### PR TITLE
Fix x-model not selecting falsy values in select dropdown

### DIFF
--- a/dist/alpine-ie11.js
+++ b/dist/alpine-ie11.js
@@ -6715,7 +6715,7 @@
     Array.from(el.options).forEach(function (option) {
       _newArrowCheck(this, _this3);
 
-      option.selected = arrayWrappedValue.includes(option.value || option.text);
+      option.selected = arrayWrappedValue.includes(option.value);
     }.bind(this));
   }
 

--- a/dist/alpine.js
+++ b/dist/alpine.js
@@ -752,7 +752,7 @@
       return value + '';
     });
     Array.from(el.options).forEach(option => {
-      option.selected = arrayWrappedValue.includes(option.value || option.text);
+      option.selected = arrayWrappedValue.includes(option.value);
     });
   }
 

--- a/src/directives/bind.js
+++ b/src/directives/bind.js
@@ -87,6 +87,6 @@ function updateSelect(el, value) {
     const arrayWrappedValue = [].concat(value).map(value => { return value + '' })
 
     Array.from(el.options).forEach(option => {
-        option.selected = arrayWrappedValue.includes(option.value || option.text)
+        option.selected = arrayWrappedValue.includes(option.value)
     })
 }

--- a/test/model.spec.js
+++ b/test/model.spec.js
@@ -746,3 +746,21 @@ test('x-model sets value before x-on directive expression is processed', async (
         expect(window.selectValueB).toEqual('bar')
     })
 })
+
+test('x-model select falsy values on select dropdown', async () => {
+    document.body.innerHTML = `
+        <div x-data="{ foo: '' }">
+            <select x-model="foo">
+                <option disabled value="">Please select one</option>
+                <option>bar</option>
+                <option>baz</option>
+            </select>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelectorAll('option')[0].selected).toEqual(true)
+    expect(document.querySelectorAll('option')[1].selected).toEqual(false)
+    expect(document.querySelectorAll('option')[2].selected).toEqual(false)
+})


### PR DESCRIPTION
Fixes #1266
As per specs (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
`Each <option> element should have a value attribute containing the data value to submit to the server when that option is selected. If no value attribute is included, the value defaults to the text contained inside the element.`

This means that options already return text when value is not defined so we don't need that `||`.

Note that `||` breaks any cases where the option value is an empty string since it resolves to false so the code incorrectly uses the option text. 

This issue wasn't noticed earlier because the empty value is usually the first option so the browser just displays it.

Bug: https://codepen.io/SimoTod/pen/rNjqXQx
Fix: https://codepen.io/SimoTod/pen/xxgyvQg
