### PR TITLE
fix: binding undefined nested value

### DIFF
--- a/packages/alpinejs/src/directives/x-bind.js
+++ b/packages/alpinejs/src/directives/x-bind.js
@@ -13,6 +13,9 @@ directive('bind', (el, { value, modifiers, expression, original }, { effect }) =
     let evaluate = evaluateLater(el, expression)
 
     effect(() => evaluate(result => {
+        // If nested object key is undefined, set the default value to empty string.
+        if (result === undefined && expression.match(/\./)) result = ''
+
         mutateDom(() => bind(el, value, result, modifiers))
     }))
 })

--- a/tests/cypress/integration/directives/x-bind.spec.js
+++ b/tests/cypress/integration/directives/x-bind.spec.js
@@ -9,6 +9,15 @@ test('sets attribute bindings on initialize',
     ({ get }) => get('span').should(haveAttribute('foo', 'bar'))
 )
 
+test('sets undefined nested keys to empty string',
+    html`
+        <div x-data="{ nested: {} }">
+            <input x-bind:value="nested.field">
+        </div>
+    `,
+    ({ get }) => get('input').should(haveAttribute('value', ''))
+)
+
 test('style attribute bindings are added by string syntax',
     html`
         <div x-data="{ initialClass: 'foo' }">


### PR DESCRIPTION
This pull request fixes an issue where non-existent / undefined nested properties in an object would bind the literal string `"undefined"` instead of an empty string, which was the old behaviour in 2.x.

This behaviour was already implemented as part of the `x-model` binding logic, but was missing from direct `x-bind:` expressions.