### PR TITLE
Docs - fix x-teleport modal example

### DIFF
--- a/packages/docs/src/en/directives/teleport.md
+++ b/packages/docs/src/en/directives/teleport.md
@@ -56,7 +56,7 @@ Here's a contrived modal example:
 
     </div>
 
-    <div class="py-4">Some other content...</div>
+    <div class="py-4">Some other content placed AFTER the modal markup.</div>
 </div>
 <!-- END_VERBATIM -->
 


### PR DESCRIPTION
Came across this inconsistency on the docs page, where the rendered example does not match the example code.

 Not _very_ confusing... but a little confusing.

<img width="748" alt="Screen Shot 2022-02-26 at 10 42 52 AM" src="https://user-images.githubusercontent.com/23181573/155853027-d9d33453-3303-478f-8b81-2ee521ef0149.png">