### PR TITLE
Add doctype, encoding, and title to HTML example

### DIFF
--- a/packages/docs/src/en/alpine-101.md
+++ b/packages/docs/src/en/alpine-101.md
@@ -10,8 +10,11 @@ Create a blank HTML file somewhere on you computer with a name like: `i-love-alp
 Using a text editor, fill the file with these contents:
 
 ```html
+<!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8" />
+    <title>I ❤️ Alpine</title>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The heart emoji in the example was not rendering correctly in the browser, I assumed due to missing UTF-8 encoding on the document. I added the encoding meta tag and the HTML5 doctype for predictable browser rendering, as well as a document title for good measure.

I considered adding a couple more things such as a `lang` attribute, and the usual viewport-related meta tags, but I wanted to first get some feedback on whether it makes sense, or to keep it deliberately minimal.

Keep up with the great work!