### PR TITLE
feature: Value/Modifier based intersect

### DIFF
--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -1,6 +1,7 @@
 import { onAttributeRemoved, onElRemoved } from './mutation'
 import { evaluate, evaluateLater } from './evaluator'
 import { elementBoundEffect } from './reactivity'
+import { dispatch } from './utils/dispatch'
 import Alpine from './alpine'
 
 let prefixAsString = 'x-'
@@ -76,6 +77,7 @@ export function getDirectiveHandler(el, directive) {
         Alpine,
         effect,
         cleanup,
+        dispatch,
         evaluateLater: evaluateLater.bind(evaluateLater, el),
         evaluate: evaluate.bind(evaluate, el),
     }

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -1,7 +1,6 @@
 import { onAttributeRemoved, onElRemoved } from './mutation'
 import { evaluate, evaluateLater } from './evaluator'
 import { elementBoundEffect } from './reactivity'
-import { dispatch } from './utils/dispatch'
 import Alpine from './alpine'
 
 let prefixAsString = 'x-'
@@ -77,7 +76,6 @@ export function getDirectiveHandler(el, directive) {
         Alpine,
         effect,
         cleanup,
-        dispatch,
         evaluateLater: evaluateLater.bind(evaluateLater, el),
         evaluate: evaluate.bind(evaluate, el),
     }

--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -75,28 +75,26 @@ For example, in the following snippet, `shown` will remain `false` until the ele
 </div>
 <!-- END_VERBATIM -->
 
-<a name="events"></a>
-## Events
+<a name="directives"></a>
+## Directives
+
+| Directive      | Description |
+| ---            | --- |
+| `:enter`       | Applied only entering phase. |
+| `:leave`       | Applied only leaving phase. |
 
 <a name="enter"></a>
-### enter
+### :enter
 
 ```html
-<div x-intersect @enter="shown = true">...</div>
+<div x-intersect:enter="shown = true">...</div>
 ```
 
 <a name="leave"></a>
-### leave
+### :leave
 
 ```html
-<div x-intersect @leave="shown = false">...</div>
-```
-
-<a name="changed"></a>
-### changed
-
-```html
-<div x-intersect @changed="shown = true">...</div>
+<div x-intersect:leave="shown = false">...</div>
 ```
 
 <a name="modifiers"></a>

--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -79,24 +79,24 @@ For example, in the following snippet, `shown` will remain `false` until the ele
 ## Events
 
 <a name="enter"></a>
-### @enter
+### enter
 
 ```html
 <div x-intersect @enter="shown = true">...</div>
 ```
 
 <a name="leave"></a>
-### @leave
+### leave
 
 ```html
 <div x-intersect @leave="shown = false">...</div>
 ```
 
-<a name="change"></a>
-### @change
+<a name="changed"></a>
+### changed
 
 ```html
-<div x-intersect @change="shown = true">...</div>
+<div x-intersect @changed="shown = true">...</div>
 ```
 
 <a name="modifiers"></a>

--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -75,6 +75,30 @@ For example, in the following snippet, `shown` will remain `false` until the ele
 </div>
 <!-- END_VERBATIM -->
 
+<a name="events"></a>
+## Events
+
+<a name="enter"></a>
+### @enter
+
+```html
+<div x-intersect @enter="shown = true">...</div>
+```
+
+<a name="leave"></a>
+### @leave
+
+```html
+<div x-intersect @leave="shown = false">...</div>
+```
+
+<a name="change"></a>
+### @change
+
+```html
+<div x-intersect @change="shown = true">...</div>
+```
+
 <a name="modifiers"></a>
 ## Modifiers
 

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -1,5 +1,6 @@
 export default function (Alpine) {
-    Alpine.directive('intersect', (el, { modifiers }, { cleanup, dispatch }) => {
+    Alpine.directive('intersect', (el, { expression, modifiers }, { evaluateLater, cleanup, dispatch }) => {
+        let evaluate = expression ? evaluateLater(expression) : () => { }
 
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
@@ -7,6 +8,10 @@ export default function (Alpine) {
                 dispatch(el, 'change', entry)
 
                 dispatch(el, entry.isIntersecting ? 'enter' : 'leave', entry)
+
+                if (entry.intersectionRatio === 0) return
+
+                evaluate()
 
                 modifiers.includes('once') && observer.disconnect()
             })

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -4,7 +4,7 @@ export default function (Alpine) {
 
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
-                dispatch(el, 'change', entry)
+                dispatch(el, 'changed', entry)
 
                 dispatch(el, entry.isIntersecting ? 'enter' : 'leave', entry)
 

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -1,12 +1,13 @@
 export default function (Alpine) {
-    Alpine.directive('intersect', (el, { expression, modifiers }, { evaluateLater, cleanup }) => {
-        let evaluate = evaluateLater(expression)
+    Alpine.directive('intersect', (el, { modifiers }, { cleanup, dispatch }) => {
 
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
-                if (entry.intersectionRatio === 0) return
+                let event = entry.isIntersecting ? 'enter' : 'leave';
+                
+                dispatch(el, 'change', entry)
 
-                evaluate()
+                dispatch(el, event, entry)
 
                 modifiers.includes('once') && observer.disconnect()
             })

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -1,14 +1,10 @@
 export default function (Alpine) {
-    Alpine.directive('intersect', (el, { expression, modifiers }, { evaluateLater, cleanup, dispatch }) => {
-        let evaluate = expression ? evaluateLater(expression) : () => { }
+    Alpine.directive('intersect', (el, { value, expression, modifiers }, { evaluateLater, cleanup }) => {
+        let evaluate = evaluateLater(expression)
 
-        let observer = new IntersectionObserver(entries => {
+        let observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
-                dispatch(el, 'changed', entry)
-
-                dispatch(el, entry.isIntersecting ? 'enter' : 'leave', entry)
-
-                if (entry.intersectionRatio === 0) return
+                if(!entry.isIntersecting && value === 'enter' || entry.isIntersecting && value === 'leave' || entry.intersectionRatio === 0 && !value) return
 
                 evaluate()
 

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -4,7 +4,6 @@ export default function (Alpine) {
 
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
-
                 dispatch(el, 'change', entry)
 
                 dispatch(el, entry.isIntersecting ? 'enter' : 'leave', entry)

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -3,11 +3,10 @@ export default function (Alpine) {
 
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
-                let event = entry.isIntersecting ? 'enter' : 'leave';
-                
+
                 dispatch(el, 'change', entry)
 
-                dispatch(el, event, entry)
+                dispatch(el, entry.isIntersecting ? 'enter' : 'leave', entry)
 
                 modifiers.includes('once') && observer.disconnect()
             })

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -2,7 +2,7 @@ export default function (Alpine) {
     Alpine.directive('intersect', (el, { value, expression, modifiers }, { evaluateLater, cleanup }) => {
         let evaluate = evaluateLater(expression)
 
-        let observer = new IntersectionObserver((entries) => {
+        let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
                 if(!entry.isIntersecting && value === 'enter' || entry.isIntersecting && value === 'leave' || entry.intersectionRatio === 0 && !value) return
 

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -24,7 +24,7 @@ test('It should emit "enter" event when the component is intersected',
     <div x-data="{ count: 0 }">
         <span x-text="count"></span>
 
-        <div x-intersect @enter="count++" style="margin-top: 100vh;" id="1">hi</div>
+        <div x-intersect:enter="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
     ({ get }, reload) => {
@@ -43,7 +43,7 @@ test('It should emit "leave" event when the component is intersected',
     <div x-data="{ count: 0 }">
         <span x-text="count"></span>
 
-        <div x-intersect @leave="count++" style="margin-top: 100vh;" id="1">hi</div>
+        <div x-intersect:leave="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
     ({ get }, reload) => {
@@ -56,27 +56,6 @@ test('It should emit "leave" event when the component is intersected',
         get('span').should(haveText('2'))
         get('span').scrollIntoView({duration: 100})
         get('span').should(haveText('3'))
-    },
-)
-
-test('It should emit "changed" event when the component is intersected',
-    [html`
-    <div x-data="{ count: 0 }">
-        <span x-text="count"></span>
-
-        <div x-intersect @changed="count++" style="margin-top: 100vh;" id="1">hi</div>
-    </div>
-    `],
-    ({ get }, reload) => {
-        get('span').should(haveText('1'))
-        get('#1').scrollIntoView({duration: 100})
-        get('span').should(haveText('2'))
-        get('span').scrollIntoView({duration: 100})
-        get('span').should(haveText('3'))
-        get('#1').scrollIntoView({duration: 100})
-        get('span').should(haveText('4'))
-        get('span').scrollIntoView({duration: 100})
-        get('span').should(haveText('5'))
     },
 )
 

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -59,6 +59,27 @@ test('It should emit "leave" event when the component is intersected',
     },
 )
 
+test('It should emit "change" event when the component is intersected',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div x-intersect @change="count++" style="margin-top: 100vh;" id="1">hi</div>
+    </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('1'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('2'))
+        get('span').scrollIntoView({duration: 100})
+        get('span').should(haveText('3'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('4'))
+        get('span').scrollIntoView({duration: 100})
+        get('span').should(haveText('5'))
+    },
+)
+
 test('.once',
     [html`
     <div x-data="{ count: 0 }" x-init="setTimeout(() => count++, 300)">

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -8,7 +8,7 @@ test('can intersect',
         <div x-intersect="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
-    ({ get }, reload) => {
+    ({ get }) => {
         get('span').should(haveText('0'))
         get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
@@ -27,7 +27,7 @@ test('It should evaluate with ":enter" only when the component is intersected',
         <div x-intersect:enter="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
-    ({ get }, reload) => {
+    ({ get }) => {
         get('span').should(haveText('0'))
         get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
@@ -46,7 +46,7 @@ test('It should evaluate with ":leave" only when the component is not intersecte
         <div x-intersect:leave="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
-    ({ get }, reload) => {
+    ({ get }) => {
         get('span').should(haveText('1'))
         get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
@@ -67,7 +67,7 @@ test('.once',
         <div x-intersect.once="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
-    ({ get }, reload) => {
+    ({ get }) => {
         get('span').should(haveText('0'))
         get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -19,7 +19,7 @@ test('can intersect',
     },
 )
 
-test('It should emit "enter" event when the component is intersected',
+test('It should evaluate with ":enter" only when the component is intersected',
     [html`
     <div x-data="{ count: 0 }">
         <span x-text="count"></span>
@@ -38,7 +38,7 @@ test('It should emit "enter" event when the component is intersected',
     },
 )
 
-test('It should emit "leave" event when the component is intersected',
+test('It should evaluate with ":leave" only when the component is not intersected',
     [html`
     <div x-data="{ count: 0 }">
         <span x-text="count"></span>

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -59,12 +59,12 @@ test('It should emit "leave" event when the component is intersected',
     },
 )
 
-test('It should emit "change" event when the component is intersected',
+test('It should emit "changed" event when the component is intersected',
     [html`
     <div x-data="{ count: 0 }">
         <span x-text="count"></span>
 
-        <div x-intersect @change="count++" style="margin-top: 100vh;" id="1">hi</div>
+        <div x-intersect @changed="count++" style="margin-top: 100vh;" id="1">hi</div>
     </div>
     `],
     ({ get }, reload) => {

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -2,7 +2,7 @@ import { haveText, test, html } from '../../utils'
 
 test('can intersect',
     [html`
-    <div x-data="{ count: 0 }" x-init="setTimeout(() => count++, 300)">
+    <div x-data="{ count: 0 }">
         <span x-text="count"></span>
 
         <div x-intersect="count++" style="margin-top: 100vh;" id="1">hi</div>
@@ -10,13 +10,52 @@ test('can intersect',
     `],
     ({ get }, reload) => {
         get('span').should(haveText('0'))
+        get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
-        get('#1').scrollIntoView()
+        get('span').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
-        get('span').scrollIntoView()
-        get('span').should(haveText('1'))
-        get('#1').scrollIntoView()
+        get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('2'))
+    },
+)
+
+test('It should emit "enter" event when the component is intersected',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div x-intersect @enter="count++" style="margin-top: 100vh;" id="1">hi</div>
+    </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('0'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('1'))
+        get('span').scrollIntoView({duration: 100})
+        get('span').should(haveText('1'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('2'))
+    },
+)
+
+test('It should emit "leave" event when the component is intersected',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div x-intersect @leave="count++" style="margin-top: 100vh;" id="1">hi</div>
+    </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('1'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('1'))
+        get('span').scrollIntoView({duration: 100})
+        get('span').should(haveText('2'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('2'))
+        get('span').scrollIntoView({duration: 100})
+        get('span').should(haveText('3'))
     },
 )
 
@@ -30,12 +69,11 @@ test('.once',
     `],
     ({ get }, reload) => {
         get('span').should(haveText('0'))
+        get('#1').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
-        get('#1').scrollIntoView()
+        get('span').scrollIntoView({duration: 100})
         get('span').should(haveText('1'))
-        get('span').scrollIntoView()
-        get('span').should(haveText('1'))
-        get('#1').scrollIntoView()
-        get('span').should(haveText('1'))
+        get('#1').scrollIntoView({duration: 100})
+        get('span').should(haveText('2'))
     },
 )


### PR DESCRIPTION
This PR

- Adds `:enter` `:leave` value directives to `x-intersect`.
- No breaking changes. `x-intersecet="[expression]"` still works as expected. 
- Improves existing `x-intersect` tests. (old ones had issues)
- It was very cheap to achieve such a high demanding behavior. 

## Directives

| Directive      | Description |
| ---            | --- |
| `:enter`       | Applied only entering phase. |
| `:leave`       | Applied only leaving phase. |

### :enter

```html
<div x-intersect:enter="shown = true">...</div>
```

### :leave

```html
<div x-intersect:leave="shown = false">...</div>
```

### both

```html
<div  x-intersect:enter="shown = true" x-intersect:leave="shown = false">...</div>
```
