### PR TITLE
RFC: Unscope x-init when nested in another component

### DIFF
--- a/packages/alpinejs/src/directives/x-init.js
+++ b/packages/alpinejs/src/directives/x-init.js
@@ -1,8 +1,13 @@
+import { addRootSelector, closestRoot } from "../lifecycle";
 import { directive, prefix } from "../directives";
-import { addRootSelector } from "../lifecycle";
 import { skipDuringClone } from "../clone";
 import { evaluate } from "../evaluator";
 
-addRootSelector(() => `[${prefix('init')}]`)
+const isNestedInsideAComponent = (el) =>
+    el && el.hasAttribute(prefix('init'))
+    && closestRoot(el.parentNode || closestRoot(el))
+
+// If an element has init, but is a child of data then do not add it as a root selector
+addRootSelector((el) => isNestedInsideAComponent(el) ? null : `[${prefix('init')}]`)
 
 directive('init', skipDuringClone((el, { expression }) => evaluate(el, expression, {}, false)))

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -33,14 +33,14 @@ export function start() {
 
 let rootSelectorCallbacks = []
 
-export function rootSelectors() {
-    return rootSelectorCallbacks.map(fn => fn())
+export function rootSelectors(el = undefined) {
+    return rootSelectorCallbacks.map(fn => fn(el))
 }
 
 export function addRootSelector(selectorCallback) { rootSelectorCallbacks.push(selectorCallback) }
 
 export function closestRoot(el) {
-    if (rootSelectors().some(selector => el.matches(selector))) return el
+    if (rootSelectors(el).some(selector => el.matches(selector))) return el
 
     if (! el.parentElement) return
 
@@ -48,7 +48,7 @@ export function closestRoot(el) {
 }
 
 export function isRoot(el) {
-    return rootSelectors().some(selector => el.matches(selector))
+    return rootSelectors(el).some(selector => el.matches(selector))
 }
 
 export function initTree(el, walker = walk) {

--- a/tests/cypress/integration/directives/x-init.spec.js
+++ b/tests/cypress/integration/directives/x-init.spec.js
@@ -17,6 +17,17 @@ test('x-init can be used outside of x-data',
     ({ get }) => get('div').should(haveText('foo'))
 )
 
+test('A nested x-init doesn\'t create a new component',
+    html`
+        <div x-data>
+            <!-- A good way to test this is to use x-ref, which is scoped to a component -->
+            <p x-ref="bob"></p>
+            <span x-init="$refs['bob'].textContent = 'lob'"></span>
+        </div>
+    `,
+    ({ get }) => get('p').should(haveText('lob'))
+)
+
 
 test('changes made in x-init happen before the rest of the component',
     html`

--- a/tests/cypress/integration/directives/x-init.spec.js
+++ b/tests/cypress/integration/directives/x-init.spec.js
@@ -28,6 +28,19 @@ test('A nested x-init doesn\'t create a new component',
     ({ get }) => get('p').should(haveText('lob'))
 )
 
+test('x-init does\'t return as a closestRoot',
+    html`
+        <div x-data>
+            <span x-init="() => {}">
+                <button @click="$el.textContent = Alpine.closestRoot($el).tagName"></button>
+            </span>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('button').should(haveText('DIV'))
+    }
+)
 
 test('changes made in x-init happen before the rest of the component',
     html`


### PR DESCRIPTION
It's not the cleanest solution since `rootSelectors()` is called once during boot up (where it applies its own filtering, see `outNestedComponents`), then later whenever using `closestRoot()`. During the latter, `rootSelectors` has more context available to it that the `addRootSelector` callback can then use (passing in `el`).

So essentially, the type signature changes depending on context. I set the default to `undefined` on `rootSelectors` as a hint to anyone later who uses it that el could be undefined (and that they should check for it as I did in `x-init`).

fixes #1643 

I thought about separating `rootSelectors()` into two things, like `rootSelectors()` and `rootSelectorsMaybe()` but that felt equally quirky. 

Thoughts anyone?