### PR TITLE
Fix x-model for csp build

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -6,8 +6,6 @@ import on from '../utils/on'
 
 directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
     let evaluate = evaluateLater(el, expression)
-    let assignmentExpression = `${expression} = rightSideOfExpression($event, ${expression})`
-    let evaluateAssignment = evaluateLater(el, assignmentExpression)
 
     // If the element we are binding to is a select, a radio, or checkbox
     // we'll listen for the change event instead of the "input" event.
@@ -19,10 +17,9 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
     let assigmentFunction = generateAssignmentFunction(el, modifiers, expression)
 
     let removeListener = on(el, event, modifiers, (e) => {
-        evaluateAssignment(() => {}, { scope: {
-            '$event': e,
-            rightSideOfExpression: assigmentFunction
-        }})
+        evaluateLater(el, function () {
+            this[expression] = assigmentFunction(e, expression)
+        })(() => {})
     })
 
     cleanup(() => removeListener())
@@ -60,7 +57,7 @@ function generateAssignmentFunction(el, modifiers, expression) {
     return (event, currentValue) => {
         return mutateDom(() => {
             // Check for event.detail due to an issue where IE11 handles other events as a CustomEvent.
-            // Safari autofill triggers event as CustomEvent and assigns value to target 
+            // Safari autofill triggers event as CustomEvent and assigns value to target
             // so we return event.target.value instead of event.detail
             if (event instanceof CustomEvent && event.detail !== undefined) {
                 return event.detail || event.target.value

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -28,6 +28,24 @@ test('x-model updates value when updated via input event',
     }
 )
 
+test.csp('csp x-model updates value when updated via input event',
+    [html`
+    <div x-data="test">
+        <input x-model="foo"></input>
+        <span x-text="foo"></span>
+    </div>
+    `, `
+        Alpine.data('test', () => ({
+            foo: 'bar',
+        }))
+    `],
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('input').type('baz')
+        get('span').should(haveText('barbaz'))
+    }
+)
+
 test('x-model has value binding when updated',
     html`
     <div x-data="{ foo: 'bar' }">


### PR DESCRIPTION
There are a couple of issues with the CSP build. For one, it is not available on npm.

This PR adds a failing test for the model directive with regards to reactivity. 

The included fix replaces an evaluated string that is created in the directive with a plain function. This does not break any other test although it might not cover all the use cases the initial implementation covered.

If the CSP build gains more momentum it might be a good idea to add more specific tests for it. One question then is, how to organise these tests. Within the existing specs or in separate CSP specific ones. I included the new test in the existing spec for simplicity.

Is this something you want to consider to pursue, @calebporzio?