### PR TITLE
Create global Alpine.$persist to enable persisting in Alpine.store

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,27 +1,117 @@
-<html>
-    <script src="./packages/intersect/dist/cdn.js" defer></script>
-    <script src="./packages/morph/dist/cdn.js" defer></script>
-    <script src="./packages/history/dist/cdn.js"></script>
-    <script src="./packages/persist/dist/cdn.js"></script>
-    <script src="./packages/trap/dist/cdn.js"></script>
-    <script src="./packages/collapse/dist/cdn.js"></script>
-    <script src="./packages/alpinejs/dist/cdn.js" defer></script>
-    <!-- <script src="https://unpkg.com/alpinejs@3.0.0/dist/cdn.min.js" defer></script> -->
+<!DOCTYPE html>
+<html x-data="" :class="$store.darkMode.on ? 'dark' : 'light'">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- Play around. -->
-    <div x-data>
-        <button @click="$store.open.on = !$store.open.on">Toggle</button>
+        <title>Alpine Example</title>
 
-        <div x-show="$store.open.on">
-            Content...
+        <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+
+        <style>
+            input:checked ~ .dot {
+                transform: translateX(100%);
+                background-color: #1ED1A8;
+            }
+        </style>
+
+        <script src="./packages/intersect/dist/cdn.js" defer></script>
+        <script src="./packages/morph/dist/cdn.js" defer></script>
+        <script src="./packages/history/dist/cdn.js"></script>
+        <script src="./packages/persist/dist/cdn.js"></script>
+        <script src="./packages/trap/dist/cdn.js"></script>
+        <script src="./packages/collapse/dist/cdn.js"></script>
+        <script src="./packages/alpinejs/dist/cdn.js" defer></script>
+
+    </head>
+    <body>
+        <div class="font-sans text-gray-800 dark:text-gray-100 bg-gray-200 dark:bg-gray-800 h-screen">
+            <div class="flex flex-col justify-center items-center h-screen" x-data="" x-init="console.log($store)">
+                <div>
+                    <h1 x-text="$store.darkMode.on ? 'Night time' : 'Day time'" class="text-6xl mb-16 font-thin"></h1>
+                </div>
+
+                <label for="wifi" class="flex flex-col items-center cursor-pointer mb-16" x-data="{ toggle: $persist(true).as('wifi') }">
+                    <div class="mb-3 font-light text-lg">
+                        WiFi: <span x-text="toggle ? 'ON' : 'OFF'"></span>
+                    </div>
+                    <div class="relative">
+                        <input type="checkbox"
+                            id="wifi"
+                            class="sr-only"
+                            x-model="toggle"
+                        >
+                        <div class="block border border-gray-800 dark:border-gray-200 w-16 h-9 rounded-full"></div>
+                        <div class="dot absolute left-1 top-1 bg-white w-7 h-7 rounded-full transition"></div>
+                    </div>
+                </label>
+
+                <label for="bluetooth" class="flex flex-col items-center cursor-pointer mb-16" x-data="{ toggle: $persist(true).as('bt') }">
+                    <div class="mb-3 font-light text-lg">
+                        Bluetooth: <span x-text="toggle ? 'ON' : 'OFF'"></span>
+                    </div>
+                    <div class="relative">
+                        <input type="checkbox"
+                            id="bluetooth"
+                            class="sr-only"
+                            x-model="toggle"
+                        >
+                        <div class="block border border-gray-800 dark:border-gray-200 w-16 h-9 rounded-full"></div>
+                        <div class="dot absolute left-1 top-1 bg-white w-7 h-7 rounded-full transition"></div>
+                    </div>
+                </label>
+
+                <label for="dark-mode" class="flex flex-col items-center cursor-pointer mb-16">
+                    <div class="mb-3 font-light text-lg">
+                        Dark mode: <span x-text="$store.darkMode.on ? 'ON' : 'OFF'"></span>
+                    </div>
+                    <div class="relative">
+                        <input type="checkbox"
+                            id="dark-mode"
+                            class="sr-only"
+                            x-model="$store.darkMode.on"
+                        >
+                        <div class="block border border-gray-800 dark:border-gray-200 w-16 h-9 rounded-full"></div>
+                        <div class="dot absolute left-1 top-1 bg-white w-7 h-7 rounded-full transition"></div>
+                    </div>
+                </label>
+
+                <label for="location" class="flex flex-col items-center cursor-pointer mb-16">
+                    <div class="mb-3 font-light text-lg">
+                        Location Services. <span x-text="$store.locationServices.on ? 'ON' : 'OFF'"></span>
+                    </div>
+                    <div class="relative">
+                        <input type="checkbox"
+                            id="location"
+                            class="sr-only"
+                            x-model="$store.locationServices.on"
+                        >
+                        <div class="block border border-gray-800 dark:border-gray-200 w-16 h-9 rounded-full"></div>
+                        <div class="dot absolute left-1 top-1 bg-white w-7 h-7 rounded-full transition"></div>
+                    </div>
+                </label>
+
+                <div class="text-center">
+                    <p>Persist counter example ...</p>
+                    <div x-data="{ count: $persist(0) }">
+                        <button x-on:click="count++" class="underline">Click me !!</button>
+                        <span x-text="count"></span>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
 
-    <script>
-        document.addEventListener('alpine:init', () => {
-            Alpine.store('open', {
-                on: Alpine.$persist(false),
-            })
-        })
-    </script>
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.store('darkMode', {
+                    on: Alpine.$persist(true).as('darkmode')
+                });
+
+                Alpine.store('locationServices', {
+                    on: Alpine.$persist(true).as('location')
+                });
+            });
+        </script>
+
+    </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,15 +4,24 @@
     <script src="./packages/history/dist/cdn.js"></script>
     <script src="./packages/persist/dist/cdn.js"></script>
     <script src="./packages/trap/dist/cdn.js"></script>
+    <script src="./packages/collapse/dist/cdn.js"></script>
     <script src="./packages/alpinejs/dist/cdn.js" defer></script>
     <!-- <script src="https://unpkg.com/alpinejs@3.0.0/dist/cdn.min.js" defer></script> -->
 
     <!-- Play around. -->
-    <div x-data="{ open: false }">
-        <button @click="open = !open">Toggle</button>
+    <div x-data>
+        <button @click="$store.open.on = !$store.open.on">Toggle</button>
 
-        <span x-show="open">
+        <div x-show="$store.open.on">
             Content...
-        </span>
+        </div>
     </div>
+
+    <script>
+        document.addEventListener('alpine:init', () => {
+            Alpine.store('open', {
+                on: Alpine.$persist(false),
+            })
+        })
+    </script>
 </html>

--- a/packages/alpinejs/src/store.js
+++ b/packages/alpinejs/src/store.js
@@ -1,3 +1,4 @@
+import { initInterceptors } from "./interceptor";
 import { reactive } from "./reactivity"
 
 let stores = {}
@@ -15,6 +16,8 @@ export function store(name, value) {
     if (typeof value === 'object' && value !== null && value.hasOwnProperty('init') && typeof value.init === 'function') {
         stores[name].init()
     }
+
+    initInterceptors(stores[name])
 }
 
 export function getStores() { return stores }

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -1,7 +1,8 @@
 
 
 export default function (Alpine) {
-    let thing = () => {
+
+    let persist = () => {
         let alias
         let storage = localStorage
 
@@ -28,13 +29,8 @@ export default function (Alpine) {
             func.using = target => { storage = target; return func }
         })
     }
-
-    Object.defineProperty(Alpine, '$persist', {
-        get: thing,
-        enumerable: true,
-    })
-
-    Alpine.magic('$persist', thing)
+    Alpine.$persist = persist()
+    Alpine.magic('persist', persist)
 }
 
 function storageHas(key, storage) {

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -1,10 +1,11 @@
 
+
 export default function (Alpine) {
-    Alpine.magic('persist', (el, { interceptor }) => {
+    let thing = () => {
         let alias
         let storage = localStorage
 
-        return interceptor((initialValue, getter, setter, path, key) => {
+        return Alpine.interceptor((initialValue, getter, setter, path, key) => {
             let lookup = alias || `_x_${path}`
 
             let initial = storageHas(lookup, storage)
@@ -26,7 +27,14 @@ export default function (Alpine) {
             func.as = key => { alias = key; return func },
             func.using = target => { storage = target; return func }
         })
+    }
+
+    Object.defineProperty(Alpine, '$persist', {
+        get: thing,
+        enumerable: true,
     })
+
+    Alpine.magic('$persist', thing)
 }
 
 function storageHas(key, storage) {

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -181,6 +181,9 @@ test('can persist to custom storage',
         reload()
         get('span').should(haveText('bar'))
         window().its('sessionStorage._x_message').should(beEqualTo(JSON.stringify('bar')))
+        window().then((win) => {
+            win.sessionStorage.clear()
+        });
     },
 )
 
@@ -197,5 +200,29 @@ test('can persist to custom storage using an alias',
         get('input').clear().type('bar')
         get('span').should(haveText('bar'))
         window().its('sessionStorage.mymessage').should(beEqualTo(JSON.stringify('bar')))
+        window().then((win) => {
+            win.sessionStorage.clear()
+        });
+    },
+)
+
+test('can persist using global Alpine.$persist within Alpine.store',
+    [html`
+        <div x-data>
+            <input x-model="$store.name.firstName">
+
+            <span x-text="$store.name.firstName"></span>
+        </div>
+    `, `
+        Alpine.store('name', {
+            firstName: Alpine.$persist('Daniel').as('dev-name')
+        })
+    `],
+    ({ get, window }, reload) => {
+        get('span').should(haveText('Daniel'))
+        get('input').clear().type('Malcolm')
+        get('span').should(haveText('Malcolm'))
+        reload()
+        get('span').should(haveText('Malcolm'))
     },
 )


### PR DESCRIPTION
Until now it has been impossible to persist values in an `Alpine.store`

This PR extracts the `$persist` magic to a globally accessible `Alpine.$persist` to enable use cases such as:

```javascript
Alpine.store('darkMode', {
    on: Alpine.$persist(true)
})
```

We've included a test, as well as an index.html that makes it easy to play with the feature. Feel free to remove the index.html before merge. :)

@danielcoulbourne says hi.