### PR TITLE
feature: support esc shorthand

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -168,8 +168,12 @@ function keyToModifier(key) {
         case ' ':
         case 'Spacebar':
             return 'space'
-        case 'esc':
-            return 'escape'
+        case 'Escape':
+            return 'esc'
+        case 'Meta':
+            return 'cmd'
+        case 'Control':
+            return 'ctrl'
         default:
             return key && kebabCase(key)
     }

--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -168,6 +168,8 @@ function keyToModifier(key) {
         case ' ':
         case 'Spacebar':
             return 'space'
+        case 'esc':
+            return 'escape'
         default:
             return key && kebabCase(key)
     }


### PR DESCRIPTION
This pull request adds support for the `.esc` modifier, acting as a shorthand for the `.escape` key modifier.