### PR TITLE
[Docs] Fix inert example in x-trap

### DIFF
--- a/packages/docs/src/en/plugins/trap.md
+++ b/packages/docs/src/en/plugins/trap.md
@@ -192,7 +192,7 @@ By adding `.inert` to `x-trap`, when focus is trapped, all other elements on the
 ```alpine
 <!-- When `open` is `false`: -->
 <body>
-    <div x-trap="open" ...>
+    <div x-trap.inert="open" ...>
         ...
     </div>
 
@@ -203,7 +203,7 @@ By adding `.inert` to `x-trap`, when focus is trapped, all other elements on the
 
 <!-- When `open` is `true`: -->
 <body>
-    <div x-trap="open" ...>
+    <div x-trap.inert="open" ...>
         ...
     </div>
 

--- a/packages/docs/src/en/plugins/trap.md
+++ b/packages/docs/src/en/plugins/trap.md
@@ -191,7 +191,7 @@ By adding `.inert` to `x-trap`, when focus is trapped, all other elements on the
 
 ```alpine
 <!-- When `open` is `false`: -->
-<body>
+<body x-data="{ open: false }">
     <div x-trap.inert="open" ...>
         ...
     </div>
@@ -202,7 +202,7 @@ By adding `.inert` to `x-trap`, when focus is trapped, all other elements on the
 </body>
 
 <!-- When `open` is `true`: -->
-<body>
+<body x-data="{ open: true }">
     <div x-trap.inert="open" ...>
         ...
     </div>


### PR DESCRIPTION
In the example you forgot to add the `.inert` modifiers to `x-trap`.
I also added an `x-data` attribute to the body element. (This is just my opinion and I can also remove it.