### PR TITLE
x-collapse: only set overflow:hidden when strictly needed

### DIFF
--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -27,34 +27,36 @@ export default function (Alpine) {
                 let current = el.getBoundingClientRect().height
 
                 Alpine.setStyles(el, {
-                    height: 'auto'
+                    height: 'auto',
                 })
 
                 let full = el.getBoundingClientRect().height
 
+                Alpine.setStyles(el, {
+                    overflow: null
+                })
+
                 if (current === full) { current = floor }
-                
+
                 Alpine.transition(el, Alpine.setStyles, {
                     during: transitionStyles,
                     start: { height: current+'px' },
                     end: { height: full+'px' },
-                }, () => {
-                    el._x_isShown = true
-                    el.removeProperty('overflow')
-                }, () => {})
+                }, () => el._x_isShown = true, () => {})
             },
-    
+
             out(before = () => {}, after = () => {}) {
+                Alpine.setStyles(el, {
+                    overflow: 'hidden'
+                })
+
                 let full = el.getBoundingClientRect().height
 
                 Alpine.transition(el, setFunction, {
                     during: transitionStyles,
                     start: { height: full+'px' },
                     end: { height: floor+'px' },
-                }, () => {}, () => {
-                    el._x_isShown = false
-                    el.style.overflow = 'hidden'
-                })
+                }, () => {}, () => el._x_isShown = false)
             },
         }
     })

--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -3,9 +3,9 @@ export default function (Alpine) {
         let duration = modifierValue(modifiers, 'duration', 250) / 1000
         let floor = 0
 
-        el.style.overflow = 'hidden'
         if (! el._x_isShown) el.style.height = `${floor}px`
         if (! el._x_isShown) el.style.removeProperty('display')
+        if (! el._x_isShown) el.style.overflow = 'hidden'
 
         // Override the setStyles function with one that won't
         // revert updates to the height style.
@@ -38,7 +38,10 @@ export default function (Alpine) {
                     during: transitionStyles,
                     start: { height: current+'px' },
                     end: { height: full+'px' },
-                }, () => el._x_isShown = true, () => {})
+                }, () => {
+                    el._x_isShown = true
+                    el.removeProperty('overflow')
+                }, () => {})
             },
     
             out(before = () => {}, after = () => {}) {
@@ -48,7 +51,10 @@ export default function (Alpine) {
                     during: transitionStyles,
                     start: { height: full+'px' },
                     end: { height: floor+'px' },
-                }, () => {}, () => el._x_isShown = false)
+                }, () => {}, () => {
+                    el._x_isShown = false
+                    el.style.overflow = 'hidden'
+                })
             },
         }
     })

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -44,6 +44,6 @@ test('@click.away with x-collapse and borders (prevent race condition)',
     ({ get }) => {
         get('h1').should(haveComputedStyle('height', '0px'))
         get('button').click()
-        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
+        get('h1').should(haveAttribute('style', 'height: auto;'))
     }
 )

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -28,7 +28,7 @@ test('@click.away with x-collapse (prevent race condition)',
     ({ get }) => {
         get('h1').should(haveComputedStyle('height', '0px'))
         get('button').click()
-        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
+        get('h1').should(haveAttribute('style', 'height: auto;'))
     }
 )
 

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -28,7 +28,7 @@ test('@click.away with x-collapse (prevent race condition)',
     ({ get }) => {
         get('h1').should(haveComputedStyle('height', '0px'))
         get('button').click()
-        get('h1').should(haveAttribute('style', 'overflow: hidden; height: auto;'))
+        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
     }
 )
 
@@ -44,6 +44,6 @@ test('@click.away with x-collapse and borders (prevent race condition)',
     ({ get }) => {
         get('h1').should(haveComputedStyle('height', '0px'))
         get('button').click()
-        get('h1').should(haveAttribute('style', 'overflow: hidden; height: auto;'))
+        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
     }
 )

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -9,8 +9,9 @@ test('can collapse and expand element',
     `],
     ({ get }, reload) => {
         get('h1').should(haveComputedStyle('height', '0px'))
+        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
         get('button').click()
-        get('h1').should(haveAttribute('style', 'overflow: hidden; height: auto;'))
+        get('h1').should(haveAttribute('style', 'height: auto;'))
         get('button').click()
         get('h1').should(haveComputedStyle('height', '0px'))
     },

--- a/tests/cypress/manual-transition-test.html
+++ b/tests/cypress/manual-transition-test.html
@@ -1,4 +1,5 @@
 <html>
+    <script src="/../../packages/collapse/dist/cdn.js" defer></script>
     <script src="/../../packages/alpinejs/dist/cdn.js" defer></script>
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
 
@@ -8,9 +9,9 @@
             <td>
                 <div x-data="{ show: false }">
                     <button @click="show = true">Show</button>
-                  
+
                     <h1 x-show="show" @click.away="show = false">h1</h1>
-                  
+
                     <h2>h2</h2>
                   </div>
                 </div>
@@ -150,6 +151,20 @@
                         <div x-show="open" x-transition:enter.delay.100ms x-transition:leave.delay.100ms>Hello 👋</div>
                         <div x-show="open" x-transition:enter.delay.250ms x-transition:leave.delay.0ms>Hello 👋</div>
                     </div>
+                </div>
+            </td>
+        </tr>
+
+        <tr>
+            <td><code>x-collapse with no overflow hidden when expanded</code></td>
+            <td>
+                <div x-data="{ show: false }">
+                    <button @click="show = !show">Show</button>
+
+                    <div x-show="show" x-collapse>
+                        <div class="ring-2 ring-offset-2 ring-red-400">my red ring should be fully visible</div>
+                    </div>
+                  </div>
                 </div>
             </td>
         </tr>


### PR DESCRIPTION
Currently, `x-collapse` will always set `overflow: hidden` to the element. This can give unwanted side effects.

This PR addresses possible issues by only setting `overflow: hidden` when it's strictly needed and defaulting to default value otherwise.

I tried to add a full integration test (check overflow:hidden, click button, see it's still there during transition, wait for transition to complete, check it's now gone) but I couldn't get that to work. Someone with more experience in Cypress might be willing to lend a hand here?

Fixes #2207 
Fixes #2208