### PR TITLE
Fix click.away regression

### DIFF
--- a/packages/alpinejs/src/directives/x-transition.js
+++ b/packages/alpinejs/src/directives/x-transition.js
@@ -125,7 +125,10 @@ function registerTransitionObject(el, setFunction, defaultValue = {}) {
 }
 
 window.Element.prototype._x_toggleAndCascadeWithTransitions = function (el, value, show, hide) {
-    let clickAwayCompatibleShow = show
+    // We are wrapping this function in a setTimeout here to prevent
+    // a race condition from happening where elements that have a
+    // @click.away always view themselves as shown on the page.
+    let clickAwayCompatibleShow = () => setTimeout(show)
 
     if (value) {
         el._x_transition


### PR DESCRIPTION
Quite a few users mentioned that 3.4.4 broke their app when using x-show + click.away.

Annoyingly, the code did pass the test (https://github.com/alpinejs/alpine/blob/main/tests/cypress/integration/directives/x-on.spec.js#L353) but the exact same example loaded on a page is broken (https://codepen.io/SimoTod/pen/OJgQmba) 🤷 

I checked the reason for the fix (navigating to different tabs) and setTimeout won't pause like requestAnimationFrame so it should be fine plus is consistent with what we do in x-show (https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/directives/x-show.js).

Closes #2080