### PR TITLE
Add Morph test for swapping keyed elements

### DIFF
--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -271,7 +271,7 @@ async function patchChildren(from, to) {
                     currentFrom = dom(currentFrom).next()
                     currentTo = dom(currentTo).next()
 
-                    await breakpoint('I dont even know what this does')
+                    await breakpoint('Swap elements with keys')
 
                     continue
                 }

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -1,4 +1,4 @@
-import { haveLength, haveText, haveValue, haveHtml, html, test } from '../../utils'
+import { haveAttribute, haveLength, haveText, haveValue, haveHtml, html, test } from '../../utils'
 
 test('can morph components and preserve Alpine state',
     [html`
@@ -284,5 +284,26 @@ test.only('can morph with added element before and siblings are different',
                 <div>second</div>
                 <div data="true">third</div>
             `))
+    },
+)
+
+test('can morph using different keys',
+    [html`
+        <ul>
+            <li key="1">foo</li>
+        </ul>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+            <ul>
+                <li key="2">bar</li>
+            </ul>
+        `
+
+        get('ul').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('li').should(haveLength(1))
+        get('li:nth-of-type(1)').should(haveText('bar'))
+        get('li:nth-of-type(1)').should(haveAttribute('key', '2'))
     },
 )


### PR DESCRIPTION
This adds a Morph test for swapping two elements with different keys and updates the debugging breakpoint comment.

Hope this helps!