### PR TITLE
Misc - Fix evaluatorMemo memory leak

### DIFF
--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -97,11 +97,18 @@ function generateEvaluatorFromString(dataStack, expression, el) {
             if (func.finished) {
                 // Return the immediate result.
                 runIfTypeOfFunction(receiver, func.result, completeScope, params, el)
+                // Once the function has run, we clear func.result so we don't create
+                // memory leaks. func is stored in the evaluatorMemo and every time
+                // it runs, it assigns the evaluated expression to result which could
+                // potentially store reference to DOM element that will be removed
+                // later on
+                func.result = undefined
             } else {
                 // If not, return the result when the promise resolves.
                 promise.then(result => {
                     runIfTypeOfFunction(receiver, result, completeScope, params, el)
                 }).catch( error => handleError( error, el, expression ) )
+                .finally( () => func.result = undefined )
             }
         }
     }

--- a/tests/cypress/manual-memory.html
+++ b/tests/cypress/manual-memory.html
@@ -24,5 +24,5 @@
                 </div>
             </td>
         </tr>
-
+    </table>
 </html>

--- a/tests/cypress/manual-memory.html
+++ b/tests/cypress/manual-memory.html
@@ -1,0 +1,28 @@
+<html>
+    <script src="/../../packages/alpinejs/dist/cdn.js" defer></script>
+    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+
+    <table class="w-dull">
+        <tr>
+            <td class="p-10 w-1/3"><code>MemoEvaluator cache</code></td>
+            <td class="p-10 w-1/3">
+                <p>
+                    In chrome, open dev tools > Memory tag, click on
+                    "Take heap snapshot". First of all, check that there are not existing leaks affecting the test results clicking on
+                    "Take heap snapshot": it should not found any results;
+                    if it does, you might want to run the test in incognito
+                    mode so it does not load any chrome extensions).
+                    Once verified, click the "test" button, go to the memory
+                    tab, click "Collect garbage" a couple of times, take another snapshot and verify we don't have any new
+                    detached node in memory.
+                </p>
+            </td>
+            <td class="p-10 w-1/3">
+                <div id="one" x-data="{ foo: 'bar' }">
+                    <span x-text="foo"></span>
+                    <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" @click="document.getElementById('one').remove()">Test</button>
+                </div>
+            </td>
+        </tr>
+
+</html>


### PR DESCRIPTION
Fixes #2126 

The issue is that generateEvaluatorFromString stores a reference to the latest operation into the cached entry after the function has run. This causes leaks when the element is removed from the DOM because the cached entries keep dangling reference to alpine scopes.

`func.result` is already set to `undefined` at each execution on this line https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/evaluator.js#L86 so setting it to `undefined` after the function has run won't change any existing behaviour. All tests are passing.

Since it's not testable in cypress, I've added a manual test for it. Feel free to checkout b2a19dcc0be9ccf8e42a9c9d908acd7bf7dea0be first to have a play.

There are other leaks to fix but I believe it's safer to just fix them one by one for each new release so we can capture bug reports from the community if there are any.

cc @bep 