### PR TITLE
add no-start option for CDN version of Alpine

### DIFF
--- a/packages/alpinejs/builds/cdn.js
+++ b/packages/alpinejs/builds/cdn.js
@@ -2,6 +2,9 @@ import Alpine from './../src/index'
 
 window.Alpine = Alpine
 
-queueMicrotask(() => {
-    Alpine.start()
-})
+let s
+if (!((s = document.currentScript) && s.hasAttribute('no-start'))) {
+    queueMicrotask(() => {
+        Alpine.start()
+    })
+}


### PR DESCRIPTION
Add no-start option to for people who do not want to start Alpine from CDN version automatically. 

Used like `<script src="cdn.js" defer no-start></script>`

Test using: 
```html
<html>
<head>
    <script defer no-start src="cdn.js"></script>
</head>
<body>
<div x-data="{a:1}">
    <span x-text="a"></span>
</div>
</body>
</html>
<script>
    setTimeout(() => {
        Alpine.start()
    }, 5000);
</script>
```

https://github.com/alpinejs/alpine/discussions/1710

https://github.com/alpinejs/alpine/discussions/1705

This strategy is borrowed directly from [petite-vue](https://github.com/vuejs/petite-vue/blob/main/src/index.ts). Just doing inverse logic. 

@ryangjchandler suggested the name `lazy` instead and it's open to discussion what it should be called if added?