### PR TITLE
Fix x-if sub expressions still being evaluated after x-if evals to false

### DIFF
--- a/packages/alpinejs/src/scheduler.js
+++ b/packages/alpinejs/src/scheduler.js
@@ -10,6 +10,13 @@ function queueJob(job) {
 
     queueFlush()
 }
+export function dequeueJob(job)
+{
+    var index = queue.indexOf(job);
+    if (index !== -1) {
+        queue.splice(index, 1);
+    }
+}
 
 function queueFlush() {
     if (! flushing && ! flushPending) {

--- a/tests/cypress/integration/directives/x-if.spec.js
+++ b/tests/cypress/integration/directives/x-if.spec.js
@@ -51,3 +51,26 @@ test('x-if initializes after being added to the DOM to allow x-ref to work',
         get('li').should(haveText('bar'))
     }
 )
+
+//If x-if evaluates to false, the expectation is that no sub-expressions will be evaluated.
+test('x-if removed dom does not evaluate reactive expressions in dom tree',
+    html`
+    <div x-data="{user: {name: 'lebowski'}}">
+        <button @click="user = null">Log out</button>
+        <template x-if="user">
+            <span x-text="user.name"></span>
+        </template>
+
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('lebowski'))
+        
+        /** Clicking button sets user=null and thus x-if="user" will evaluate to false. 
+            If the sub-expression x-text="user.name" is evaluated, the button click  
+            will produce an error because user is no longer defined and the test will fail
+        **/
+        get('button').click()
+        get('span').should('not.exist')
+    }
+)


### PR DESCRIPTION
Hi There!

This PR is to address an issue where after an `<template x-if="expression"></template>` has evaluated to false and thus the DOM element has been removed, sub expressions are still evaluated. Example reports of this issue are: #2540 #2296 #1837 #1917

Imagine the following code:

```
<div x-data="{user: {name: 'lebowski'}}">
  <button @click="user=null">Logout</logout>
  <template x-if="user">
    <span x-text="user.name"></span>
  </template>
</div>
```

Before the suggested fix the above code would produce the following when "Logout" is clicked:

<img width="499" alt="Screen Shot 2022-01-03 at 5 03 05 PM" src="https://user-images.githubusercontent.com/3186142/147989729-f270e542-2fb5-4d62-8d00-b34b557e3595.png">

This is because of the following pseudo timeline:

1. `user` is set to `null`
2. This causes `effect()` on the `x-text` directive to queue  an expression evaluation i.e `user.name`.
3. The `x-if="user"` expression is evaluated and the result is now false. The cleanup tasks run and removes the `<span></span>` element from the DOM.
4. The queue runs and evaluates the expression from Step 2. At this point user is null and thus `user.name` throws an exception.

My solution is to simply remove the queued effect from the queue in the `el._x_undoIf()` method call. I am however not sure how maintainers will feel about exposing a new method in `scheduler.js` though. I could not determine a better way though.

This was my first peek into the internals of Alpine so there very well may be a better way to solve this issue. I added a new Cypress test to demonstrate this bug and to also demonstrate how this solution fixes the bug.

Very open to feedback on a better solution.



