### PR TITLE
Bug - Add support for x-data on html tag

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -20,8 +20,7 @@ export function start() {
         directives(el, attrs).forEach(handle => handle())
     })
 
-    let outNestedComponents = el => ! closestRoot(el.parentNode || closestRoot(el))
-
+    let outNestedComponents = el => ! closestRoot(el.parentElement)
     Array.from(document.querySelectorAll(allSelectors()))
         .filter(outNestedComponents)
         .forEach(el => {
@@ -46,6 +45,8 @@ export function addRootSelector(selectorCallback) { rootSelectorCallbacks.push(s
 export function addInitSelector(selectorCallback) { initSelectorCallbacks.push(selectorCallback) }
 
 export function closestRoot(el) {
+    if (!el) return
+
     if (rootSelectors().some(selector => el.matches(selector))) return el
 
     if (! el.parentElement) return

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -20,7 +20,8 @@ export function start() {
         directives(el, attrs).forEach(handle => handle())
     })
 
-    let outNestedComponents = el => ! closestRoot(el.parentElement)
+    let outNestedComponents = el => ! closestRoot(el.parentNode || closestRoot(el))
+
     Array.from(document.querySelectorAll(allSelectors()))
         .filter(outNestedComponents)
         .forEach(el => {
@@ -45,8 +46,6 @@ export function addRootSelector(selectorCallback) { rootSelectorCallbacks.push(s
 export function addInitSelector(selectorCallback) { initSelectorCallbacks.push(selectorCallback) }
 
 export function closestRoot(el) {
-    if (!el) return
-
     if (rootSelectors().some(selector => el.matches(selector))) return el
 
     if (! el.parentElement) return

--- a/tests/cypress/integration/directives/x-data.spec.js
+++ b/tests/cypress/integration/directives/x-data.spec.js
@@ -95,3 +95,13 @@ test('functions in x-data have access to proper this context',
         get('span').should(haveText('baz'))
     }
 )
+
+test('x-data works on the html tag',
+    html`
+        <script>document.documentElement.setAttribute('x-data', '')</script>
+        <div>
+            <span x-text="'foo'"></span>
+        </div>
+    `,
+    ({ get }) => get('span').should(haveText('foo'))
+)

--- a/tests/cypress/integration/directives/x-data.spec.js
+++ b/tests/cypress/integration/directives/x-data.spec.js
@@ -98,7 +98,7 @@ test('functions in x-data have access to proper this context',
 
 test('x-data works on the html tag',
     [html`
-        <div x-data>
+        <div>
             <span x-text="'foo'"></span>
         </div>
     `,

--- a/tests/cypress/integration/directives/x-data.spec.js
+++ b/tests/cypress/integration/directives/x-data.spec.js
@@ -97,11 +97,15 @@ test('functions in x-data have access to proper this context',
 )
 
 test('x-data works on the html tag',
-    html`
-        <script>document.documentElement.setAttribute('x-data', '')</script>
-        <div>
+    [html`
+        <div x-data>
             <span x-text="'foo'"></span>
         </div>
     `,
-    ({ get }) => get('span').should(haveText('foo'))
+    `
+        document.querySelector('html').setAttribute('x-data', '')
+    `],
+    ({ get }) => {
+        get('span').should(haveText('foo'))
+    }
 )


### PR DESCRIPTION
- `closestRoot` uses `el.matches` which requires a DOM Element
- `outNestedComponents` was using `parentNode` that doesn't always return a DOM Element (e.g. html.parentNode. returns document which is a Dom Node). `parentElement` instead will return null if the parent node is. not a DOM Element.
- ⚠️ I had to change `closestRoot(el.parentNode || closestRoot(el))` to `closestRoot(el.parentNode)` but I'm not sure about your original intentions so it might not be suitable. Reason: `closestRoot(el)` always returns the current element if `el` has an `x-data` attribute, so does `closestRoot(closestRoot(el))`. This means that `outNestedComponents` would filter out all the components when `x-data` is on the html tag. All test pass but I thought it was important to highlight this point since there could be a reason why the original code had `|| closestRoot(el)`. Thanks