### PR TITLE
Add $cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Here's a brief look at each package in this repo:
 Package | Description
 --- | ---
 [alpinejs](packages/alpinejs) | The main Alpine repo with all of Alpine's core
+[cookie](packages/cookie) | Manage browser Cookies across page loads
 [csp](packages/csp) | A repo to provide a "CSP safe" build of Alpine
 [history](packages/history) | A plugin for binding data to query string parameters using the history API (name is likely to change)
 [intersect](packages/intersect) | A plugin for triggering JS expressions based on elements intersecting with the viewport

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "alpine",
             "workspaces": [
                 "packages/*"
             ],
@@ -17,6 +18,14 @@
                 "esbuild": "^0.8.39",
                 "jest": "^26.6.3"
             }
+        },
+        "node_modules/@alpinejs/collapse": {
+            "resolved": "packages/collapse",
+            "link": true
+        },
+        "node_modules/@alpinejs/cookie": {
+            "resolved": "packages/cookie",
+            "link": true
         },
         "node_modules/@alpinejs/csp": {
             "resolved": "packages/csp",
@@ -1288,9 +1297,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -1474,12 +1483,12 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.10.0"
+                "follow-redirects": "^1.14.0"
             }
         },
         "node_modules/babel-jest": {
@@ -7160,9 +7169,9 @@
             }
         },
         "node_modules/tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
         "node_modules/to-fast-properties": {
@@ -7794,11 +7803,21 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.3.3",
+            "version": "3.4.2",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "^3.0.2"
+                "@vue/reactivity": "~3.1.1"
             }
+        },
+        "packages/collapse": {
+            "name": "@alpinejs/collapse",
+            "version": "3.4.2",
+            "license": "MIT"
+        },
+        "packages/cookie": {
+            "name": "@alpinejs/cookie",
+            "version": "3.4.2",
+            "license": "MIT"
         },
         "packages/csp": {
             "name": "@alpinejs/csp",
@@ -7810,7 +7829,7 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.3.3-revision.1",
+            "version": "3.4.2-revision.2",
             "license": "MIT"
         },
         "packages/history": {
@@ -7823,7 +7842,7 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.3.3",
+            "version": "3.4.2",
             "license": "MIT"
         },
         "packages/morph": {
@@ -7836,12 +7855,12 @@
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.3.3",
+            "version": "3.4.2",
             "license": "MIT"
         },
         "packages/trap": {
             "name": "@alpinejs/trap",
-            "version": "3.3.3",
+            "version": "3.4.2",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.6.1"
@@ -7849,6 +7868,12 @@
         }
     },
     "dependencies": {
+        "@alpinejs/collapse": {
+            "version": "file:packages/collapse"
+        },
+        "@alpinejs/cookie": {
+            "version": "file:packages/cookie"
+        },
         "@alpinejs/csp": {
             "version": "file:packages/csp",
             "requires": {
@@ -8876,7 +8901,7 @@
         "alpinejs": {
             "version": "file:packages/alpinejs",
             "requires": {
-                "@vue/reactivity": "^3.0.2"
+                "@vue/reactivity": "~3.1.1"
             }
         },
         "ansi-escapes": {
@@ -8889,9 +8914,9 @@
             }
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
         "ansi-styles": {
@@ -9016,12 +9041,12 @@
             "dev": true
         },
         "axios": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.10.0"
+                "follow-redirects": "^1.14.0"
             }
         },
         "babel-jest": {
@@ -13491,9 +13516,9 @@
             }
         },
         "tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+            "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
         "to-fast-properties": {

--- a/packages/cookie/builds/cdn.js
+++ b/packages/cookie/builds/cdn.js
@@ -1,0 +1,5 @@
+import cookie from '../src/index.js'
+
+document.addEventListener('alpine:init', () => {
+    window.Alpine.plugin(cookie)
+})

--- a/packages/cookie/builds/module.js
+++ b/packages/cookie/builds/module.js
@@ -1,0 +1,3 @@
+import cookie from '../src/index.js'
+
+export default cookie

--- a/packages/cookie/package.json
+++ b/packages/cookie/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "@alpinejs/persist",
+    "version": "3.4.2",
+    "description": "Manage browser Cookies across page loads",
+    "author": "Caneco",
+    "license": "MIT",
+    "main": "dist/module.cjs.js",
+    "module": "dist/module.esm.js",
+    "unpkg": "dist/cdn.min.js",
+    "dependencies": {}
+}

--- a/packages/cookie/package.json
+++ b/packages/cookie/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@alpinejs/persist",
+    "name": "@alpinejs/cookie",
     "version": "3.4.2",
     "description": "Manage browser Cookies across page loads",
     "author": "Caneco",

--- a/packages/cookie/src/index.js
+++ b/packages/cookie/src/index.js
@@ -1,0 +1,87 @@
+
+export default function (Alpine) {
+    Alpine.magic('cookie', (el, { interceptor }) => {
+        let alias
+        let attributes
+
+        return interceptor((initialValue, getter, setter, path, key) => {
+            let lookup = alias || `_x_${path}`
+
+            let initial = cookieGet(lookup) || initialValue
+
+            setter(initial)
+
+            Alpine.effect(() => {
+                let value = getter()
+
+                if (value === null) cookiePop(lookup, attributes)
+                if (value) cookieSet(lookup, value, attributes)
+
+                setter(value)
+            })
+
+            return initial
+        }, func => {
+            func.as = key => { alias = key; return func },
+            func.using = options => { attributes = options; return func }
+        })
+    })
+}
+
+function cookieSet(key, value, attributes) {
+
+    function cookieWrap (value) {
+        return encodeURIComponent(value).replace(/%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])/g, decodeURIComponent)
+    }
+
+    attributes = Object.assign({}, attributes)
+
+    if (typeof attributes.expires === 'number') {
+        attributes.expires = new Date(Date.now() + attributes.expires * 864e5)
+    }
+    if (Object.prototype.toString.call(attributes.expires) === '[object Date]') {
+        attributes.expires = attributes.expires.toUTCString()
+    }
+
+    key = encodeURIComponent(key)
+        .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
+        .replace(/[()]/g, escape)
+
+    let stringifiedAttributes = ''
+    for (let u in attributes) {
+        if (!attributes[u]) continue
+        stringifiedAttributes += `; ${u}`
+        if (attributes[u] === true) continue
+        stringifiedAttributes += `=${attributes[u].split(';')[0]}`
+    }
+
+    return document.cookie = `${key}=${cookieWrap(value, key)}${stringifiedAttributes}`
+}
+
+function cookieGet(key) {
+    if (arguments.length && !key) return
+
+    function cookieUnwrap(value) {
+        if (value[0] === '"') value = value.slice(1,-1)
+        return value.replace(/(%[\dA-F]{2})+/gi, decodeURIComponent)
+    }
+
+    let cookies = document.cookie ? document.cookie.split('; ') : []
+    let cookieJar = {}
+
+    for (var i = 0; i < cookies.length; i++) {
+        var parts = cookies[i].split('=')
+        var value = parts.slice(1).join('=')
+        try {
+            var found = decodeURIComponent(parts[0])
+            cookieJar[found] = cookieUnwrap(value, found)
+            if (key === found) break
+        } catch (e) {}
+    }
+
+    return key ? cookieJar[key] : null
+}
+
+function cookiePop(key, attributes) {
+    cookieSet(key, '', Object.assign({}, attributes, { expires: -1 }))
+}

--- a/packages/docs/src/en/plugins/cookie.md
+++ b/packages/docs/src/en/plugins/cookie.md
@@ -1,0 +1,188 @@
+---
+order: 5
+title: Cookie
+description: Easily manage browser Cookies across page loads
+---
+
+# Cookies Plugin
+
+Alpine's Cookies plugin allows you handling cookies.
+
+This is useful for preventing showing banners based on the expiration time of your cookies.
+
+This codebase was based from a well known JavaScript library for handling cookies, the (`js-cookie`)[https://github.com/js-cookie/js-cookie].
+
+<a name="installation"></a>
+## Installation
+
+You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+
+### Via CDN
+
+You can include the CDN build of this plugin as a `<script>` tag, just make sure to include it BEFORE Alpine's core JS file.
+
+```alpine
+<!-- Alpine Plugins -->
+<script defer src="https://unpkg.com/@alpinejs/cookie@3.x.x/dist/cdn.min.js"></script>
+
+<!-- Alpine Core -->
+<script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+```
+
+### Via NPM
+
+You can install Cookie from NPM for use inside your bundle like so:
+
+```shell
+npm install @alpinejs/cookie
+```
+
+Then initialize it from your bundle:
+
+```js
+import Alpine from 'alpinejs'
+import cookie from '@alpinejs/cookie'
+
+Alpine.plugin(cookie)
+
+...
+```
+
+<a name="magic-cookie"></a>
+## $cookie
+
+The primary API for using this plugin is the magic `$cookie` method.
+
+You can wrap any value inside `x-data` with `$cookie` like below to persist its value across page loads:
+
+```alpine
+<div x-data="{ accepted: $cookie() }">
+    <dialog x-bind:open="accepted!='yes'">
+        <p>Please accept our Cookies!</p>
+        <button x-on:click="accepted='yes'">I Accept</button>
+    </dialog>
+</div>
+```
+
+<!-- START_VERBATIM -->
+<div class="demo">
+    <div x-data="{ accepted: $cookie() }">
+        <dialog x-bind:open="accepted!='yes'">
+            <p>Please accept our Cookies!</p>
+            <button x-on:click="accepted='yes'">I Accept</button>
+        </dialog>
+    </div>
+</div>
+<!-- END_VERBATIM -->
+
+In the above example Alpine will intercept any changes made to `accepted`, store them in your browser cookies, and persist them across page loads.
+
+<a name="how-it-works"></a>
+## How does it work?
+
+If a value is wrapped in `$cookie`, on initialization Alpine will register its own watcher for that value. Now everytime that value changes for any reason, Alpine will store the new value in your browser [cookies](https://support.mozilla.org/en-US/kb/cookies-information-websites-store-on-your-computer).
+
+Then when your page is reloaded, Alpine will check your browser Cookies (using the name of the property as the key) for a value. If it finds one, it will set the property value immediately.
+
+You can observe this behavior by opening your browser devtool's Storage > Cookies viewer:
+
+<a href="https://developer.chrome.com/docs/devtools/storage/cookies/"><img src="/img/cookie_devtools.png" alt="Chrome devtools showing the Cookies accepted property set as 'yes'"></a>
+
+You'll observe that by simply visiting this page, Alpine already set the value of "accepted" in the Cookie list. You'll also notice it prefixes the property name "accepted" with "_x_" as a way of namespacing these values so Alpine doesn't conflict with other tools using the Cookies from your browser.
+
+Now change the "accepted" in the following example and observe the changes made by Alpine to localStorage:
+
+```alpine
+<div x-data="{ accepted: $cookie() }">
+    <button x-on:click="accepted='yes'">Accept Cookies</button>
+
+    <span x-text="accepted"></span>
+</div>
+```
+
+<!-- START_VERBATIM -->
+<div class="demo">
+    <div x-data="{ accepted: $cookie() }">
+        <button x-on:click="accepted='yes'">Accept Cookies</button>
+        <span x-text="accepted"></span>
+    </div>
+</div>
+<!-- END_VERBATIM -->
+
+> `$cookie` works with only plain string values.
+
+<a name="custom-key"></a>
+## Setting a custom key
+
+By default, Alpine uses the property key that `$cookie(...)` is being assigned to ("accepted" in the above examples).
+
+Consider the scenario where you have multiple Alpine components across pages or even on the same page that all use "accepted" as the property key.
+
+Alpine will have no way of differentiating between these components.
+
+In these cases, you can set your own custom key for any persisted value using the `.as` modifier like so:
+
+```alpine
+<div x-data="{ accepted: $cookie().as('accepted-terms') }">
+    <button x-on:click="accepted='yes'">Accept Terms</button>
+
+    <span x-text="accepted"></span>
+</div>
+```
+
+Now Alpine will store and retrieve the above "accepted" value using the key "accepted-terms".
+
+Here's a view of Chrome Devtools to see for yourself:
+
+<img src="/img/cookie_custom_key_devtools.png" alt="Chrome devtools showing the accepted cookie set as 'yes'">
+
+<a name="cookie-with-expiration"></a>
+## Setting an expiration date
+
+You can define that a cookie across the entire site, that will expire in 7 days, by using the `.using` modifier and pass an object with the `expires` key – like so:
+
+```alpine
+<div x-data="{ accepted: $cookie().using({ expires: 7 }) }">
+    <button x-on:click="accepted='yes'">Accept for 7 days</button>
+
+    <span x-text="accepted"></span>
+</div>
+```
+
+If you want to define an expiring or not cookie, valid to the path of the current page, by passing an object with the `path` key – like so:
+
+```alpine
+<div x-data="{ accepted: $cookie().using({ expires: 7, path: '' }) }">
+    <button x-on:click="accepted='yes'">Accept for 7 days</button>
+
+    <span x-text="accepted"></span>
+</div>
+```
+
+<a name="remove-a-cookie"></a>
+## Removing a cookie
+
+If you need to remove a cookie just defined it as `null` – like so:
+
+```alpine
+<div x-data="{ accepted: $cookie() }">
+    <button x-on:click="accepted='yes'">Accept Cookies</button>
+
+    <span x-text="accepted"></span>
+
+    <button x-on:click="accepted=null">Refuse Cookies</button>
+</div>
+```
+
+<a name="using-cookie-with-alpine-data"></a>
+## Using $cookie with Alpine.data
+
+If you want to use `$cookie` with `Alpine.data`, you need to use a standard function instead of an arrow function so Alpine can bind a custom `this` context when it initially evaluates the component scope.
+
+```js
+Alpine.data('dropdown', function () {
+    return {
+        open: this.$cookie(false)
+    }
+})
+```

--- a/tests/cypress/integration/plugins/cookie.spec.js
+++ b/tests/cypress/integration/plugins/cookie.spec.js
@@ -1,0 +1,18 @@
+import { beEqualTo, beVisible, haveText, html, notBeVisible, test } from '../../utils'
+
+test('can accept cookie',
+    [html`
+        <div x-data="{ accepted: $cookie() }">
+            <button x-on:click="accepted='yes'">Accept Cookies</button>
+            <span x-text="accepted"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText(''))
+        get('button').click()
+        get('span').should(haveText('yes'))
+        reload()
+        get('span').should(haveText('yes'))
+    },
+)
+

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -58,6 +58,8 @@ function injectHtmlAndBootAlpine(cy, templateAndPotentiallyScripts, callback, pa
 
         el.evalScripts(scripts)
 
+        console.info(scripts)
+
         cy.get('[alpine-is-ready]', { timeout: 5000 }).should('be.visible');
 
         // We can't just simply reload a page from a test, because we need to


### PR DESCRIPTION
Here's my suggestion of a `$cookie` plugin using some Alpine magic ✨

I know that we could change the `$persist` storage to handle cookies… but I think this it's more direct way.

The codebase it's heavily inspired from the best practices in [js-cookie](https://github.com/js-cookie/js-cookie), and with that it allows the user to set expiration, paths and domains for the cookies.

Let me know what _**y'all**_ think…