### PR TITLE
Use the hidden attribute & `display:none` to hide x-collapse content from the accessibility tree

### DIFF
--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -25,6 +25,8 @@ export default function (Alpine) {
 
         el._x_transition = {
             in(before = () => {}, after = () => {}) {
+                el.hidden = false;
+
                 let current = el.getBoundingClientRect().height
 
                 Alpine.setStyles(el, {
@@ -44,7 +46,6 @@ export default function (Alpine) {
                     start: { height: current+'px' },
                     end: { height: full+'px' },
                 }, () => {
-                    el.hidden = false
                     el._x_isShown = true
                 }, () => {})
             },
@@ -61,12 +62,13 @@ export default function (Alpine) {
 
                     // check if element is fully collapsed
                     if (el.style.height == `${floor}px`) {
-                        Alpine.nextTick(() => Alpine.setStyles(el, {
-                            overflow: 'hidden'
-                        }))
+                        Alpine.nextTick(() => {
+                            Alpine.setStyles(el, {
+                                overflow: 'hidden'
+                            })
+                            el.hidden = true;
+                        })
                     }
-
-                    el.hidden = true
                 })
             },
         }

--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -52,9 +52,7 @@ export default function (Alpine) {
                     during: transitionStyles,
                     start: { height: current+'px' },
                     end: { height: full+'px' },
-                }, () => {
-                    el._x_isShown = true
-                }, () => {})
+                }, () => el._x_isShown = true, () => {})
             },
 
             out(before = () => {}, after = () => {}) {

--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -6,6 +6,7 @@ export default function (Alpine) {
         if (! el._x_isShown) el.style.height = `${floor}px`
         if (! el._x_isShown) el.style.removeProperty('display')
         if (! el._x_isShown) el.style.overflow = 'hidden'
+        if (! el._x_isShown) el.hidden = true
 
         // Override the setStyles function with one that won't
         // revert updates to the height style.
@@ -42,7 +43,10 @@ export default function (Alpine) {
                     during: transitionStyles,
                     start: { height: current+'px' },
                     end: { height: full+'px' },
-                }, () => el._x_isShown = true, () => {})
+                }, () => {
+                    el.hidden = false
+                    el._x_isShown = true
+                }, () => {})
             },
 
             out(before = () => {}, after = () => {}) {
@@ -61,6 +65,8 @@ export default function (Alpine) {
                             overflow: 'hidden'
                         }))
                     }
+
+                    el.hidden = true
                 })
             },
         }

--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -5,8 +5,14 @@ export default function (Alpine) {
 
         if (! el._x_isShown) el.style.height = `${floor}px`
         if (! el._x_isShown) el.style.removeProperty('display')
-        if (! el._x_isShown) el.style.overflow = 'hidden'
+        // We use the hidden attribute for the benefit of Tailwind
+        // users as the .space utility will ignore [hidden] elements.
         if (! el._x_isShown) el.hidden = true
+        // We use display:none as the hidden attribute has very low
+        // CSS specificity and could be accidentally overriden by a
+        // user.
+        if (! el._x_isShown) el.style.display = 'none'
+        if (! el._x_isShown) el.style.overflow = 'hidden'
 
         // Override the setStyles function with one that won't
         // revert updates to the height style.
@@ -30,6 +36,7 @@ export default function (Alpine) {
                 let current = el.getBoundingClientRect().height
 
                 Alpine.setStyles(el, {
+                    display: null,
                     height: 'auto',
                 })
 
@@ -64,6 +71,7 @@ export default function (Alpine) {
                     if (el.style.height == `${floor}px`) {
                         Alpine.nextTick(() => {
                             Alpine.setStyles(el, {
+                                display: 'none',
                                 overflow: 'hidden'
                             })
                             el.hidden = true;

--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -4,14 +4,12 @@ export default function (Alpine) {
         let floor = 0
 
         if (! el._x_isShown) el.style.height = `${floor}px`
-        if (! el._x_isShown) el.style.removeProperty('display')
         // We use the hidden attribute for the benefit of Tailwind
         // users as the .space utility will ignore [hidden] elements.
+        // We also use display:none as the hidden attribute has very
+        // low CSS specificity and could be accidentally overriden
+        // by a user.
         if (! el._x_isShown) el.hidden = true
-        // We use display:none as the hidden attribute has very low
-        // CSS specificity and could be accidentally overriden by a
-        // user.
-        if (! el._x_isShown) el.style.display = 'none'
         if (! el._x_isShown) el.style.overflow = 'hidden'
 
         // Override the setStyles function with one that won't

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -9,7 +9,7 @@ test('can collapse and expand element',
     `],
     ({ get }, reload) => {
         get('h1').should(haveComputedStyle('height', '0px'))
-        get('h1').should(haveAttribute('style', 'height: 0px; display: none; overflow: hidden;'))
+        get('h1').should(haveAttribute('style', 'display: none; height: 0px; overflow: hidden;'))
         get('h1').should(haveAttribute('hidden', 'hidden'))
         get('button').click()
         get('h1').should(haveAttribute('style', 'height: auto;'))

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -9,13 +9,14 @@ test('can collapse and expand element',
     `],
     ({ get }, reload) => {
         get('h1').should(haveComputedStyle('height', '0px'))
-        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
+        get('h1').should(haveAttribute('style', 'height: 0px; display: none; overflow: hidden;'))
         get('h1').should(haveAttribute('hidden', 'hidden'))
         get('button').click()
         get('h1').should(haveAttribute('style', 'height: auto;'))
         get('h1').should(notHaveAttribute('hidden'))
         get('button').click()
         get('h1').should(haveComputedStyle('height', '0px'))
+        get('h1').should(haveAttribute('style', 'height: 0px; display: none; overflow: hidden;'))
         get('h1').should(haveAttribute('hidden', 'hidden'))
     },
 )

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -1,4 +1,4 @@
-import { haveAttribute, haveComputedStyle, html, notHaveAttribute, notHaveFocus, test } from '../../utils'
+import { haveAttribute, haveComputedStyle, html, notHaveAttribute, test } from '../../utils'
 
 test('can collapse and expand element',
     [html`

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -4,7 +4,7 @@ test('can collapse and expand element',
     [html`
         <div x-data="{ expanded: false }">
             <button @click="expanded = ! expanded">toggle</button>
-            <h1 x-show="expanded" x-collapse>contents <a href="#">focusable content</a></a></h1>
+            <h1 x-show="expanded" x-collapse>contents <a href="#">focusable content</a></h1>
         </div>
     `],
     ({ get }, reload) => {

--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -1,19 +1,22 @@
-import { haveAttribute, haveComputedStyle, html, test } from '../../utils'
+import { haveAttribute, haveComputedStyle, html, notHaveAttribute, notHaveFocus, test } from '../../utils'
 
 test('can collapse and expand element',
     [html`
         <div x-data="{ expanded: false }">
             <button @click="expanded = ! expanded">toggle</button>
-            <h1 x-show="expanded" x-collapse>contents</h1>
+            <h1 x-show="expanded" x-collapse>contents <a href="#">focusable content</a></a></h1>
         </div>
     `],
     ({ get }, reload) => {
         get('h1').should(haveComputedStyle('height', '0px'))
         get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
+        get('h1').should(haveAttribute('hidden', 'hidden'))
         get('button').click()
         get('h1').should(haveAttribute('style', 'height: auto;'))
+        get('h1').should(notHaveAttribute('hidden'))
         get('button').click()
         get('h1').should(haveComputedStyle('height', '0px'))
+        get('h1').should(haveAttribute('hidden', 'hidden'))
     },
 )
 


### PR DESCRIPTION
Big fan of Alpine! Thanks for all the time that has been put into it :) 

I was checking out [x-collapse](https://alpinejs.dev/plugins/collapse) and noticed that visually collapsed content is not hidden/removed from the accessibility tree, so keyboard users can tab to focusable elements that should be hidden, and the content may be announced to screenreader users.

At the moment we just hide content with `overflow: hidden; height: 0px;` but this isn't enough to hide content from assistive tech.

One way to hide the content safely would be to add a `hidden` attribute after the transition has ended and the content has been collapsed (or add it on load), and remove the attribute before un-collapsing the content.

The `hidden` attribute approach is particularly nice as it will play nicely with Tailwind's https://tailwindcss.com/docs/space utility. The utility won't add space around content that has been hidden with `hidden`:

```css
.space-y-1>:not([hidden])~:not([hidden]) {
    --tw-space-y-reverse: 0;
    margin-top: calc(.25rem * calc(1 - var(--tw-space-y-reverse)));
    margin-bottom: calc(.25rem * var(--tw-space-y-reverse))
}
```

`hidden` is essentially the same as `style="display:none"` except by using the `hidden` attribute we get that extra compatibility with Tailwind's space utilities 👍 

The browser user-agent stylesheet manages the hiding for us via a rule like:

```css
[hidden] { display: none; }
``` 

A downside of that is that author CSS can very easily override the `[hidden]` rule by setting a `display` property on the element being collapsed/uncollapsed, but that can be worked around by the author adding something like:

```css
[hidden] { display: none !important; }
```

This PR uses the `hidden` attribute and updates the Cypress tests for `x-collapse` to test for the presence or lack of the attribute.