### PR TITLE
New event specific for plugin initialization

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -8,6 +8,7 @@ import { warn } from './utils/warn'
 export function start() {
     if (! document.body) warn('Unable to initialize. Trying to load Alpine before `<body>` is available. Did you forget to add `defer` in Alpine\'s `<script>` tag?')
 
+    dispatch(document, 'alpine:plugin-init')
     dispatch(document, 'alpine:init')
     dispatch(document, 'alpine:initializing')
 

--- a/packages/collapse/builds/cdn.js
+++ b/packages/collapse/builds/cdn.js
@@ -1,5 +1,5 @@
 import collapse from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(collapse)
 })

--- a/packages/history/builds/cdn.js
+++ b/packages/history/builds/cdn.js
@@ -1,5 +1,5 @@
 import history from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(history)
 })

--- a/packages/intersect/builds/cdn.js
+++ b/packages/intersect/builds/cdn.js
@@ -1,5 +1,5 @@
 import intersect from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(intersect)
 })

--- a/packages/morph/builds/cdn.js
+++ b/packages/morph/builds/cdn.js
@@ -1,5 +1,5 @@
 import morph from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(morph)
 })

--- a/packages/persist/builds/cdn.js
+++ b/packages/persist/builds/cdn.js
@@ -1,5 +1,5 @@
 import persist from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(persist)
 })

--- a/packages/portal/builds/cdn.js
+++ b/packages/portal/builds/cdn.js
@@ -1,5 +1,5 @@
 import portal from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(portal)
 })

--- a/packages/trap/builds/cdn.js
+++ b/packages/trap/builds/cdn.js
@@ -1,5 +1,5 @@
 import trap from '../src/index.js'
 
-document.addEventListener('alpine:init', () => {
+document.addEventListener('alpine:plugin-init', () => {
     window.Alpine.plugin(trap)
 })


### PR DESCRIPTION
This change is to introduce an extra event fired prior to `alpine:init` for initializing plugin, namely `alpine:plugin-init`. This is based on discussion in #2465.

Currently, plugins are initialized in `alpine:init` cycle which is same as what user would normally do for their own code, and this could result in timing issue that plugins aren't initialized yet before user accessing plugin in their code

There are ways to mitigate this issue but not ideal, e.g. enforcing code loading order: plugins → user's code → alpine library. Introducing an extra event fired before `alpine:init`.