### PR TITLE
Fix `x-init` bug introduced in v3.3.0

### DIFF
--- a/packages/alpinejs/src/directives/x-init.js
+++ b/packages/alpinejs/src/directives/x-init.js
@@ -5,4 +5,12 @@ import { evaluate } from "../evaluator";
 
 addInitSelector(() => `[${prefix('init')}]`)
 
-directive('init', skipDuringClone((el, { expression }) => !! expression.trim() && evaluate(el, expression, {}, false)))
+directive('init', skipDuringClone((el, { expression }) => {
+  const evaluation = evaluate(el, expression, {}, false)
+
+  if (typeof expression === 'string') {
+    return !! expression.trim() && evaluation
+  }
+
+  return evaluation
+}))

--- a/packages/alpinejs/src/directives/x-init.js
+++ b/packages/alpinejs/src/directives/x-init.js
@@ -6,11 +6,9 @@ import { evaluate } from "../evaluator";
 addInitSelector(() => `[${prefix('init')}]`)
 
 directive('init', skipDuringClone((el, { expression }) => {
-  const evaluation = evaluate(el, expression, {}, false)
-
   if (typeof expression === 'string') {
-    return !! expression.trim() && evaluation
+    return !! expression.trim() && evaluate(el, expression, {}, false)
   }
 
-  return evaluation
+  return evaluate(el, expression, {}, false)
 }))


### PR DESCRIPTION
### Bug caused by #1993:

The change breaks `x-init` expressions that are defined via `x-bind` and possibly other
directives that pass an object through. It assumes the value of `x-init` will always be a string
(empty or not) by using the `trim` function.

The following still works after this change:

```
<div x-init="$nextTick(() => { console.log('this will be logged') })"></div>
```

But the following will now break:

```
<script>
const test = {
  ['x-init']() {
    return this.$nextTick(() => console.log('this will not be logged'));
  }
};
</script>

<div x-bind="test"></div>
```

### Change introduced to fix:

Check the `expression` is a string before checking `trim` produces an empty string.