### PR TITLE
x-collapse not working properly when used with click.away

### DIFF
--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -15,3 +15,18 @@ test('can collapse and expand element',
         get('h1').should(haveComputedStyle('height', '0px'))
     },
 )
+
+test('@click.away with x-collapse (prevent race condition)',
+    html`
+        <div x-data="{ show: false }">
+            <button @click="show = true">Show</button>
+
+            <h1 x-show="show" @click.away="show = false" x-collapse>h1</h1>
+        </div>
+    `,
+    ({ get }) => {
+        get('h1').should(haveComputedStyle('height', '0px'))
+        get('button').click()
+        get('h1').should(haveAttribute('style', 'overflow: hidden; height: auto;'))
+    }
+)


### PR DESCRIPTION
Note, this change is could be considered as a mild BC. 

Before this PR an element was considered as 'not visible' if both the outer width and outer height were 0. This was working okay with a standard x-show but with x-collapse, only the height is 0.

With this PR, an element is considered as "not visible" even if only one of the 2 is 0. From a human point of view, this makes sense because an element with height = 0 is not really visible. Despite being a behavioural change, I don't think anyone was expecting click away to trigger in this scenario so it won't probably break anything to anyone.