### PR TITLE
Fix x-transition documentation

### DIFF
--- a/packages/docs/src/en/directives/transition.md
+++ b/packages/docs/src/en/directives/transition.md
@@ -52,9 +52,9 @@ You can configure the duration you want for a transition with the `.duration` mo
 <div ... x-transition.duration.500ms>
 ```
 
-The above `<div>` will transition for 500 milliseconds when entering, and 250 milliseconds when leaving.
+The above `<div>` will transition for 500 milliseconds when entering, and 500 milliseconds when leaving.
 
-This difference in duration generally desirable default. If you wish to customize the durations specifically for entering and leaving, you can do that like so:
+If you wish to customize the durations specifically for entering and leaving, you can do that like so:
 
 ```alpine
 <div ...

--- a/packages/docs/src/en/directives/transition.md
+++ b/packages/docs/src/en/directives/transition.md
@@ -46,6 +46,8 @@ You can override these defaults with modifiers attached to `x-transition`. Let's
 <a name="customizing-duration"></a>
 ### Customizing duration
 
+Initially, the duration is set to be 150 milliseconds when entering, and 75 milliseconds when leaving.
+
 You can configure the duration you want for a transition with the `.duration` modifier:
 
 ```alpine


### PR DESCRIPTION
I noticed an error in the `x-transition` directive documentation: the `.duration` modifier currently handles both `enter` and `leave` durations.