### PR TITLE
Expose the initTree method

### DIFF
--- a/packages/alpinejs/src/alpine.js
+++ b/packages/alpinejs/src/alpine.js
@@ -1,7 +1,7 @@
 import { setReactivityEngine, disableEffectScheduling, reactive, effect, release, raw } from './reactivity'
 import { mapAttributes, directive, setPrefix as prefix } from './directives'
 import { setEvaluator, evaluate, evaluateLater } from './evaluator'
-import { start, addRootSelector, closestRoot } from './lifecycle'
+import { start, addRootSelector, closestRoot, initTree } from './lifecycle'
 import { interceptor } from './interceptor'
 import { mutateDom } from './mutation'
 import { nextTick } from './nextTick'
@@ -29,6 +29,7 @@ let Alpine = {
     mutateDom,
     directive,
     evaluate,
+    initTree,
     nextTick,
     prefix,
     plugin,


### PR DESCRIPTION
This would fix #567 or be one way to approach it. Example:

```html
<div x-data="{ready: false}" x-process="ready">
    <span x-ignore>
      Not processed until `x-process` is truthy
      <!-- Maybe this has 100s of elements that need processing later-->
    </span>
</div>
```
We can use `initTree` in a plugin like this:
```js
Alpine.directive('process', (el, { expression }, { Alpine: { initTree }, evaluateLater, effect }) => {

  const evaluate = evaluateLater(expression)

  effect(() => {
    const ignored = el.querySelectorAll('[x-ignore]')
    evaluate(result => result && ignored.forEach(n => {
        n.removeAttribute('x-ignore')
        n._x_ignore = false
        initTree(n)
      })
    )
  })
})
```

I set up a demo here: https://codepen.io/KevinBatdorf/pen/KKmPqML?editors=1010