### PR TITLE
Update CSP documentation to clarify availability of the CSP build

### DIFF
--- a/packages/docs/src/en/advanced/csp.md
+++ b/packages/docs/src/en/advanced/csp.md
@@ -14,7 +14,7 @@ In order to accommodate environments where this CSP is necessary, Alpine will of
 <a name="installation"></a>
 ## Installation
 
-The CSP build hasn’t been officially released yet. In the meantime, you may [build it from source](https://github.com/alpinejs/alpine/tree/main/packages/csp). Once released, ike all Alpine extensions, you will be able to include this either via `<script>` tag or module import:
+The CSP build hasn’t been officially released yet. In the meantime, you may [build it from source](https://github.com/alpinejs/alpine/tree/main/packages/csp). Once released, like all Alpine extensions, you will be able to include this either via `<script>` tag or module import:
 
 <a name="script-tag"></a>
 ### Script tag

--- a/packages/docs/src/en/advanced/csp.md
+++ b/packages/docs/src/en/advanced/csp.md
@@ -9,12 +9,12 @@ In order for Alpine to be able to execute plain strings from HTML attributes as 
 
 > Under the hood, Alpine doesn't actually use eval() itself because it's slow and problematic. Instead it uses Function declarations, which are much better, but still violate "unsafe-eval".
 
-In order to accommodate environments where this CSP is necessary, Alpine offers an alternate build that doesn't violate "unsafe-eval", but has a more restrictive syntax.
+In order to accommodate environments where this CSP is necessary, Alpine will offer an alternate build that doesn't violate "unsafe-eval", but has a more restrictive syntax.
 
 <a name="installation"></a>
 ## Installation
 
-Like all Alpine extensions, you can include this either via `<script>` tag or module import:
+The CSP build hasn’t been officially released yet. In the meantime, you may [build it from source](https://github.com/alpinejs/alpine/tree/main/packages/csp). Once released, ike all Alpine extensions, you will be able to include this either via `<script>` tag or module import:
 
 <a name="script-tag"></a>
 ### Script tag


### PR DESCRIPTION
As a newcomer considering Alpine.js for a project, I found it very confusing that the CSP build’s documentation makes it sound like it’s available to use now even though it’s not published on npm. This PR makes minimal changes to the page to clarify this, and provide guidance on what people should do in the meantime.

The info I added is based on https://github.com/alpinejs/alpine/issues/237#issuecomment-999692410 – there might be more details that could be added here that aren’t publicly available (see also https://github.com/alpinejs/alpine/discussions/1944).