### PR TITLE
Add warning for use of standalone x-init directive

### DIFF
--- a/packages/docs/src/en/directives/init.md
+++ b/packages/docs/src/en/directives/init.md
@@ -48,6 +48,8 @@ You can add `x-init` to any elements inside or outside an `x-data` HTML block. F
 <span x-init="console.log('I can initialize too')"></span>
 ```
 
+**Note:** `x-init` creates a new component scope, so any `$refs` created outside of this scope will not be accessible on the DOM tag containing a standalone `x-init` directive, nor will any of its children.
+
 <a name="auto-evaluate-init-method"></a>
 ## Auto-evaluate init() method
 

--- a/packages/docs/src/en/directives/ref.md
+++ b/packages/docs/src/en/directives/ref.md
@@ -22,3 +22,5 @@ title: ref
     </div>
 </div>
 <!-- END_VERBATIM -->
+
+**Note:** If using `x-ref` in combination with a standalone `x-init` directive, note that `x-init` creates a new component scope, so any `$refs` created outside of this scope will not be accessible on the DOM tag containing a standalone `x-init` attribute, nor will any of its children.


### PR DESCRIPTION
- Warn that using standalone x-init creates a new scope and any $refs
  created outside this scope will not be accessible inside the new scope