### PR TITLE
Bug ($persist) Multiple components

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -10,7 +10,7 @@ export default function (Alpine) {
                 ? storageGet(lookup)
                 : initialValue
 
-            setter(initialValue)
+            setter(initial)
 
             Alpine.effect(() => {
                 let value = getter()

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -1,6 +1,6 @@
-import { haveText, html, test } from '../../utils'
+import { beVisible, haveText, html, notBeVisible, test } from '../../utils'
 
-test('can perist number',
+test('can persist number',
     [html`
         <div x-data="{ count: $persist(1) }">
             <button @click="count++">Inc</button>
@@ -16,7 +16,7 @@ test('can perist number',
     },
 )
 
-test('can perist string',
+test('can persist string',
     [html`
         <div x-data="{ message: $persist('foo') }">
             <input x-model="message">
@@ -33,7 +33,7 @@ test('can perist string',
     },
 )
 
-test('can perist array',
+test('can persist array',
     [html`
         <div x-data="{ things: $persist(['foo', 'bar']) }">
             <button @click="things.push('baz')"></button>
@@ -47,5 +47,46 @@ test('can perist array',
         get('span').should(haveText('foo-bar-baz'))
         reload()
         get('span').should(haveText('foo-bar-baz'))
+    },
+)
+
+test('can persist objects',
+    [html`
+        <div x-data="{ something: $persist({foo: 'bar'}) }">
+            <button id="one" @click="something.foo = 'baz'"></button>
+            <button id="two" @click="something = {foo: 'bob'}"></button>
+
+            <span x-text="something.foo"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('bar'))
+        get('button#one').click()
+        get('span').should(haveText('baz'))
+        reload()
+        get('span').should(haveText('baz'))
+        get('button#two').click()
+        get('span').should(haveText('bob'))
+        reload()
+        get('span').should(haveText('bob'))
+    },
+)
+
+test('can persist booleans',
+    [html`
+        <div x-data="{ show: $persist(false) }">
+            <button @click="show = true"></button>
+
+            <template x-if="show">
+                <span>Foo</span>
+            </template>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(notBeVisible())
+        get('button').click()
+        get('span').should(beVisible())
+        reload()
+        get('span').should(beVisible())
     },
 )

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -50,7 +50,7 @@ test('can persist array',
     },
 )
 
-test('can persist objects',
+test('can persist object',
     [html`
         <div x-data="{ something: $persist({foo: 'bar'}) }">
             <button id="one" @click="something.foo = 'baz'"></button>
@@ -72,7 +72,7 @@ test('can persist objects',
     },
 )
 
-test('can persist booleans',
+test('can persist boolean',
     [html`
         <div x-data="{ show: $persist(false) }">
             <button @click="show = true"></button>
@@ -88,5 +88,26 @@ test('can persist booleans',
         get('span').should(beVisible())
         reload()
         get('span').should(beVisible())
+    },
+)
+
+test('can persist multiple components using the same property',
+    [html`
+        <div x-data="{ duplicate: $persist('foo') }">
+            <button @click="duplicate = 'bar'"></button>
+            <span id="one" x-text="duplicate"></span>
+        </div>
+        <div x-data="{ duplicate: $persist('foo') }">
+            <span id="two" x-text="duplicate"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span#one').should(haveText('foo'))
+        get('span#two').should(haveText('foo'))
+        get('button').click()
+        get('span#one').should(haveText('bar'))
+        reload()
+        get('span#one').should(haveText('bar'))
+        get('span#two').should(haveText('bar'))
     },
 )


### PR DESCRIPTION
This PR fixes an anomaly which we can see on the documentation page: https://alpinejs.dev/plugins/persist.

When there are 2 components on the same page using the same property, the last one is setting the value in local storage as expected but when reloading the page, only the first component is initialised correctly whilst the second component uses the default of the first one. I appreciate this is not a real use case, the 2 components won't communicate with each other out of the box after the page is loaded so they would behave weirdly but I think they should be consistent.

To replicate
- go to https://alpinejs.dev/plugins/persist#how-it-works
- scroll down to the example (note that above there is another example using the same component)
- increment the counter
- reload the page
- note that the component in https://alpinejs.dev/plugins/persist#magic-persist behaves correctly but the component in https://alpinejs.dev/plugins/persist#how-it-works doesn't 

I've also added a couple of tests for booleans and objects.

Discussed in #1834