### PR TITLE
Test for x-collapse double click bug

### DIFF
--- a/tests/cypress/integration/plugins/collapse.spec.js
+++ b/tests/cypress/integration/plugins/collapse.spec.js
@@ -32,7 +32,6 @@ test('@click.away with x-collapse (prevent race condition)',
     }
 )
 
-
 test('@click.away with x-collapse and borders (prevent race condition)',
     html`
         <div x-data="{ show: false }">
@@ -46,4 +45,26 @@ test('@click.away with x-collapse and borders (prevent race condition)',
         get('button').click()
         get('h1').should(haveAttribute('style', 'height: auto;'))
     }
+)
+
+// https://github.com/alpinejs/alpine/issues/2335
+test('double-click on x-collapse does not mix styles up',
+    [html`
+        <div x-data="{ expanded: false }">
+            <button @click="expanded = ! expanded">toggle</button>
+            <h1 x-show="expanded" x-collapse>contents</h1>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('h1').should(haveComputedStyle('height', '0px'))
+        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
+        get('button').click()
+        get('button').click()
+        get('h1').should(haveAttribute('style', 'height: 0px; overflow: hidden;'))
+        get('button').click()
+        get('h1').should(haveAttribute('style', 'height: auto;'))
+        get('button').click()
+        get('button').click()
+        get('h1').should(haveAttribute('style', 'height: auto;'))
+    },
 )


### PR DESCRIPTION
Just an additional test to prevent future regressions.
The bug was already addressed by #2339
Branched off 3.5.0 to confirm that the test was failing as expected (see https://github.com/SimoTod/alpine/runs/4198418042?check_suite_focus=true#step:6:927then) then merged 3.5.1 into this PR to confirm that the test passes.