### PR TITLE
Additional test for x-trap (livewire issue)

### DIFF
--- a/tests/cypress/integration/plugins/trap.spec.js
+++ b/tests/cypress/integration/plugins/trap.spec.js
@@ -28,3 +28,31 @@ test('can trap focus',
         get('#2').should(haveFocus())
     },
 )
+
+test('works with clone',
+    [html`
+        <script>
+            function triggerClone() {
+                var original = document.getElementById('foo')
+                var copy = original.cloneNode(true)
+                Alpine.clone(original, copy)
+                let p = document.createElement("p")
+                p.textContent = 'bar'
+                copy.appendChild(p)
+                original.parentNode.replaceChild(copy, original)
+            }
+        </script>
+        <div id="foo" x-data="{ open: false }">
+            <button id="one" @click="open = true">Trap</button>
+            <div x-trap="open">
+                <input type="text">
+                <button id="two" @click="triggerClone()">Test</button>
+            </div>
+        </div>
+    `],
+    ({ get, wait }, reload) => {
+        get('#one').click()
+        get('#two').click()
+        get('p').should(haveText('bar'))
+    }
+)


### PR DESCRIPTION
This PR just contains a test for the fix to the x-trap bug affecting livewire (https://github.com/alpinejs/alpine/pull/1986).
The bug was likely caused by cloneNode starting Alpine on an element temporary detached from the DOM so it contains a function to simulate the same behaviour. As the code stops on the Alpine.clone call, it will never insert the p element.
The PR was originally applied to v3.2.4 to ensure the test was failing (see https://github.com/SimoTod/alpine/actions/runs/1199403219) cc @MuzafferDede 
