### PR TITLE
Updated incorrect apostrophes in dispatch.md

### DIFF
--- a/packages/docs/src/en/magics/dispatch.md
+++ b/packages/docs/src/en/magics/dispatch.md
@@ -66,7 +66,7 @@ Notice that, because of [event bubbling](https://en.wikipedia.org/wiki/Event_bub
 <div>
 ```
 
-> The first example won't work because when `custom-event` is dispatched, it'll propagate to its common ancestor, the `div`, not it's sibling, the `<span>`. The second example will work because the sibling is listening for `notify` at the `window` level, which the custom event will eventually bubble up to.
+> The first example won't work because when `custom-event` is dispatched, it'll propagate to its common ancestor, the `div`, not its sibling, the `<span>`. The second example will work because the sibling is listening for `notify` at the `window` level, which the custom event will eventually bubble up to.
 
 <a name="dispatching-to-components"></a>
 ## Dispatching to other components
@@ -103,4 +103,4 @@ You can also use `$dispatch()` to trigger data updates for `x-model` data bindin
 </div>
 ```
 
-This opens up the door for making custom input components who's value can be set via `x-model`.
+This opens up the door for making custom input components whos value can be set via `x-model`.

--- a/packages/docs/src/en/magics/dispatch.md
+++ b/packages/docs/src/en/magics/dispatch.md
@@ -103,4 +103,4 @@ You can also use `$dispatch()` to trigger data updates for `x-model` data bindin
 </div>
 ```
 
-This opens up the door for making custom input components whos value can be set via `x-model`.
+This opens up the door for making custom input components whose value can be set via `x-model`.


### PR DESCRIPTION
changed a who's (possesive) to whos and an it's (possesive) to its.