### PR TITLE
Remove leading blank line in intersect plugin

### DIFF
--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -1,4 +1,3 @@
-
 export default function (Alpine) {
     Alpine.directive('intersect', (el, { expression, modifiers }, { evaluateLater, cleanup }) => {
         let evaluate = evaluateLater(expression)


### PR DESCRIPTION
A few more like this and the plugin will be *negative* 311 bytes. 😝 