### PR TITLE
Firefox: Avoid warning "Unknown property 'null'. Skipped to next declaration."

### DIFF
--- a/packages/alpinejs/src/utils/styles.js
+++ b/packages/alpinejs/src/utils/styles.js
@@ -36,7 +36,7 @@ function setStylesFromString(el, value) {
     el.setAttribute('style', value)
 
     return () => {
-        el.setAttribute('style', cache)
+        el.setAttribute('style', cache || '')
     }
 }
 


### PR DESCRIPTION
```
<body x-data="{ tab: 'si' }">
  <nav>
    <ul>
      <li><a @click.prevent="tab = 'ai'" :style="tab == 'ai' ? 'text-decoration: underline;' : 'text-decoration: inherit;'" href="#">AI</a></li>
```
`
Unknown property 'null'. Skipped to next declaration.`