### PR TITLE
Adds clarification to x-if page in docs

### DIFF
--- a/packages/docs/src/en/directives/if.md
+++ b/packages/docs/src/en/directives/if.md
@@ -16,3 +16,5 @@ Because of this difference in behavior, `x-if` should not be applied directly to
 ```
 
 > Unlike `x-show`, `x-if`, does NOT support transitioning toggles with `x-transition`.
+
+> Remember: `<template>` tags can only contain one root level element.


### PR DESCRIPTION
Currently the docs do not mention the fact that `<template>` tags can only contain one root element, specifically when used with `x-if`. I've added a small point of clarification that may help those wondering why only the first element in the tag is showing.

Added the following to the end of the file:

> Remember: `<template>` tags can only contain one root level element.