### PR TITLE
pass in proper param to querySelectorAll

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -22,7 +22,7 @@ export function start() {
 
     let outNestedComponents = el => ! closestRoot(el.parentNode || closestRoot(el))
 
-    Array.from(document.querySelectorAll(rootSelectors()))
+    Array.from(document.querySelectorAll(rootSelectors().join(",")))
         .filter(outNestedComponents)
         .forEach(el => {
             initTree(el)


### PR DESCRIPTION
Very small thing but rootSelectors() returns string array (which works but is technically invalid) so add comma for proper usage (https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll#parameters)

- only matters because of d.ts file I'm building for work (maybe future PR)
- covered under existing test coverage (will add test if requested)