### PR TITLE
fix to x-for breaking with error when iterated item is undefined

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -53,23 +53,28 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
         // In order to preserve DOM elements (move instead of replace)
         // we need to generate all the keys for every iteration up
         // front. These will be our source of truth for diffing.
-        if (isObject(items)) {
-            items = Object.entries(items).map(([key, value]) => {
-                let scope = getIterationScopeVariables(iteratorNames, value, key, items)
 
-                evaluateKey(value => keys.push(value), { scope: { index: key, ...scope} })
+        // Do not throw error when iterated variable is deleted/is undefined
+        if (typeof items !== 'undefined'){
+            if (isObject(items)) {
+                items = Object.entries(items).map(([key, value]) => {
+                    let scope = getIterationScopeVariables(iteratorNames, value, key, items)
 
-                scopes.push(scope)
-            })
-        } else {
-            for (let i = 0; i < items.length; i++) {
-                let scope = getIterationScopeVariables(iteratorNames, items[i], i, items)
+                    evaluateKey(value => keys.push(value), { scope: { index: key, ...scope} })
 
-                evaluateKey(value => keys.push(value), { scope: { index: i, ...scope} })
+                    scopes.push(scope)
+                })
+            } else {
+                for (let i = 0; i < items.length; i++) {
+                    let scope = getIterationScopeVariables(iteratorNames, items[i], i, items)
 
-                scopes.push(scope)
+                    evaluateKey(value => keys.push(value), { scope: { index: i, ...scope} })
+
+                    scopes.push(scope)
+                }
             }
         }
+
 
         // Rather than making DOM manipulations inside one large loop, we'll
         // instead track which mutations need to be made in the following

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -1,4 +1,4 @@
-import {beVisible, haveLength, haveText, html, notBeVisible, test} from '../../utils'
+import { beVisible, haveLength, haveText, html, notBeVisible, test } from '../../utils'
 
 test('renders loops with x-for',
     html`
@@ -10,7 +10,7 @@ test('renders loops with x-for',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span:nth-of-type(1)').should(haveText('foo'))
         get('span:nth-of-type(2)').should(notBeVisible())
         get('button').click()
@@ -45,7 +45,7 @@ test('renders loops with x-for that have space or newline',
             </div>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('#1 span:nth-of-type(1)').should(haveText('foo'))
         get('#1 span:nth-of-type(2)').should(notBeVisible())
         get('#2 span:nth-of-type(1)').should(haveText('foo'))
@@ -69,7 +69,7 @@ test('can destructure arrays',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('#1 span').should(haveText('1'))
         get('#1 h1').should(haveText('foo'))
         get('#2 span').should(haveText('2'))
@@ -87,7 +87,7 @@ test('removes all elements when array is empty and previously had one item',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(beVisible())
         get('button').click()
         get('span').should(notBeVisible())
@@ -104,7 +104,7 @@ test('removes all elements when array is empty and previously had multiple items
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span:nth-of-type(1)').should(beVisible())
         get('span:nth-of-type(2)').should(beVisible())
         get('span:nth-of-type(3)').should(beVisible())
@@ -128,7 +128,7 @@ test('elements inside of loop are reactive',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(beVisible())
         get('h1').should(haveText('first'))
         get('h2').should(haveText('bar'))
@@ -150,7 +150,7 @@ test('components inside of loop are reactive',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(haveText('bar'))
         get('button').click()
         get('span').should(haveText('bob'))
@@ -170,7 +170,7 @@ test('components inside a plain element of loop are reactive',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(haveText('bar'))
         get('button').click()
         get('span').should(haveText('bob'))
@@ -188,7 +188,7 @@ test('adding key attribute moves dom nodes properly',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         let haveOgIndex = index => el => expect(el[0].og_loop_index).to.equal(index)
 
         get('#assign').click()
@@ -213,7 +213,7 @@ test('can key by index',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         let haveOgIndex = index => el => expect(el[0].og_loop_index).to.equal(index)
 
         get('#assign').click()
@@ -237,7 +237,7 @@ test('can use index inside of loop',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1').should(haveText(0))
         get('h2').should(haveText(0))
     }
@@ -254,7 +254,7 @@ test('can use third iterator param (collection) inside of loop',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1').should(haveText('foo'))
         get('h2').should(haveText('foo'))
     }
@@ -272,7 +272,7 @@ test('listeners in loop get fresh iteration data even though they are only regis
             <h1 x-text="output"></h1>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1').should(haveText(''))
         get('span').click()
         get('h1').should(haveText('foo'))
@@ -295,7 +295,7 @@ test('nested x-for',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1:nth-of-type(1) h2:nth-of-type(1)').should(beVisible())
         get('h1:nth-of-type(1) h2:nth-of-type(2)').should(beVisible())
         get('h1:nth-of-type(2) h2:nth-of-type(1)').should(notBeVisible())
@@ -316,7 +316,7 @@ test('x-for updates the right elements when new item are inserted at the beginni
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span:nth-of-type(1)').should(haveText('one'))
         get('span:nth-of-type(2)').should(haveText('two'))
         get('button').click()
@@ -338,7 +338,7 @@ test('nested x-for access outer loop variable',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1:nth-of-type(1) h2:nth-of-type(1)').should(haveText('foo: bob'))
         get('h1:nth-of-type(1) h2:nth-of-type(2)').should(haveText('foo: lob'))
         get('h1:nth-of-type(2) h2:nth-of-type(1)').should(haveText('baz: bab'))
@@ -358,7 +358,7 @@ test('sibling x-for do not interact with each other',
             <button @click="foos = [1, 2];bars = [1, 2, 3]">Change</button>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1:nth-of-type(1)').should(haveText('1'))
         get('h2:nth-of-type(1)').should(haveText('1'))
         get('h2:nth-of-type(2)').should(haveText('2'))
@@ -379,7 +379,7 @@ test('x-for over range using i in x syntax',
             </template>
         </div>
     `,
-    ({get}) => get('span').should(haveLength('10'))
+    ({ get }) => get('span').should(haveLength('10'))
 )
 
 test('x-for over range using i in property syntax',
@@ -390,7 +390,7 @@ test('x-for over range using i in property syntax',
             </template>
         </div>
     `,
-    ({get}) => get('span').should(haveLength('10'))
+    ({ get }) => get('span').should(haveLength('10'))
 )
 
 // @flaky
@@ -404,7 +404,7 @@ test.retry(2)('x-for with an array of numbers',
             <button @click="items.push(3)" id="second">click me</button>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(haveLength('0'))
         get('#first').click()
         get('span').should(haveLength('1'))
@@ -423,7 +423,7 @@ test('x-for does not break on undefined iterable',
             <button @click="showitems = 'c'" id="second">Show c (undefined)</button>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(haveLength('3'))
         get('#first').click()
         get('span').should(haveLength('4'))

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -1,4 +1,4 @@
-import { beVisible, haveLength, haveText, html, notBeVisible, test } from '../../utils'
+import {beVisible, haveLength, haveText, html, notBeVisible, test} from '../../utils'
 
 test('renders loops with x-for',
     html`
@@ -10,7 +10,7 @@ test('renders loops with x-for',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span:nth-of-type(1)').should(haveText('foo'))
         get('span:nth-of-type(2)').should(notBeVisible())
         get('button').click()
@@ -45,7 +45,7 @@ test('renders loops with x-for that have space or newline',
             </div>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('#1 span:nth-of-type(1)').should(haveText('foo'))
         get('#1 span:nth-of-type(2)').should(notBeVisible())
         get('#2 span:nth-of-type(1)').should(haveText('foo'))
@@ -69,7 +69,7 @@ test('can destructure arrays',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('#1 span').should(haveText('1'))
         get('#1 h1').should(haveText('foo'))
         get('#2 span').should(haveText('2'))
@@ -87,7 +87,7 @@ test('removes all elements when array is empty and previously had one item',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span').should(beVisible())
         get('button').click()
         get('span').should(notBeVisible())
@@ -104,7 +104,7 @@ test('removes all elements when array is empty and previously had multiple items
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span:nth-of-type(1)').should(beVisible())
         get('span:nth-of-type(2)').should(beVisible())
         get('span:nth-of-type(3)').should(beVisible())
@@ -128,7 +128,7 @@ test('elements inside of loop are reactive',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span').should(beVisible())
         get('h1').should(haveText('first'))
         get('h2').should(haveText('bar'))
@@ -150,7 +150,7 @@ test('components inside of loop are reactive',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span').should(haveText('bar'))
         get('button').click()
         get('span').should(haveText('bob'))
@@ -170,7 +170,7 @@ test('components inside a plain element of loop are reactive',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span').should(haveText('bar'))
         get('button').click()
         get('span').should(haveText('bob'))
@@ -188,7 +188,7 @@ test('adding key attribute moves dom nodes properly',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         let haveOgIndex = index => el => expect(el[0].og_loop_index).to.equal(index)
 
         get('#assign').click()
@@ -213,7 +213,7 @@ test('can key by index',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         let haveOgIndex = index => el => expect(el[0].og_loop_index).to.equal(index)
 
         get('#assign').click()
@@ -237,7 +237,7 @@ test('can use index inside of loop',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1').should(haveText(0))
         get('h2').should(haveText(0))
     }
@@ -254,7 +254,7 @@ test('can use third iterator param (collection) inside of loop',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1').should(haveText('foo'))
         get('h2').should(haveText('foo'))
     }
@@ -272,7 +272,7 @@ test('listeners in loop get fresh iteration data even though they are only regis
             <h1 x-text="output"></h1>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1').should(haveText(''))
         get('span').click()
         get('h1').should(haveText('foo'))
@@ -295,7 +295,7 @@ test('nested x-for',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1:nth-of-type(1) h2:nth-of-type(1)').should(beVisible())
         get('h1:nth-of-type(1) h2:nth-of-type(2)').should(beVisible())
         get('h1:nth-of-type(2) h2:nth-of-type(1)').should(notBeVisible())
@@ -316,7 +316,7 @@ test('x-for updates the right elements when new item are inserted at the beginni
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span:nth-of-type(1)').should(haveText('one'))
         get('span:nth-of-type(2)').should(haveText('two'))
         get('button').click()
@@ -338,7 +338,7 @@ test('nested x-for access outer loop variable',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1:nth-of-type(1) h2:nth-of-type(1)').should(haveText('foo: bob'))
         get('h1:nth-of-type(1) h2:nth-of-type(2)').should(haveText('foo: lob'))
         get('h1:nth-of-type(2) h2:nth-of-type(1)').should(haveText('baz: bab'))
@@ -358,7 +358,7 @@ test('sibling x-for do not interact with each other',
             <button @click="foos = [1, 2];bars = [1, 2, 3]">Change</button>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1:nth-of-type(1)').should(haveText('1'))
         get('h2:nth-of-type(1)').should(haveText('1'))
         get('h2:nth-of-type(2)').should(haveText('2'))
@@ -379,7 +379,7 @@ test('x-for over range using i in x syntax',
             </template>
         </div>
     `,
-    ({ get }) => get('span').should(haveLength('10'))
+    ({get}) => get('span').should(haveLength('10'))
 )
 
 test('x-for over range using i in property syntax',
@@ -390,7 +390,7 @@ test('x-for over range using i in property syntax',
             </template>
         </div>
     `,
-    ({ get }) => get('span').should(haveLength('10'))
+    ({get}) => get('span').should(haveLength('10'))
 )
 
 // @flaky
@@ -404,11 +404,31 @@ test.retry(2)('x-for with an array of numbers',
             <button @click="items.push(3)" id="second">click me</button>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span').should(haveLength('0'))
         get('#first').click()
         get('span').should(haveLength('1'))
         get('#second').click()
         get('span').should(haveLength('2'))
+    }
+)
+
+test('x-for does not break on undefined iterable',
+    `
+        <div x-data="{ items: {a:[1,2,3],b:[4,5,6,7]},showitems:'a'  }">
+            <template x-for="i in items[showitems]">
+                <span x-text="i"></span>
+            </template>
+            <button @click="showitems = 'b'" id="first">Show b</button>
+            <button @click="showitems = 'c'" id="second">Show c (undefined)</button>
+        </div>
+    `,
+    ({get}) => {
+        get('span').should(haveLength('3'))
+        get('#first').click()
+        get('span').should(haveLength('4'))
+        get('#second').click()
+        get('span').should(haveLength('0'))
+
     }
 )

--- a/tests/cypress/integration/directives/x-if.spec.js
+++ b/tests/cypress/integration/directives/x-if.spec.js
@@ -1,4 +1,4 @@
-import { beVisible, haveText, html, notBeVisible, test } from '../../utils'
+import {beVisible, haveLength, haveText, html, notBeVisible, test} from '../../utils'
 
 test('x-if',
     html`
@@ -10,7 +10,7 @@ test('x-if',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('h1').should(notBeVisible())
         get('button').click()
         get('h1').should(beVisible())
@@ -32,7 +32,7 @@ test('x-if inside x-for allows nested directives',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('span').should(haveText('1'))
     }
 )
@@ -47,7 +47,31 @@ test('x-if initializes after being added to the DOM to allow x-ref to work',
             </template>
         </div>
     `,
-    ({ get }) => {
+    ({get}) => {
         get('li').should(haveText('bar'))
+    }
+)
+
+test('x-if condition is same as x-for iterator, and is undfined',
+    `
+        <div x-data="{ items: {a:[1,2,3],b:[4,5,6,7]},showitems:'a'  }">
+            <template x-if="items[showitems]">
+                <template x-for="i in items[showitems]">
+                    <span x-text="i"></span>
+                </template>
+            </template>
+            <button @click="showitems = 'b'" id="first">Show b</button>
+            <button @click="showitems = 'c'" id="second">Show c (undefined)</button>
+
+
+        </div>
+    `,
+    ({get}) => {
+        get('span').should(haveLength('3'))
+        get('#first').click()
+        get('span').should(haveLength('4'))
+        get('#second').click()
+        get('span').should(haveLength('0'))
+
     }
 )

--- a/tests/cypress/integration/directives/x-if.spec.js
+++ b/tests/cypress/integration/directives/x-if.spec.js
@@ -1,4 +1,4 @@
-import {beVisible, haveLength, haveText, html, notBeVisible, test} from '../../utils'
+import { beVisible, haveLength, haveText, html, notBeVisible, test } from '../../utils'
 
 test('x-if',
     html`
@@ -10,7 +10,7 @@ test('x-if',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('h1').should(notBeVisible())
         get('button').click()
         get('h1').should(beVisible())
@@ -32,7 +32,7 @@ test('x-if inside x-for allows nested directives',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(haveText('1'))
     }
 )
@@ -47,7 +47,7 @@ test('x-if initializes after being added to the DOM to allow x-ref to work',
             </template>
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('li').should(haveText('bar'))
     }
 )
@@ -66,7 +66,7 @@ test('x-if condition is same as x-for iterator, and is undfined',
 
         </div>
     `,
-    ({get}) => {
+    ({ get }) => {
         get('span').should(haveLength('3'))
         get('#first').click()
         get('span').should(haveLength('4'))


### PR DESCRIPTION
possible fix for #1805 

By checking if item is not undefined, the loop function does not throw a breaking error, but properly cleans up inserted dom elements.

I think this may be the expected behaviour, even when not wrapped in x-if.  
Tests are commited for both cases.

non working codepen from the issue: [https://codepen.io/acxz/pen/mdmeJRo?editors=1010](https://codepen.io/acxz/pen/mdmeJRo?editors=1010)

same example with after fix [https://codepen.io/tvdr/pen/bGWojwd](https://codepen.io/tvdr/pen/bGWojwd)