### PR TITLE
add ShadowRoot protection for older browsers

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -26,7 +26,7 @@ export function refreshScope(element, scope) {
 export function closestDataStack(node) {
     if (node._x_dataStack) return node._x_dataStack
 
-    if (node instanceof ShadowRoot) {
+    if (typeof ShadowRoot === 'function' && node instanceof ShadowRoot) {
         return closestDataStack(node.host)
     }
 

--- a/packages/alpinejs/src/utils/walk.js
+++ b/packages/alpinejs/src/utils/walk.js
@@ -1,5 +1,5 @@
 export function walk(el, callback) {
-    if (el instanceof ShadowRoot) {
+    if (typeof ShadowRoot === 'function' && el instanceof ShadowRoot) {
         Array.from(el.children).forEach(el => walk(el, callback))
 
         return


### PR DESCRIPTION
Add check to ensure ShadowRoot exists so Alpine V3 loads for older browsers (Chrome/Safari/Firefox when polyfills are present)