### PR TITLE
Fix x html with alpine content when sibling of xfor or xif

### DIFF
--- a/packages/alpinejs/src/directives/x-html.js
+++ b/packages/alpinejs/src/directives/x-html.js
@@ -1,13 +1,14 @@
-import { evaluateLater } from '../evaluator'
-import { directive } from '../directives'
-import { mutateDom } from '../mutation'
+import {directive} from '../directives'
+import {nextTick} from "../nextTick";
 
-directive('html', (el, { expression }, { effect, evaluateLater }) => {
+directive('html', (el, {expression}, {effect, evaluateLater}) => {
     let evaluate = evaluateLater(expression)
 
     effect(() => {
         evaluate(value => {
-            el.innerHTML = value
+            nextTick(() => {
+                el.innerHTML = value
+            })
         })
     })
 })

--- a/packages/alpinejs/src/directives/x-html.js
+++ b/packages/alpinejs/src/directives/x-html.js
@@ -1,7 +1,7 @@
 import {directive} from '../directives'
-import {nextTick} from "../nextTick";
+import {nextTick} from "../nextTick"
 
-directive('html', (el, {expression}, {effect, evaluateLater}) => {
+directive('html', (el, { expression }, { effect, evaluateLater }) => {
     let evaluate = evaluateLater(expression)
 
     effect(() => {

--- a/tests/cypress/integration/directives/x-html.spec.js
+++ b/tests/cypress/integration/directives/x-html.spec.js
@@ -35,3 +35,41 @@ test('x-html allows alpine code within',
     }
 
 )
+
+test('x-html with alpine code within, as sibling of an x-if',
+    html`
+        <div x-data="{ foo: '<h2  x-text=&quot;bar&quot;></h2>',bar:'baz', show: true }">
+            <template x-if="show">
+                <h1>X-if template shown</h1>
+            </template>
+            <div x-html="foo"></div>
+        </div>
+
+
+    `,
+    ({ get }) => {
+        get('h1').should(haveText('X-if template shown'))
+        get('h2').should(haveText('baz'))
+    }
+
+)
+
+test('x-html with alpine code within, as sibling of an x-for',
+    html`
+        <div x-data="{ foo: '<h2  x-text=&quot;bar&quot;></h2>',bar:'baz', items: [1,2,3] }">
+            <template x-for="(item,index) in items" :key="index">
+                <div :id="'xfor'+item" x-text="item"></div>
+            </template>
+            <div x-html="foo"></div>
+        </div>
+
+
+    `,
+    ({ get }) => {
+        get('#xfor1').should(haveText('1'))
+        get('#xfor2').should(haveText('2'))
+        get('#xfor3').should(haveText('3'))
+        get('h2').should(haveText('baz'))
+    }
+
+)


### PR DESCRIPTION
This pull request fixes the bug discovered in #1688 

The problem generally is that when one wants to insert alpine code with x-html but it is preceded by x-for or x-if , then the for/if directives pause observing mutations and as walking through the elements, initialize the x-html.
As the mutationobserver is paused, the alpine content inserted from the x-html wont "render".

Wrapping the el.innerHTML assignment in a nextTick solves the issue, as mutationobserver is turned back on.

Codepen showing non working examples : [Alpine3 x-html with alpine data render error](https://codepen.io/tvdr/pen/eYWvpbm) 

Same code with the fixed directive : [Alpine3 x-html with alpine data render fix](https://codepen.io/tvdr/pen/bGWrvep)