### PR TITLE
Add warning for x-for key not being an integer or string

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -5,6 +5,7 @@ import { reactive } from '../reactivity'
 import { initTree } from '../lifecycle'
 import { mutateDom } from '../mutation'
 import { flushJobs } from '../scheduler'
+import { warn } from '../utils/warn'
 
 directive('for', (el, { expression }, { effect, cleanup }) => {
     let iteratorNames = parseForExpression(expression)
@@ -176,6 +177,10 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
 
                 initTree(clone)
             })
+
+            if (typeof key === 'object') {
+                warn('x-for key cannot be an object, it must be a string or an integer', templateEl)
+            }
 
             lookup[key] = clone
         }


### PR DESCRIPTION
The following snippet won't work because the `:key` is set to the entire object and not a stringable value:

```html
<div x-data="{ items: [{ label: 'foo' }, { label: 'bar' }] }">
    <template x-for="item in items" :key="item">
        <span x-text="item.label"></span>
    </template>
</div>
```

This PR adds the following warning in this case:
![image](https://user-images.githubusercontent.com/3670578/123470586-a09dcd00-d5c2-11eb-8864-941541ebc336.png)
