### PR TITLE
Fix empty x-init

### DIFF
--- a/packages/alpinejs/src/directives/x-init.js
+++ b/packages/alpinejs/src/directives/x-init.js
@@ -5,4 +5,4 @@ import { evaluate } from "../evaluator";
 
 addInitSelector(() => `[${prefix('init')}]`)
 
-directive('init', skipDuringClone((el, { expression }) => evaluate(el, expression, {}, false)))
+directive('init', skipDuringClone((el, { expression }) => !! expression.trim() && evaluate(el, expression, {}, false)))

--- a/tests/cypress/integration/directives/x-init.spec.js
+++ b/tests/cypress/integration/directives/x-init.spec.js
@@ -35,3 +35,12 @@ test('can make deferred changes with $nextTick',
     `,
     ({ get }) => get('span').should(haveText('yo'))
 )
+
+test('x-init will not evaluate expression if it is empty',
+    html`
+        <div x-data="{ foo: 'bar' }" x-init=" ">
+            <span x-text="foo" x-ref="foo">baz</span>
+        </div>
+    `,
+    ({ get }) => get('span').should(haveText('bar'))
+)


### PR DESCRIPTION
This PR
- adds a check on `x-init` expression to skip `evaluate` if it's empty. 

This will allow server side conditional `x-init` expressions rendering such as:
```html
<div x-init="@if ($initialExpression) .... @endif">...</div>
```
Mentioned: 
- #1991 