### PR TITLE
Update morph documentation

### DIFF
--- a/packages/docs/src/en/plugins/morph.md
+++ b/packages/docs/src/en/plugins/morph.md
@@ -61,6 +61,7 @@ Then initialize it from your bundle:
 import Alpine from 'alpinejs'
 import morph from '@alpinejs/morph'
 
+window.Alpine = Alpine
 Alpine.plugin(morph)
 
 ...


### PR DESCRIPTION
The current implementation relies on Alpine being available on the window object.
Whilst that line was optional for other plugins, it's a required step for this specific one when using npm