### PR TITLE
feature: support other data types for $persist

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -3,14 +3,14 @@ export default function (Alpine) {
     Alpine.magic('persist', (el, { interceptor }) => {
         return interceptor((initialValue, getter, setter, path, key) => {
             let initial = localStorage.getItem(path)
-                ? localStorage.getItem(path)
+                ? JSON.parse(localStorage.getItem(path))
                 : initialValue
 
             setter(initialValue)
 
             Alpine.effect(() => {
                 let value = getter()
-                localStorage.setItem(path, value)
+                localStorage.setItem(path, JSON.stringify(value))
 
                 setter(value)
             })

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -1,6 +1,6 @@
-import { haveText, html, test } from '../../utils'
+import { beHidden, beVisible, haveText, html, test } from '../../utils'
 
-test('can perist data',
+test('can persist data',
     [html`
         <div x-data="{ count: $persist(1) }">
             <button @click="count++">Inc</button>
@@ -11,6 +11,51 @@ test('can perist data',
         get('span').should(haveText('1'))
         get('button').click()
         get('span').should(haveText('2'))
+        reload()
+        get('span').should(haveText('2'))
+    },
+)
+
+test('can persist boolean data',
+    [html`
+        <div x-data="{ show: $persist(true) }">
+            <button x-on:click="show = false"></button>
+            <span x-show="show">thing</span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(beVisible())
+        get('button').click()
+        reload()
+        get('span').should(beHidden())
+    },
+)
+
+test('can persist array data',
+    [html`
+        <div x-data="{ items: $persist(['foo']) }">
+            <button x-on:click="items[0] = 'bar'"></button>
+            <span x-text="items[0]"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('foo'))
+        get('button').click()
+        reload()
+        get('span').should(haveText('bar'))
+    },
+)
+
+test('can persist object data',
+    [html`
+        <div x-data="{ foo: $persist({ bar: 1 }) }">
+            <button x-on:click="foo.bar = 2"></button>
+            <span x-text="foo.bar"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('1'))
+        get('button').click()
         reload()
         get('span').should(haveText('2'))
     },


### PR DESCRIPTION
This pull request adds support for other data types to $persist. The current implementation doesn't preserve the type nor supports `array` or `object`.