### PR TITLE
Add instructions to use $persist with Alpine.data

### DIFF
--- a/packages/docs/src/en/plugins/persist.md
+++ b/packages/docs/src/en/plugins/persist.md
@@ -136,3 +136,16 @@ Now Alpine will store and retrieve the above "count" value using the key "other-
 Here's a view of Chrome Devtools to see for yourself:
 
 <img src="/img/persist_custom_key_devtools.png" alt="Chrome devtools showing the localStorage view with count set to 0">
+
+<a name="using-persist-with-alpine-data"></a>
+## Using $persist with Alpine.data
+
+If you want to use `$persist` with `Alpine.data`, you need to use a standard function instead of an arrow function so Alpine can bind a custom `this` context when it initially evaluates the component scope.
+
+```js
+Alpine.data('dropdown', function () {
+    return {
+        open: this.$persist(false)
+    }
+})
+```


### PR DESCRIPTION
Feel free to reword it to make it clearer.
A few people are trying to use `$persist` with `Alpine.data` but all examples on the docs use arrow functions.
Alpine tries to bind the custom context [here](https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/datas.js#L13) but in javascript is not possible to re-bind `this` for arrow functions.

This applies every time we try to use `this` to define a property value in Alpine.data but currently `$persist` is the only magic that needs it. Using `this` inside a function defined in x-data works as expected since at that point the object has been "Alpinefied" by the custom evaluate function.