### PR TITLE
refactored x-trap to use focus-trap plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,6 @@
             "workspaces": [
                 "packages/*"
             ],
-            "dependencies": {
-                "@vue/reactivity": "^3.0.2",
-                "wicg-inert": "^3.1.1"
-            },
             "devDependencies": {
                 "axios": "^0.21.1",
                 "brotli-size": "^4.0.0",
@@ -3049,6 +3045,14 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/focus-trap": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.6.1.tgz",
+            "integrity": "sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==",
+            "dependencies": {
+                "tabbable": "^5.2.1"
             }
         },
         "node_modules/follow-redirects": {
@@ -7096,6 +7100,11 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "node_modules/tabbable": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
+            "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
+        },
         "node_modules/terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -7611,11 +7620,6 @@
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
         },
-        "node_modules/wicg-inert": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
-            "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
-        },
         "node_modules/word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -7790,13 +7794,14 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.0.6",
+            "version": "3.3.3",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "^3.0.2"
             }
         },
         "packages/csp": {
+            "name": "@alpinejs/csp",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7804,10 +7809,12 @@
             }
         },
         "packages/docs": {
-            "version": "3.0.6-revision.2",
+            "name": "@alpinejs/docs",
+            "version": "3.3.3-revision.1",
             "license": "MIT"
         },
         "packages/history": {
+            "name": "@alpinejs/history",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7815,10 +7822,12 @@
             }
         },
         "packages/intersect": {
-            "version": "3.0.0-alpha.0",
+            "name": "@alpinejs/intersect",
+            "version": "3.3.3",
             "license": "MIT"
         },
         "packages/morph": {
+            "name": "@alpinejs/morph",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7826,14 +7835,16 @@
             }
         },
         "packages/persist": {
-            "version": "3.0.0-alpha.0",
+            "name": "@alpinejs/persist",
+            "version": "3.3.3",
             "license": "MIT"
         },
         "packages/trap": {
-            "version": "3.0.0-alpha.0",
+            "name": "@alpinejs/trap",
+            "version": "3.3.3",
             "license": "MIT",
             "dependencies": {
-                "wicg-inert": "^3.1.1"
+                "focus-trap": "^6.6.1"
             }
         }
     },
@@ -7868,7 +7879,7 @@
         "@alpinejs/trap": {
             "version": "file:packages/trap",
             "requires": {
-                "wicg-inert": "^3.1.1"
+                "focus-trap": "^6.6.1"
             }
         },
         "@babel/code-frame": {
@@ -10264,6 +10275,14 @@
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
+            }
+        },
+        "focus-trap": {
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.6.1.tgz",
+            "integrity": "sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==",
+            "requires": {
+                "tabbable": "^5.2.1"
             }
         },
         "follow-redirects": {
@@ -13424,6 +13443,11 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "tabbable": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
+            "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
+        },
         "terminal-link": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -13846,11 +13870,6 @@
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
-        },
-        "wicg-inert": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
-            "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
         },
         "word-wrap": {
             "version": "1.2.3",

--- a/packages/trap/package.json
+++ b/packages/trap/package.json
@@ -8,6 +8,6 @@
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
     "dependencies": {
-        "wicg-inert": "^3.1.1"
+        "focus-trap": "^6.6.1"
     }
 }

--- a/packages/trap/src/index.js
+++ b/packages/trap/src/index.js
@@ -1,4 +1,4 @@
-import 'wicg-inert'
+import { createFocusTrap } from 'focus-trap';
 
 export default function (Alpine) {
     Alpine.directive('trap', (el, { expression }, { effect, evaluateLater }) => {
@@ -6,62 +6,27 @@ export default function (Alpine) {
 
         let oldValue = false
 
-        let undoTrappings = []
+        let trap = createFocusTrap(el, { 
+            escapeDeactivates: false,
+            allowOutsideClick: true
+        })
 
         effect(() => evaluator(value => {
             if (oldValue === value) return
 
             // Start trapping.
             if (value && ! oldValue) {
-                let activeEl = document.activeElement
-
-                undoTrappings.push(() => activeEl && setTimeout(() => activeEl.focus()))
-
-                crawlSiblingsUp(el, (sibling) => {
-                    let cache = sibling.hasAttribute('inert')
-
-                    sibling.setAttribute('inert', 'inert')
-
-                    undoTrappings.push(() => cache || sibling.removeAttribute('inert'))
-                })
-
-                focusFirstElement(el)
+                setTimeout(() => {
+                    trap.activate()
+                });
             }
 
             // Stop trapping.
             if (! value && oldValue) {
-                while(undoTrappings.length) undoTrappings.pop()()
+                trap.deactivate()
             }
 
             oldValue = !! value
         }))
     })
-}
-
-function crawlSiblingsUp(el, callback) {
-    if (el.isSameNode(document.body) || ! el.parentNode) return
-
-    Array.from(el.parentNode.children).forEach(sibling => {
-        if (! sibling.isSameNode(el)) callback(sibling)
-
-        crawlSiblingsUp(el.parentNode, callback)
-    })
-}
-
-function focusFirstElement(el) {
-    let autofocus = el.querySelector('[autofocus]')
-
-    if (autofocus) {
-        setTimeout(() => autofocus.focus())
-    } else {
-        // All focusable element types...
-        let selector = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
-
-        let firstFocusable = Array.from(el.querySelectorAll(selector))
-            // All non-disabled elements...
-            .filter(el => ! el.hasAttribute('disabled'))
-            [0]
-
-        setTimeout(() => firstFocusable && firstFocusable.focus())
-    }
 }


### PR DESCRIPTION
This PR

- replaces `wicg-inert` with `focus-trap` plugin to introduce new approach to prevent focus bouncing to address bar when focus is trapped. 

This has been mentioned 
- #2057 ,discord and a tweet replay of mine. 

P.S.
I think this approach is cheaper and performs better since it does not need to crawl the dom to add or remove attributes. 