### PR TITLE
Removed non breaking space

### DIFF
--- a/packages/alpinejs/src/utils/styles.js
+++ b/packages/alpinejs/src/utils/styles.js
@@ -41,7 +41,7 @@ function setStylesFromString(el, value) {
     el.setAttribute('style', value)
 
     return () => {
-        el.setAttribute('style', cache || '')
+        el.setAttribute('style', cache || '')
     }
 }
 


### PR DESCRIPTION
The non breaking space gives issues in webpack where it may be transformed into
 
```javascript
l.setAttribute('style', cache ||Â '')
```

![image](https://user-images.githubusercontent.com/8638425/156239466-2ffddc69-0673-42f2-8410-bad3cd86ce8e.png)
