### PR TITLE
Fix x-intersect reliability

### DIFF
--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -78,16 +78,18 @@ For example, in the following snippet, `shown` will remain `false` until the ele
 <a name="x-intersect-enter"></a>
 ### x-intersect:enter
 
-You can opt to only trigger x-intersect when the element ENTERS the viewport by adding the `:enter` suffix to `x-intersect` like so:
+The `:enter` suffix is an alias of `x-intersect`, and works the same way:
 
 ```alpine
 <div x-intersect:enter="shown = true">...</div>
 ```
 
+You may choose to use this for clarity when also using the `:leave` suffix.
+
 <a name="x-intersect-leave"></a>
 ### x-intersect:leave
 
-Similarly, you can add `:leave` to only trigger x-intersect when the element LEAVES the viewport:
+Appending `:leave` runs your expression when the element leaves the viewport:
 
 ```alpine
 <div x-intersect:leave="shown = true">...</div>

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -10,9 +10,8 @@ export default function (Alpine) {
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
                 if (
-                     ! entry.isIntersecting && value === 'enter'
+                     ! entry.isIntersecting && (value === 'enter' || ! value)
                     || entry.isIntersecting && value === 'leave'
-                    || entry.intersectionRatio === 0 && ! value
                 ) return
 
                 evaluate()

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -9,10 +9,8 @@ export default function (Alpine) {
 
         let observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
-                if (
-                     ! entry.isIntersecting && (value === 'enter' || ! value)
-                    || entry.isIntersecting && value === 'leave'
-                ) return
+                // Ignore entry if intersecting in leave mode, or not intersecting in enter mode
+                if (entry.isIntersecting === (value === 'leave')) return
 
                 evaluate()
 


### PR DESCRIPTION
`x-intersect` doesn't currently reliably work.

See #1833, #1871.

I can verify those experiences. Sometimes you can scroll an element into view, and the expression doesn't fire.

Next, #1933 added `x-intersect:leave` (yay) and `x-intersect:enter`, which was an implied alias (though the docs didn't acknowledge this explicitly) with one key difference: it works.

The problem is that the `IntersectionObserver` handler bails on the following three conditions:

```js
     ! entry.isIntersecting && value === 'enter'
    || entry.isIntersecting && value === 'leave'
    || entry.intersectionRatio === 0 && ! value
```

The first two are fine. The last one is no good. `intersectionRatio` is a tricky beast, and receiving a `0` doesn't mean that the element isn't visible. Since Alpine is supplying a `threshold` of `0`, for slow scrolls or small elements, the browser may send a `IntersectionObserverEntry` with an `intersectionRatio` of `0`.

It won't send another, so this is the cause of `x-intersect` being unreliable.

This PR makes `x-intersect` a true alias of `x-intersect:enter`, and ensures that it reliably works when the tracked item enters the viewport.

It no longer relies on the untrustworthy `intersectionRatio`.

I also updated the docs to make it clear that `x-intersect:enter` is an alias, for parity with `:leave` (and it also matches `x-transition`).