### PR TITLE
fix: add git url to all package.json's

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
     "private": true,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
+    },
     "workspaces": [
         "packages/*"
     ],

--- a/packages/alpinejs/package.json
+++ b/packages/alpinejs/package.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/alpinejs/alpine.git"
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/alpinejs"
     },
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",

--- a/packages/alpinejs/package.json
+++ b/packages/alpinejs/package.json
@@ -4,6 +4,10 @@
     "description": "The rugged, minimal JavaScript framework",
     "author": "Caleb Porzio",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
+    },
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",

--- a/packages/csp/package.json
+++ b/packages/csp/package.json
@@ -4,6 +4,10 @@
     "description": "A CSP compatible build of Alpine",
     "author": "Caleb Porzio",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
+    },
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
     "dependencies": {

--- a/packages/csp/package.json
+++ b/packages/csp/package.json
@@ -6,7 +6,8 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/alpinejs/alpine.git"
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/csp"
     },
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -3,5 +3,9 @@
     "version": "3.0.6-revision.1",
     "description": "The documentation for Alpine",
     "author": "Caleb Porzio",
-    "license": "MIT"
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
+    }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/alpinejs/alpine.git"
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/docs"
     }
 }

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -8,5 +8,9 @@
     "module": "dist/module.esm.js",
     "dependencies": {
         "@vue/reactivity": "^3.0.2"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
     }
 }

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -11,6 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/alpinejs/alpine.git"
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/history"
     }
 }

--- a/packages/intersect/package.json
+++ b/packages/intersect/package.json
@@ -9,6 +9,7 @@
     "dependencies": {},
     "repository": {
         "type": "git",
-        "url": "https://github.com/alpinejs/alpine.git"
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/intersect"
     }
 }

--- a/packages/intersect/package.json
+++ b/packages/intersect/package.json
@@ -6,5 +6,9 @@
     "license": "MIT",
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
-    "dependencies": {}
+    "dependencies": {},
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
+    }
 }

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -11,6 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/alpinejs/alpine.git"
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/morph"
     }
 }

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -8,5 +8,9 @@
     "module": "dist/module.esm.js",
     "dependencies": {
         "@vue/reactivity": "^3.0.2"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git"
     }
 }


### PR DESCRIPTION
This would help services like renovatebot and dependabot find the changelog for each package when creating package update PR's - I'd appreciate it if that was possible!