### PR TITLE
Updated docs - order matters w/ Alpine.data

### DIFF
--- a/packages/docs/src/en/upgrade-guide.md
+++ b/packages/docs/src/en/upgrade-guide.md
@@ -371,3 +371,5 @@ The following 2 APIs will still work in V3, but are considered deprecated and ar
     })
 </script>
 ```
+
+> Note that you need to define `Alpine.data()` extensions BEFORE you call `Alpine.start()`. For more information, refer to the [Lifecycle Concerns](https://alpinejs.dev/advanced/extending#lifecycle-concerns) and [Installation as a Module](https://alpinejs.dev/essentials/installation#as-a-module) documentation pages. 


### PR DESCRIPTION
When upgrading a project to v3, I got tripped up by this. Betting other folks will skip straight to the upgrade guide like I did and not realize that order matters with how v3 is initialized on the page. This is the only thing I've encountered so far! Perhaps some background about why this is deprecated would also be useful? 

Is it deprecated because it's better to have these data functions scoped within Alpine, or do you expect the old (global) functions to no longer work in a future version?

Thanks! ✌️