### PR TITLE
Documentation for `destroy()` and component cleanup

### DIFF
--- a/packages/docs/src/en/globals/alpine-data.md
+++ b/packages/docs/src/en/globals/alpine-data.md
@@ -123,7 +123,7 @@ Alpine.data('blinker', () => {
 })
 ```
 
-> Note the difference in the first line of this component definition—we're opening a function body, rather than the arrow function’s [implicit return](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#function_body) feature, as in previous examples. Your component's final definition still takes the same shape, but must be explicitly returned by the factory function.
+> Note the difference in the first line of this component definition—we're opening a function body, rather than using the arrow function’s [implicit return](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#function_body) feature, as in previous examples. Your component's final definition still takes the same shape, but must be explicitly returned by the factory function.
 
 <a name="using-magic-properties"></a>
 ## Using magic properties

--- a/packages/docs/src/en/globals/alpine-data.md
+++ b/packages/docs/src/en/globals/alpine-data.md
@@ -87,6 +87,44 @@ Alpine.data('dropdown', () => ({
 }))
 ```
 
+<a name="destroy-functions"></a>
+## Destroy functions
+
+Like `init()`, Alpine will automatically discover and execute your component's `destroy()` method after cleaning up other reactive properties. This is useful for unbinding anything registered against the global scope, or outside Alpine's own reactivity engine.
+
+```js
+Alpine.data('dropdown', () => ({
+    destroy() {
+        // This code will be executed once Alpine
+        // has finished cleaning up the component.
+        // As a result, reactive data will no
+        // longer be available!
+    }
+}))
+```
+
+If you need to maintain a reference to something throughout the entire life of your component, you can declare a variable within the factory function's scope:
+
+```js
+Alpine.data('blinker', () => {
+    let tick
+
+    return {
+        open: false,
+        init () {
+            tick = window.setInterval(() => {
+                this.open = !this.open
+            }, 1000)
+        },
+        destroy() {
+            window.clearInterval(tick)
+        }
+    }
+})
+```
+
+> Note the difference in the first line of this component definition—we're opening a function body, rather than the arrow function’s [implicit return](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#function_body) feature, as in previous examples. Your component's final definition still takes the same shape, but must be explicitly returned by the factory function.
+
 <a name="using-magic-properties"></a>
 ## Using magic properties
 

--- a/packages/docs/src/en/globals/alpine-data.md
+++ b/packages/docs/src/en/globals/alpine-data.md
@@ -90,34 +90,39 @@ Alpine.data('dropdown', () => ({
 <a name="destroy-functions"></a>
 ## Destroy functions
 
-Like `init()`, Alpine will automatically discover and execute your component's `destroy()` method after cleaning up other reactive properties. This is useful for unbinding anything registered against the global scope, or outside Alpine's own reactivity engine.
+Like `init()`, Alpine will automatically discover and execute your component's `destroy()` method just prior to cleaning up other reactive properties.
 
 ```js
-Alpine.data('dropdown', () => ({
+Alpine.data('timer', (delay = 5000) => ({
+    countdown: null,
+    init () {
+        this.countdown = window.setTimeout(() => {
+            console.log('Time’s up!')
+        }, delay)
+    },
     destroy() {
-        // This code will be executed once Alpine
-        // has finished cleaning up the component.
-        // As a result, reactive data will no
-        // longer be available!
-    }
+        window.clearTimeout(this.countdown)
+    },
 }))
 ```
 
-If you need to maintain a reference to something throughout the entire life of your component, you can declare a variable within the factory function's scope:
+<a name="non-reactive-data">
+## Non-reactive Data
+
+If you need to maintain a reference to something that is a dependency of your component (but not necessarily tracked by or compatible with Alpine’s reactivity engine), you can declare a variable within the factory function’s scope:
 
 ```js
-Alpine.data('blinker', () => {
-    let tick
+Alpine.data('super-dropdown', () => {
+    let superSelectInstance
 
     return {
-        open: false,
         init () {
-            tick = window.setInterval(() => {
-                this.open = !this.open
-            }, 1000)
+            superSelectInstance = new SuperSelect(this.$el)
         },
         destroy() {
-            window.clearInterval(tick)
+            // Supposing the library has its own global
+            // event listeners that need cleanup:
+            superSelectInstance.teardown()
         }
     }
 })


### PR DESCRIPTION
Hi!

This PR adds two new sections to the [`Alpine.data()` documentation page](https://alpinejs.dev/globals/alpine-data) that seek to explain these concepts:

1. The unadvertised `destroy()` component method;
2. How to track local, non-reactive data;

Both of these took some deeper exploration of the source (and issue history, discussions) to understand, and felt like they deserved clarification. In particular, the apparent preference for the terse “implicit return” syntax in the component definition syntax was a subtly distracting pattern—one that had me fully convinced that there was no strategy for holding non-reactive data that might be required to mount third-party libraries (say, a MapboxGL instance), or to memoize scalar values (like an interval ID) that need manual cleanup at the end of a component's lifecycle.

I do understand that blurring Alpine's reactivity and local scope could result in an undue support burden—but I think the documentation is already plenty explicit about object properties and methods’ relationship to the reactivity engine.

Hope this tracks, and that the writing is stylistically acceptable!

## Related Issues and Discussions:
- #2692 
- #2693 
- #2103 
- #775 