### PR TITLE
feature: `x-data.isolate` modifier

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -10,7 +10,7 @@ import { evaluate } from '../evaluator'
 
 addRootSelector(() => `[${prefix('data')}]`)
 
-directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
+directive('data', skipDuringClone((el, { expression, modifiers }, { cleanup }) => {
     expression = expression === '' ? '{}' : expression
 
     let magicContext = {}
@@ -29,7 +29,7 @@ directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
 
     initInterceptors(reactiveData)
 
-    let undo = addScopeToNode(el, reactiveData)
+    let undo = addScopeToNode(el, reactiveData, el, modifiers.includes('isolate'))
 
     reactiveData['init'] && evaluate(el, reactiveData['init'])
 

--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -29,7 +29,7 @@ directive('data', skipDuringClone((el, { expression, modifiers }, { cleanup }) =
 
     initInterceptors(reactiveData)
 
-    let undo = addScopeToNode(el, reactiveData, el, modifiers.includes('isolate'))
+    let undo = addScopeToNode(el, reactiveData, modifiers.includes('isolate') ? document : null)
 
     reactiveData['init'] && evaluate(el, reactiveData['init'])
 

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -3,8 +3,8 @@ export function scope(node) {
     return mergeProxies(closestDataStack(node))
 }
 
-export function addScopeToNode(node, data, referenceNode) {
-    node._x_dataStack = [data, ...closestDataStack(referenceNode || node)]
+export function addScopeToNode(node, data, referenceNode, isolate = false) {
+    node._x_dataStack = isolate ? [data] : [data, ...closestDataStack(referenceNode || node)]
 
     return () => {
         node._x_dataStack = node._x_dataStack.filter(i => i !== data)
@@ -60,7 +60,7 @@ export function mergeProxies(objects) {
                     if ((descriptor.get && descriptor.get._x_alreadyBound) || (descriptor.set && descriptor.set._x_alreadyBound)) {
                         return true
                     }
-                    
+
                     // Properly bind getters and setters to this wrapper Proxy.
                     if ((descriptor.get || descriptor.set) && descriptor.enumerable) {
                         // Only bind user-defined getters, not our magic properties.
@@ -81,7 +81,7 @@ export function mergeProxies(objects) {
                         })
                     }
 
-                    return true 
+                    return true
                 }
 
                 return false

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -3,8 +3,8 @@ export function scope(node) {
     return mergeProxies(closestDataStack(node))
 }
 
-export function addScopeToNode(node, data, referenceNode, isolate = false) {
-    node._x_dataStack = isolate ? [data] : [data, ...closestDataStack(referenceNode || node)]
+export function addScopeToNode(node, data, referenceNode) {
+    node._x_dataStack = [data, ...closestDataStack(referenceNode || node)]
 
     return () => {
         node._x_dataStack = node._x_dataStack.filter(i => i !== data)

--- a/tests/cypress/integration/directives/x-data.spec.js
+++ b/tests/cypress/integration/directives/x-data.spec.js
@@ -124,3 +124,18 @@ test('x-data getters have access to parent scope',
     `,
     ({ get }) => get('h1').should(haveText('bar'))
 )
+
+test('.isolate modifiers prevent parent scope from being used',
+    html`
+    <div x-data="{ foo: 'bar' }">
+        <div x-data.isolate="{
+            get bob() {
+                return this.foo ?? 'baz'
+            }
+        }">
+            <h1 x-text="bob"></h1>
+        </div>
+    </div>
+    `,
+    ({ get }) => get('h1').should(haveText('baz'))
+)


### PR DESCRIPTION
This pull request introduces a new `.isolate` modifier for the `x-data` directive. When present, it will prevent the root element's data-stack inheriting all parent components.

This came from a request in the Discord server and prior to the `x-teleport` directive being available, I would have liked something similar.

If this is something that is mergeable / wanted, I'll update the docs to include information about the modifier too. 