### PR TITLE
Swap mainfields in build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -59,7 +59,7 @@ function bundleFile(package, file) {
                 outfile: `packages/${package}/dist/${file.replace('.js', '.esm.js')}`,
                 bundle: true,
                 platform: 'neutral',
-                mainFields: ['main', 'module'],
+                mainFields: ['module', 'main'],
             })
 
             build({


### PR DESCRIPTION
This reduces the build size of the AlpineJS module by ~20%

AlpineJS
Before: 112kb
After: 87kb

Focus Plugin:
Before: 32kb
After: 28kb


I've used a variation of this build myself on projects for a while now and have yet to see any actual issues in browser or with bundlers.