### PR TITLE
Prevent breaking when Alpine is transpiled to ES5 (fixes #2454)

### DIFF
--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -51,7 +51,8 @@ function generateFunctionFromString(expression, el) {
         return evaluatorMemo[expression]
     }
 
-    let AsyncFunction = Object.getPrototypeOf(async function(){}).constructor
+    // Use `eval` to protect AsyncFunction constructor from possible third-party ES5 transpilation
+    let AsyncFunction = Object.getPrototypeOf((0, eval)('(async function(){})')).constructor
 
     // Some expressions that are useful in Alpine are not valid as the right side of an expression.
     // Here we'll detect if the expression isn't valid for an assignement and wrap it in a self-

--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -51,8 +51,11 @@ function generateFunctionFromString(expression, el) {
         return evaluatorMemo[expression]
     }
 
-    // Use `eval` to protect AsyncFunction constructor from possible third-party ES5 transpilation
-    let AsyncFunction = Object.getPrototypeOf((0, eval)('(async function(){})')).constructor
+    // Use `new Function` to protect AsyncFunction constructor from deconstruction
+    // through possible third-party ES5 transpilation
+    let AsyncFunction = Object.getPrototypeOf(
+        new Function('return async function() {}')()
+    ).constructor
 
     // Some expressions that are useful in Alpine are not valid as the right side of an expression.
     // Here we'll detect if the expression isn't valid for an assignement and wrap it in a self-


### PR DESCRIPTION
This PR prevents the Alpine attribute evaluator from breaking when it's transpiled to ES5 by a third party bundler. The main problem in this scenario is that the `AsyncFunction` constructor can not properly be retreived. (More on this in #2454.)

I hoped to be able to fix #2454 by just wrapping the generated function's call in a Promise layer. However, it turns out that the Babel-transpiled `AsyncFunction` leads to all kinds of scope-related problems and seems to not be (easily) fixable.

The consequence I draw from this is that we should avoid using a possibly transpiled `AsyncFunction` at all.

I see two ways to achieve this:

1. Prevent the `async function() {}` that retreives the `AsyncFunction` constructor from being transpiled in the first place, via `eval`.
2. Check the `AsyncFunction` constructor name after retreiving it. If it's `"Function"`, we are in an ES5-transpiled environment and should use the regular `Function` constructor as a fallback.

Each of these approaches has its own unique drawback: (1) will fail users that transpile to ES5 on purpose because it will still use an `async` function. (2) will fail users that accidentally transpile to ES5 (e.g. via higher-level tools like Laravel Mix) but are not actually targeting ES5-only browsers and expect the `await` keyword to work in their Alpine attributes.

For this PR, I've decided to go with approach (1) because I think the set of users who transpile a library (which does not support ES5 anyway) on purpose should be negligible.