### PR TITLE
Removes unnecessary el argument in evaluate docs

### DIFF
--- a/packages/docs/src/en/advanced/extending.md
+++ b/packages/docs/src/en/advanced/extending.md
@@ -124,7 +124,7 @@ Alpine.directive('log', (el, { expression }, { evaluate }) => {
     // expression === 'message'
 
     console.log(
-        evaluate(el, expression)
+        evaluate(expression)
     )
 })
 ```


### PR DESCRIPTION
Little PR to remove the `el` arg in the `evaluate` docs as the element is already bound as the first arg in this instance of the evaluate method.