### PR TITLE
Fix x-trap test

### DIFF
--- a/tests/cypress/integration/plugins/trap.spec.js
+++ b/tests/cypress/integration/plugins/trap.spec.js
@@ -90,10 +90,13 @@ test('can trap focus with noscroll',
             <div style="height: 100vh">&nbsp;</div>
         </div>
     `],
-    ({ get }, reload) => {
-        get('#open').click()
-        get('html').should(haveAttribute('style', 'overflow: hidden; padding-right: 0px;'))
-        get('#close').click()
-        get('html').should(notHaveAttribute('style', 'overflow: hidden; padding-right: 0px;'))
+    ({ get, window }, reload) => {
+        window().then((win) => {
+            let scrollbarWidth = win.innerWidth - win.document.documentElement.clientWidth
+            get('#open').click()
+            get('html').should(haveAttribute('style', `overflow: hidden; padding-right: ${scrollbarWidth}px;`))
+            get('#close').click()
+            get('html').should(notHaveAttribute('style', `overflow: hidden; padding-right: ${scrollbarWidth}px;`))
+        })
     },
 )


### PR DESCRIPTION
The test is failing on master because it assumes that the scrollbar width is 0 but it's not the case if the test runs on a real browser.