### PR TITLE
Documentation: Added hint in installation.md

### DIFF
--- a/packages/docs/src/en/essentials/installation.md
+++ b/packages/docs/src/en/essentials/installation.md
@@ -60,3 +60,9 @@ Alpine.start()
 ```
 
 > The `window.Alpine = Alpine` bit is optional, but is nice to have for freedom and flexibility. Like when tinkering with Alpine from the devtools for example.
+
+
+> If you imported Alpine into a bundle, you have to make sure you are registering any extension code IN BETWEEN when you import the `Alpine` global object, and when you initialize Alpine by calling `Alpine.start()`. 
+
+
+[→ Read more about extending Alpine](/advanced/extending)


### PR DESCRIPTION
I have been trying to upgrade my existing Alpine 2.X installation to Alpine 3.X for some time but always had some errors. 
I finally stumbled upon the solution to my problem today in the documentation under "[Extending](https://alpinejs.dev/advanced/extending#via-npm)":

Apparently the reusable data code needs to be executed BETWEEN the import of `Alpine` and `Alpine.start()`.
I hope that hint might be helpfull for others, too.