### PR TITLE
Remove single quote under Forwarding Events

### DIFF
--- a/packages/docs/src/en/directives/teleport.md
+++ b/packages/docs/src/en/directives/teleport.md
@@ -61,7 +61,7 @@ Notice how when toggling the modal, the actual modal contents show up AFTER the 
 <a name="forwarding-events"></a>
 ## Forwarding events
 
-Alpine tries it's best to make the experience of teleporting seamless. Anything you would normally do in a template, you should be able to do inside an `x-teleport` template. Teleported content can access the normal Alpine scope of the component as well as other features like `$refs`, `$root`, etc...
+Alpine tries its best to make the experience of teleporting seamless. Anything you would normally do in a template, you should be able to do inside an `x-teleport` template. Teleported content can access the normal Alpine scope of the component as well as other features like `$refs`, `$root`, etc...
 
 However, native DOM events have no concept of teleportation, so if, for example, you trigger a "click" event from inside a teleported element, that event will bubble up the DOM tree as it normally would.
 


### PR DESCRIPTION
Grammatical correction - its not it's