### PR TITLE
feature: add alias to $persist

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -1,21 +1,26 @@
 
 export default function (Alpine) {
     Alpine.magic('persist', (el, { interceptor }) => {
+        let alias
+
         return interceptor((initialValue, getter, setter, path, key) => {
-            let initial = localStorage.getItem(path)
-                ? localStorage.getItem(path)
+            let storageKey = alias || path
+            let initial = localStorage.getItem(storageKey)
+                ? localStorage.getItem(storageKey)
                 : initialValue
 
             setter(initialValue)
 
             Alpine.effect(() => {
                 let value = getter()
-                localStorage.setItem(path, value)
+                localStorage.setItem(storageKey, value)
 
                 setter(value)
             })
 
             return initial
+        }, func => {
+            func.as = key => { alias = key; return func }
         })
     })
 }

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -1,4 +1,4 @@
-import { haveText, html, test } from '../../utils'
+import { haveText, html, test, wait } from '../../utils'
 
 test('can perist data',
     [html`
@@ -14,4 +14,14 @@ test('can perist data',
         reload()
         get('span').should(haveText('2'))
     },
+)
+
+test('can alias the localStorage key',
+    [html`
+        <div x-data="{ foo: $persist('bar').as('baz') }"></div>
+    `],
+    () => wait(100).then(() => {
+        expect(localStorage.getItem('foo')).to.be.null
+        expect(localStorage.getItem('baz')).to.eq('bar')
+    }),
 )

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -108,3 +108,5 @@ export function root(el) {
 
     return closestRoot(el.parentElement)
 }
+
+export let wait = ms => new Cypress.Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
This pull request adds support for $persist aliases, just like in the $queryString plugin.

```html
<div x-data="{ form: $persist({}).as('form-0Jp3d') }"></div>
```

This useful for cases where you have multiple data components on the same page. With alias you can give each localStore entry a unique key. I recently needed it for a form component.