### PR TITLE
Bug - Another regression 

### DIFF
--- a/packages/alpinejs/src/directives/x-transition.js
+++ b/packages/alpinejs/src/directives/x-transition.js
@@ -125,10 +125,15 @@ function registerTransitionObject(el, setFunction, defaultValue = {}) {
 }
 
 window.Element.prototype._x_toggleAndCascadeWithTransitions = function (el, value, show, hide) {
-    // We are wrapping this function in a setTimeout here to prevent
+    // We are running this function after one tick to prevent
     // a race condition from happening where elements that have a
     // @click.away always view themselves as shown on the page.
-    let clickAwayCompatibleShow = () => setTimeout(show)
+    // If the tab is active, we prioritise requestAnimationFrame which plays
+    // nicely with nested animations otherwise we use setTimeout to make sure
+    // it keeps running in background. setTimeout has a lower priority in the
+    // event loop so it would skip nested transitions but when the tab is
+    // hidden, it's not relevant.
+    let clickAwayCompatibleShow = () => {document.visibilityState === 'visible' ? requestAnimationFrame(show) : setTimeout(show)}
 
     if (value) {
         el._x_transition

--- a/tests/cypress/integration/directives/x-transition.spec.js
+++ b/tests/cypress/integration/directives/x-transition.spec.js
@@ -1,4 +1,4 @@
-import { beHidden, beVisible, haveClasses, html, notBeVisible, notHaveClasses, test } from '../../utils'
+import { beHidden, beVisible, haveClasses, haveComputedStyle, html, notBeVisible, notHaveClasses, notHaveComputedStyle, test } from '../../utils'
 
 test('transition in',
     html`
@@ -52,5 +52,31 @@ test('transition out',
         get('span').should(notHaveClasses(['leave-start']))
         get('span').should(haveClasses(['leave', 'leave-end']))
         get('span').should(beHidden())
+    }
+)
+
+test('transition:enter in nested x-show visually runs',
+    html`
+        <style>
+            .transition { transition: opacity 1s ease; }
+            .opacity-0 {opacity: 0}
+            .opacity-1 {opacity: 1}
+        </style>
+        <div x-data="{ show: false }">
+            <span x-show="show">
+                <h1 x-show="show"
+                    x-transition:enter="transition"
+                    x-transition:enter-start="opacity-0"
+                    x-transition:enter-end="opacity-1">thing</h1>
+            </span>
+
+            <button x-on:click="show = true"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('span').should(beVisible())
+        get('h1').should(notHaveComputedStyle('opacity', '1')) // We expect a value between 0 and 1
+        get('h1').should(haveComputedStyle('opacity', '1')) // Eventually opacity will be 1
     }
 )

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -103,6 +103,16 @@ export let haveLength = length => el => expect(el).to.have.length(length)
 
 export let beEqualTo = value => el => expect(el).to.eq(value)
 
+export let notHaveComputedStyle = (name, value) => el => {
+    const win = el[0].ownerDocument.defaultView
+    expect(win.getComputedStyle(el[0]).getPropertyValue(name)).not.to.eq(value)
+}
+
+export let haveComputedStyle = (name, value) => el => {
+    const win = el[0].ownerDocument.defaultView
+    expect(win.getComputedStyle(el[0]).getPropertyValue(name)).to.eq(value)
+}
+
 export function root(el) {
     if (el._x_dataStack) return el
 


### PR DESCRIPTION
It seems that the fix for click away broke x-transition when they are defined in nested x-show.
setTimeout has a lower priority so the microtask for the transition start before the parent div gets showed and before the property change happens when the div is still hidden, the browser won't show any fancy effect. :(

I tried 'let clickAwayCompatibleShow = () => Promise.resolve().then(show)' and 'let clickAwayCompatibleShow = () => queueMicrotask(show)'. Both work correctly with the nested transition but do not work with clickAway

I tried
```javascript
    let clickAwayCompatibleShow = () => setTimeout(show)
    let nestedTransitionCompatibleShow = () => setTimeout(() => el._x_transition.in(show))

    if (value) {
        el._x_transition
            ? nestedTransitionCompatibleShow()
            : clickAwayCompatibleShow()

        return
    }
```
This would fix the issue and would be compatible with click.away but it would introduce a delay so I suspect it could break some other edge case for some users relying on the transition to start immediately.

The final version reverts it to the original implementation (requestAnimationFrame) which seemed solid and it uses setTimeout only if the tab is not visible (at that point transitions are not important anyway and we just care that everything keeps running).

Bit of an annoying one, sorry.

closes #2095