### PR TITLE
Remove plugin reference from teleport doc

### DIFF
--- a/packages/docs/src/en/directives/teleport.md
+++ b/packages/docs/src/en/directives/teleport.md
@@ -7,7 +7,7 @@ graph_image: https://alpinejs.dev/social_teleport.jpg
 
 # Teleport Plugin
 
-Alpine's Teleport plugin allows you to transport part of your Alpine template to another part of the DOM on the page entirely.
+The `x-teleport` directive allows you to transport part of your Alpine template to another part of the DOM on the page entirely.
 
 This is useful for things like modals (especially nesting them), where it's helpful to break out of the z-index of the current Alpine component.
 


### PR DESCRIPTION
`x-teleport` was still called a plugin.