### PR TITLE
Name lifecycle event sections after event name

### DIFF
--- a/packages/docs/src/en/essentials/lifecycle.md
+++ b/packages/docs/src/en/essentials/lifecycle.md
@@ -70,7 +70,7 @@ The two main behavioral differences with this approach are:
 ## Alpine initialization
 
 <a name="alpine-initializing"></a>
-### `Alpine.initializing`
+### `alpine:init`
 
 Ensuring a bit of code executes after Alpine is loaded, but BEFORE it initializes itself on the page is a necessary task.
 
@@ -85,7 +85,7 @@ document.addEventListener('alpine:init', () => {
 ```
 
 <a name="alpine-initialized"></a>
-### `Alpine.initialized`
+### `alpine:initialized`
 
 Alpine also offers a hook that you can use to execute code After it's done initializing called `alpine:initialized`:
 


### PR DESCRIPTION
I found it confusing that the lifecycle event sections were named `Alpine.event` instead of just being named after the event (`alpine:event`). This PR names the sections after the event they document instead.