### PR TITLE
Bug: init() function doesn't have access to the parent scope

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -29,11 +29,11 @@ directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
 
     let undo = addScopeToNode(el, reactiveData)
 
-    if (reactiveData['init']) reactiveData['init']()
+    reactiveData['init'] && evaluate(el, reactiveData['init'])
 
     cleanup(() => {
         undo()
 
-        reactiveData['destroy'] && reactiveData['destroy']()
+        reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])
     })
 }))

--- a/tests/cypress/integration/custom-data.spec.js
+++ b/tests/cypress/integration/custom-data.spec.js
@@ -17,7 +17,7 @@ test('can register custom data providers',
     ({ get }) => get('span').should(haveText('bar'))
 )
 
-test.only('can accept initial params',
+test('can accept initial params',
     html`
         <script>
             document.addEventListener('alpine:init', () => {
@@ -39,7 +39,7 @@ test.only('can accept initial params',
     }
 )
 
-test.only('can spread together',
+test('can spread together',
     html`
         <script>
             document.addEventListener('alpine:init', () => {
@@ -113,5 +113,56 @@ test('init functions "this" context is reactive',
         get('span').should(haveText('bar'))
         get('button').click()
         get('span').should(haveText('baz'))
+    }
+)
+
+test('init functions have access to the parent scope',
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('parent', () => ({
+                    foo: 'bar',
+                }))
+
+                Alpine.data('child', () => ({
+                    init() {
+                        this.$el.textContent = this.foo
+                    },
+                }))
+            })
+        </script>
+
+        <div x-data="parent">
+            <p x-data="child"></p>
+        </div>
+    `,
+    ({ get }) => {
+        get('p').should(haveText('bar'))
+    }
+)
+
+test('destroy functions inside custom datas are called automatically',
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('test', () => ({
+                    destroy() {
+                        document.querySelector('span').textContent = 'foo'
+                    },
+                    test() {
+                        Alpine.closestRoot(this.$el).remove()
+                    }
+                }))
+            })
+        </script>
+
+        <div x-data="test">
+            <button x-on:click="test()"></button>
+        </div>
+        <span><span>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('span').should(haveText('foo'))
     }
 )


### PR DESCRIPTION
Bug description: The init function that gets called automatically doesn't have access to the parent scope while x-init does.

Mentioned in #1674 and #1711

Relevant changes:
- changed simple function call to `evaluate` so the function gets full access to all Alpine magic.
- removed .only from 2 tests in custom-data.spec.js since the other tests were not running
- added test for the specific use case which fails without the fix (See https://github.com/alpinejs/alpine/runs/3189986654?check_suite_focus=true#step:6:72)
- added minimal test for `destroy` as that line of code was updated as well

Note:
I didn't run many tests for `destroy` since we might need a follow-up. In the current implementation, we call `undo` first and then `destroy` which means that the scope is removed before we call `destroy`. I believe they should be swapped but I'm not sure if it's been done on purpose so I didn't touch it in this PR.