### PR TITLE
Feature/destroy scope

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -34,8 +34,8 @@ directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
     reactiveData['init'] && evaluate(el, reactiveData['init'])
 
     cleanup(() => {
-        undo()
-
         reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])
+
+        undo()
     })
 }))

--- a/tests/cypress/integration/custom-data.spec.js
+++ b/tests/cypress/integration/custom-data.spec.js
@@ -159,10 +159,38 @@ test('destroy functions inside custom datas are called automatically',
         <div x-data="test">
             <button x-on:click="test()"></button>
         </div>
-        <span><span>
+        <span></span>
     `,
     ({ get }) => {
         get('button').click()
         get('span').should(haveText('foo'))
+    }
+)
+
+test('destroy have access to the current scope',
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('test', () => ({
+                    destroy() {
+                        document.querySelector('span').textContent = this.foo
+                    },
+                    test() {
+                        Alpine.closestRoot(this.$el).remove()
+                    },
+                    foo: 'bar'
+                }))
+            })
+        </script>
+
+        <div x-data="test">
+            <button x-on:click="test()"></button>
+        </div>
+        <span>baz</span>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('baz'))
+        get('button').click()
+        get('span').should(haveText('bar'))
     }
 )


### PR DESCRIPTION
This is not properly a bug but a lot of people are expecting to have access to the current scope in the destroy callback, similarly to what happens in init so they can do stuff like
```html
<div x-data="{
  foo: null,
  init() {foo = setInterval(() => console.log('tick'), 1000)},
  destroy() {clearInterval(foo)}
}">
```

Note, there are workarounds such as storing data on the global object or inside the function scope when using Alpine.data but they are not obvious ones.

The feature is undocumented so I don't think it's a bug but more of a nicety. Feel free to close it if you think it's not important or there is a specific design choice behind it.

Failing test applied to the current build: https://github.com/SimoTod/alpine/runs/5433954162?check_suite_focus=true#step:6:273