### PR TITLE
feature: support args with Alpine.data()

### DIFF
--- a/tests/cypress/integration/custom-data.spec.js
+++ b/tests/cypress/integration/custom-data.spec.js
@@ -17,6 +17,23 @@ test('can register custom data providers',
     ({ get }) => get('span').should(haveText('bar'))
 )
 
+test('can pass arguments to data provider',
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('test', (value) => ({
+                    foo: value
+                }))
+            })
+        </script>
+
+        <div x-data="test('bar')">
+            <span x-text="foo"></span>
+        </div>
+    `,
+    ({ get }) => get('span').should(haveText('bar'))
+)
+
 test('init functions inside custom datas are called automatically',
     html`
         <script>


### PR DESCRIPTION
This pull request adds support for passing arguments through to `Alpine.data` providers.

Without too much thought, the simplest approach is the one that I took. 

Everything before the first `(` character in the expression will be used to get the data provider. If that exists and there is some expression after the first `(`, that will be evaluated inside of an array, allowing us to spread the data into the function call.

i.e. `x-data="foo('bar')"`, in this scenario `foo` will be used as the data-provider and the `'bar'` will actually be evaluated as `['bar']` so that we can then spread the result of the evaluation into the data provider's function.

Here's a few bullet points of the flow:

1. Get everything before the first occurence of `(` in `expression`. If it doesn't return anything (meaning `(` isn't present), then default to `expression`.
2. If `dataProviderName` is not empty and the `dataProviderName` is not equal to the original `expression` then we must have some arguments or at least `()` present in the `expression`.
3. Get the raw argument string by taking everything after the first `(` and then removing the last character, which should be a `)` char.
4. Evaluate this string inside of an array, i.e. `[${stringHere}]`. This will return an array into `args` which we can then `...` spread into the data provider callback.

**Question**: is there anything that needs to be done for CSP-safety here?