### PR TITLE
Ensure `Alpine.closestDataStack` exists

### DIFF
--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -23,7 +23,7 @@ export async function morph(from, toHtml, options) {
 
     // If there is no x-data on the element we're morphing,
     // let's seed it with the outer Alpine scope on the page.
-    if (window.Alpine && ! from._x_dataStack) {
+    if (window.Alpine && window.Alpine.closestDataStack && ! from._x_dataStack) {
         toEl._x_dataStack = window.Alpine.closestDataStack(from)
 
         toEl._x_dataStack && window.Alpine.clone(from, toEl)


### PR DESCRIPTION
When implementing the Morph plugin in Livewire, Livewire's tests were using an old version of Alpine, as such were getting the below error.

<img width="585" alt="Screen Shot 2022-03-04 at 9 01 23 pm" src="https://user-images.githubusercontent.com/882837/156742563-78b350b0-fe40-41ed-bbde-31b152a00d00.png">

This PR ensures `Alpine.closestDataStack` exists, before using in the Morph plugin, as it wasn't introduced until 3.5.2.

Didn't add a test for it, as wasn't sure how to run a test using an older version of Alpine in Cypress.

Hope this helps!