### PR TITLE
fixed safari autofill bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,4 @@
             Content...
         </span>
     </div>
-
-<div x-data="{username: '', password: ''}" >
-    <input x-model="username" type="text" name="username" id="username">
-    <input x-model="password" type="password" name="password" id="password">
-    <div x-text="username">test</div>
-    <div x-text="password">test</div>
-    <button @click="username = null, password=null">TEst</button>
-</div>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,4 +15,12 @@
             Content...
         </span>
     </div>
+
+<div x-data="{username: '', password: ''}" >
+    <input x-model="username" type="text" name="username" id="username">
+    <input x-model="password" type="password" name="password" id="password">
+    <div x-text="username">test</div>
+    <div x-text="password">test</div>
+    <button @click="username = null, password=null">TEst</button>
+</div>
 </html>

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -60,8 +60,10 @@ function generateAssignmentFunction(el, modifiers, expression) {
     return (event, currentValue) => {
         return mutateDom(() => {
             // Check for event.detail due to an issue where IE11 handles other events as a CustomEvent.
+            // Safari autofill triggers event as CustomEvent and assigns value to target 
+            // so we return event.target.value instead of event.detail
             if (event instanceof CustomEvent && event.detail !== undefined) {
-                return event.detail
+                return event.detail || event.target.value
             } else if (el.type === 'checkbox') {
                 // If the data we are binding to is an array, toggle its value inside the array.
                 if (Array.isArray(currentValue)) {


### PR DESCRIPTION
This PR 
- fixes #1909
- fixes #1862
- fixes #1810
- fixes #1501

Fix was very simple as Safari triggers `autofill` event as CustomEvent instead of `input` event, even Alpine handles customEvent but it did not handle the assigned value properly. So i just fixed that part.

I don't have an iOS device to check but so far i could only check desktop safari and its seems fixed. It would be nice to have some feedbacks if anyone can try this. 