### PR TITLE
Fix "dependancies" typo

### DIFF
--- a/packages/alpinejs/src/magics/$watch.js
+++ b/packages/alpinejs/src/magics/$watch.js
@@ -16,7 +16,7 @@ magic('watch', el => (key, callback) => {
 
         if (! firstTime) {
             // We have to queue this watcher as a microtask so that
-            // the watcher doesn't pick up its own dependancies.
+            // the watcher doesn't pick up its own dependencies.
             queueMicrotask(() => {
                 callback(value, oldValue)
 

--- a/tests/cypress/integration/magics/$watch.spec.js
+++ b/tests/cypress/integration/magics/$watch.spec.js
@@ -129,7 +129,7 @@ test('$watch nested arrays',
     }
 )
 
-test('$watch ignores other dependancies',
+test('$watch ignores other dependencies',
     html`
         <div
             x-data="{ a: 0, b: 0, c: 0 }"


### PR DESCRIPTION
Also noticed it on the [webpage](https://alpinejs.dev), but that doesn't seem to be open source so can't PR there:
![image](https://user-images.githubusercontent.com/8201077/124677397-a77ce780-dec0-11eb-8f30-fd060b1ac0b4.png)