### PR TITLE
Add period and equal  directives

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -182,6 +182,8 @@ function keyToModifiers(key) {
         'down': 'arrow-down',
         'left': 'arrow-left',
         'right': 'arrow-right',
+        'period': '.',
+        'equal': '=',
     }
 
     modifierToKeyMap[key] = key

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -85,6 +85,8 @@ For easy reference, here is a list of common keys you may want to listen for.
 | `.escape`                   | Escape                      |
 | `.tab`                      | Tab                         |
 | `.caps-lock`                | Caps Lock                   |
+| `.equal`                    | Equal, `=`                  |
+| `.period`                   | Period, `.`                 |
 
 <a name="custom-events"></a>
 ## Custom events

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -257,6 +257,8 @@ test('keydown modifiers',
                 x-on:keydown.esc="count++"
                 x-on:keydown.ctrl="count++"
                 x-on:keydown.slash="count++"
+                x-on:keydown.period="count++"
+                x-on:keydown.equal="count++"
             >
 
             <span x-text="count"></span>
@@ -286,6 +288,10 @@ test('keydown modifiers',
         get('span').should(haveText('21'))
         get('input').type('/')
         get('span').should(haveText('23'))
+        get('input').type('=')
+        get('span').should(haveText('25'))
+        get('input').type('.')
+        get('span').should(haveText('27'))
     }
 )
 


### PR DESCRIPTION
Built a simple calculator demo last night. Ran into two obvious key issues:

`@keydown.window..=` is not valid Alpine syntax 
`@keydown.window.==` is not valid HTML 

This PR solves both issues by introducing:
1. `@keydown.window.period=`
2. `@keydown.window.equal=`