### PR TITLE
Fix throttle on key events

### DIFF
--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -240,6 +240,23 @@ test('.debounce modifier',
     }
 )
 
+test('.throttle modifier',
+    html`
+        <div x-data="{ count: 0 }">
+            <input x-on:keyup.throttle.504ms="count = count+1">
+
+            <span x-text="count"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('0'))
+        get('input').type('f')
+        get('span').should(haveText('1'))
+        get('input').type('ffffffffffff')
+        get('span').should(haveText('1'))
+    }
+)
+
 test('keydown modifiers',
     html`
         <div x-data="{ count: 0 }">


### PR DESCRIPTION
Add a test for the case when throttle is used with key events, and fix.

The handler was never called when throttle is used on key events (keyup and keydown).

This is because `isListeningForASpecificKeyThatHasntBeenPressed()` filters out a list of known event types and assumes that any remaining modifiers are keys to wait for. Unfortunately it omits throttle from the list of known events, so it waits for an invalid key to be pressed.

This fix moves all parsing of the modifiers to the top of `on()` so the repeat parsing is avoided.