### PR TITLE
Remove .only from x-on.spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 scratch.md
 dist/
 .env.json
+.idea

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -97,7 +97,7 @@ test('.stop modifier',
     }
 )
 
-test.only('.capture modifier',
+test('.capture modifier',
     html`
         <div x-data="{ foo: 'bar' }">
             <button @click.capture="foo = 'baz'">


### PR DESCRIPTION
I found that we are not running all the tests, because of the `test.only`.
I think it was added during development, but by mistake, it is merged to the main branch.

Before:
<img width="439" alt="Screenshot 2021-12-29 at 17 59 08" src="https://user-images.githubusercontent.com/29600182/147686883-a1d89e04-651c-47ea-b81d-e54941e41d49.png">

After:
<img width="862" alt="Screenshot 2021-12-29 at 18 02 00" src="https://user-images.githubusercontent.com/29600182/147686906-9a8f965f-6ac8-4cf0-bd33-c4499a5014eb.png">


PS. I was thinking to add eslint to prevent this kind of issue, but if you will agree to it I will add it in the next PR.