### PR TITLE
Fix Morph missing next sibling when replacing element

### DIFF
--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -207,7 +207,7 @@ async function patchChildren(from, to) {
             } else {
                 let added = addNodeTo(currentTo, from) || {}
 
-                await breakpoint('Add element: ' + added.outerHTML || added.nodeValue)
+                await breakpoint('Add element: ' + (added.outerHTML || added.nodeValue))
 
                 currentTo = dom(currentTo).nodes().next()
 

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -278,11 +278,14 @@ async function patchChildren(from, to) {
             }
         }
 
+        // Get next from sibling before patching in case the node is replaced
+        let currentFromNext = currentFrom && dom(currentFrom).nodes().next()
+
         // Patch elements
         await patch(currentFrom, currentTo)
 
         currentTo = currentTo && dom(currentTo).nodes().next()
-        currentFrom = currentFrom && dom(currentFrom).nodes().next()
+        currentFrom = currentFromNext
     }
 
     // Cleanup extra froms.

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -256,7 +256,7 @@ test('can morph text nodes',
     },
 )
 
-test.only('can morph with added element before and siblings are different',
+test('can morph with added element before and siblings are different',
     [html`
         <button>
             <div>

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -286,3 +286,22 @@ test('can morph with added element before and siblings are different',
             `))
     },
 )
+
+test('can morph different inline nodes',
+    [html`
+    <div id="from">
+        Hello <span>World</span>
+    </div>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+        <div id="to">
+            Welcome <b>Person</b>!
+        </div>
+        `
+
+        get('div').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('div').should(haveHtml('\n            Welcome <b>Person</b>!\n        '))
+    },
+)


### PR DESCRIPTION
When morphing inline elements, Morph is currently adding a space before the "!" in the test.

With this as the starting from and to elements:

<img width="188" alt="image" src="https://user-images.githubusercontent.com/882837/156868936-a1ceb0de-57f6-401c-bfb1-e364aef347c6.png">

Running morph results in this:

<img width="271" alt="image" src="https://user-images.githubusercontent.com/882837/156868948-8974e6b0-6a7a-473d-bdb1-8343ff8d1b52.png">

This PR adds a failing test for this use case.

It also removes the `.only` left on the previous morph testcase.

I have some ideas on why this is happening so will have a play with it.

Hope this helps!