### PR TITLE
Accessibility: display none on fully collapsed

### DIFF
--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -58,7 +58,8 @@ export default function (Alpine) {
                     // check if element is fully collapsed
                     if (el.style.height == `${floor}px`) {
                         Alpine.nextTick(() => Alpine.setStyles(el, {
-                            overflow: 'hidden'
+                            overflow: 'hidden',
+                            display: 'none'
                         }))
                     }
                 })


### PR DESCRIPTION
If the element is fully collapsed, it can still be tabbed into, and a focus ring gets lost in the hidden element. Adding `display: none` again when the element is fully collapsed will enable tabbing, etc. to skip over collapsed elements.