### PR TITLE
feature: support registering multiple stores at once

### DIFF
--- a/packages/alpinejs/src/store.js
+++ b/packages/alpinejs/src/store.js
@@ -6,6 +6,14 @@ let isReactive = false
 export function store(name, value) {
     if (! isReactive) { stores = reactive(stores); isReactive = true; }
 
+    if (typeof name === 'object' && value === undefined) {
+        Object.entries(name).forEach(([key, value]) => {
+            store(key, value)
+        })
+
+        return
+    }
+
     if (value === undefined) {
         return stores[name]
     }

--- a/tests/cypress/integration/store.spec.js
+++ b/tests/cypress/integration/store.spec.js
@@ -17,6 +17,29 @@ test('can register and use a global store',
     }
 )
 
+test('can register multiple stores at once',
+    [html`
+        <div x-data>
+            <span id="foo" x-text="$store.foo.bar"></span>
+            <span id="boo" x-text="$store.boo.car"></span>
+        </div>
+    `,
+    `
+        Alpine.store({
+            foo: {
+                bar: 'baz'
+            },
+            boo: {
+                car: 'caz'
+            }
+        })
+    `],
+    ({ get }) => {
+        get('span#foo').should(haveText('baz'))
+        get('span#boo').should(haveText('caz'))
+    }
+)
+
 test('store init function is called',
     [html`
         <div x-data>


### PR DESCRIPTION
This pull request adds support for registering multiple stores at once via an object. Thought this was worth a shot at getting merged. 

Here's how it will affect your code:

**Before**:
```js
Alpine.store('settings', {
    darkMode: false,
})

Alpine.store('modals', {
    active: null,
})
```

**After**
```js
Alpine.store({
    settings: {
        darkMode: false,
    },
    modals: {
        active: null,
    }
})
```

This is somewhat similar to ["state modules"](https://vuex.vuejs.org/guide/modules.html) in VueX, where you register each module inside of a single object and provide a key. 

> If this has merge potential, I'll also update the docs.