### PR TITLE
Fixed shadow dom parent issue

### DIFF
--- a/packages/trap/src/index.js
+++ b/packages/trap/src/index.js
@@ -39,7 +39,7 @@ export default function (Alpine) {
 }
 
 function crawlSiblingsUp(el, callback) {
-    if (el.isSameNode(document.body)) return
+    if (el.isSameNode(document.body) || ! el.parentNode) return
 
     Array.from(el.parentNode.children).forEach(sibling => {
         if (! sibling.isSameNode(el)) callback(sibling)


### PR DESCRIPTION
This PR fixes a bug caused by #1965 fix when using it with Livewire `@entangle ` .

Mentioned:
- #1983 
- #1982
- #1959 

Livewire `@entangle ` creates a bug on the Alpine components where parent node of the `x-trap` element is become a `document-fragment`. Just added `el.parentNode ` check on el to fix this.
