### PR TITLE
Option to set custom listener manipulation (e. g. jQuery events compatibility) 

### DIFF
--- a/packages/alpinejs/src/alpine.js
+++ b/packages/alpinejs/src/alpine.js
@@ -5,6 +5,7 @@ import { start, addRootSelector, closestRoot, initTree } from './lifecycle'
 import { interceptor } from './interceptor'
 import { debounce } from './utils/debounce'
 import { throttle } from './utils/throttle'
+import { setListenerManipulators } from './utils/on'
 import { mutateDom } from './mutation'
 import { nextTick } from './nextTick'
 import { plugin } from './plugin'
@@ -26,6 +27,7 @@ let Alpine = {
     evaluateLater,
     setEvaluator,
     closestRoot,
+    setListenerManipulators,
     // Warning: interceptor is not public API and is subject to change without major release.
     interceptor,
     mutateDom,

--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -1,6 +1,22 @@
 import { debounce } from './debounce'
 import { throttle } from './throttle'
 
+let theListenerAdderFunction = nativeListenerAdder
+let theListenerRemoverFunction = nativeListenerRemover
+
+export function setListenerManipulators(listenerAdder, listenerRemover) {
+    theListenerAdderFunction = listenerAdder
+    theListenerRemoverFunction = listenerRemover
+}
+
+export function nativeListenerAdder(target, event, handler, options, modifiers) {
+    target.addEventListener(event, handler, options)
+}
+
+export function nativeListenerRemover(target, event, handler, options) {
+    target.removeEventListener(event, handler, options)
+}
+
 export default function on (el, event, modifiers, callback) {
     let listenerTarget = el
 
@@ -62,14 +78,14 @@ export default function on (el, event, modifiers, callback) {
         handler = wrapHandler(handler, (next, e) => {
             next(e)
 
-            listenerTarget.removeEventListener(event, handler, options)
+            theListenerRemoverFunction(listenerTarget, event, handler, options)
         })
     }
 
-    listenerTarget.addEventListener(event, handler, options)
+    theListenerAdderFunction(listenerTarget, event, handler, options, modifiers)
 
     return () => {
-        listenerTarget.removeEventListener(event, handler, options)
+        theListenerRemoverFunction(listenerTarget, event, handler, options)
     }
 }
 


### PR DESCRIPTION
This change would allow to enable compatibility with jQuery event system

```javascript
document.addEventListener('alpine:init', () => {
  Alpine.setListenerManipulators(
    (target, event, handler, options, modifiers) => { $(target).on(event, handler) },
    (target, event, handler, options) => { $(target).off(event, handler) }
  )
})
```