### PR TITLE
update arrow key docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,6 @@
             "workspaces": [
                 "packages/*"
             ],
-            "dependencies": {
-                "@vue/reactivity": "^3.0.2",
-                "wicg-inert": "^3.1.1"
-            },
             "devDependencies": {
                 "axios": "^0.21.1",
                 "brotli-size": "^4.0.0",
@@ -7790,13 +7786,14 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.0.6",
+            "version": "3.2.2",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "^3.0.2"
             }
         },
         "packages/csp": {
+            "name": "@alpinejs/csp",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7804,10 +7801,12 @@
             }
         },
         "packages/docs": {
-            "version": "3.0.6-revision.2",
+            "name": "@alpinejs/docs",
+            "version": "3.2.2-revision.1",
             "license": "MIT"
         },
         "packages/history": {
+            "name": "@alpinejs/history",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7815,10 +7814,12 @@
             }
         },
         "packages/intersect": {
-            "version": "3.0.0-alpha.0",
+            "name": "@alpinejs/intersect",
+            "version": "3.2.2",
             "license": "MIT"
         },
         "packages/morph": {
+            "name": "@alpinejs/morph",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7826,10 +7827,12 @@
             }
         },
         "packages/persist": {
+            "name": "@alpinejs/persist",
             "version": "3.0.0-alpha.0",
             "license": "MIT"
         },
         "packages/trap": {
+            "name": "@alpinejs/trap",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -81,7 +81,7 @@ For easy reference, here is a list of common keys you may want to listen for.
 | `.cmd`                      | Cmd                         |
 | `.meta`                     | Cmd on Mac, Ctrl on Windows |
 | `.alt`                      | Alt                         |
-| `.up` `.down` `.left` `.right` | Up/Down/Left/Right arrows   |
+| `.arrow-up` `.arrow-down` `.arrow-left` `.arrow-right` | Up/Down/Left/Right arrows   |
 | `.escape`                   | Escape                      |
 | `.tab`                      | Tab                         |
 | `.caps-lock`                | Caps Lock                   |

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -263,6 +263,26 @@ test('keydown modifiers',
     }
 )
 
+test('keydown arrow modifiers',
+    html`
+        <div x-data="{ count: 0 }">
+            <input type="text"
+                x-on:keydown.up="count++"
+                x-on:keydown.arrow-down="count++"
+            >
+
+            <span x-text="count"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('0'))
+        get('input').type('{upArrow}')
+        get('span').should(haveText('0'))
+        get('input').type('{downArrow}')
+        get('span').should(haveText('1'))
+    }
+)
+
 test('keydown combo modifiers',
     html`
         <div x-data="{ count: 0 }">


### PR DESCRIPTION
AFAICT, the `.up`-like arrow key shorthands mentioned in the [keyboard events](https://github.com/alpinejs/alpine/blob/919d5717263fc2ccfb6de79a8200fd8021bfc755/packages/docs/src/en/directives/on.md#keyboard-events) don't work. I found that they _did_ work when I used the kebab-case form from [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#navigation_keys), i.e. `.arrow-up`.