### PR TITLE
Bug - Alias for global persist shared between different properties

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -27,7 +27,6 @@ export default function (Alpine) {
         })
     }
 
-    //Alpine.$persist = persist()
     Object.defineProperty(Alpine, '$persist', { get: () => persist() })
     Alpine.magic('persist', persist)
 }

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -27,7 +27,8 @@ export default function (Alpine) {
         })
     }
 
-    Alpine.$persist = persist()
+    //Alpine.$persist = persist()
+    Object.defineProperty(Alpine, '$persist', { get: () => persist() })
     Alpine.magic('persist', persist)
 }
 

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -226,3 +226,29 @@ test('can persist using global Alpine.$persist within Alpine.store',
         get('span').should(haveText('Malcolm'))
     },
 )
+
+test('multiple aliases work when using global Alpine.$persist',
+    [html`
+        <div x-data>
+            <input x-model="$store.name.firstName">
+
+            <span x-text="$store.name.firstName"></span>
+            <p x-text="$store.name.lastName"></p>
+        </div>
+    `, `
+        Alpine.store('name', {
+            firstName: Alpine.$persist('John').as('first-name'),
+            lastName: Alpine.$persist('Doe').as('name-name')
+        })
+    `],
+    ({ get, window }, reload) => {
+        get('span').should(haveText('John'))
+        get('p').should(haveText('Doe'))
+        get('input').clear().type('Joe')
+        get('span').should(haveText('Joe'))
+        get('p').should(haveText('Doe'))
+        reload()
+        get('span').should(haveText('Joe'))
+        get('p').should(haveText('Doe'))
+    },
+)


### PR DESCRIPTION
While the magic returns a new instance every time (so alias and storage are scoped in that function call), the global persis was just returning the same function scope once so each usage of Alpine.$persist was sharing alias and storage.
See https://github.com/alpinejs/alpine/discussions/2317 where only the last value was persisted.

This PR changes the global property to a getter so we can return a fresh function scope every time.
In the future, if there are more global helpers like this one, it might be worth having something like `Alpine.addGlobal('persist', persist)` to abstract the getter so it's easier for people to use it.

Tests are failing because they are broken in master (something wrong with x-trap) but the relevant one is
https://github.com/alpinejs/alpine/runs/4110072717?check_suite_focus=true#step:6:1071 (before fix)
vs 
https://github.com/alpinejs/alpine/runs/4110080921?check_suite_focus=true#step:6:1071

cc @MalcolmKnott @DanielCoulbourne