### PR TITLE
[Docs] Fix Anchor Links

### DIFF
--- a/packages/docs/src/en/directives/transition.md
+++ b/packages/docs/src/en/directives/transition.md
@@ -9,8 +9,8 @@ Alpine provides a robust transitions utility out of the box. With a few `x-trans
 
 There are two primary ways to handle transitions in Alpine:
 
-* [The Transition Helper]()
-* [Applying CSS Classes]()
+* [The Transition Helper](#the-transition-helper)
+* [Applying CSS Classes](#applying-css-classes)
 
 <a name="the-transition-helper"></a>
 ## The transition helper


### PR DESCRIPTION
It looks like the links on the `packages/docs/src/en/directives/transition.md` wanted to be linked to an anchor tag, but it didn't exists. ﻿
