### PR TITLE
Fixed toggling overflow in collapse-plugin

### DIFF
--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -44,7 +44,7 @@ export default function (Alpine) {
                     start: { height: current+'px' },
                     end: { height: full+'px' },
                 }, () => el._x_isShown = true, () => {
-                    if (el.style.height == `${full}px`) {
+                    if (el.offsetHeight >= full) {
                         el.style.overflow = null
                     }
                 })
@@ -61,7 +61,7 @@ export default function (Alpine) {
                     el._x_isShown = false
 
                     // check if element is fully collapsed
-                    if (el.style.height == `${floor}px`) {
+                    if (el.offsetHeight == floor) {
                         el.style.display = 'none'
                         el.hidden = true
                     }


### PR DESCRIPTION
Sometimes the element-height are not equal the value of full/floor.
Example:
```
el.style.height = 678.695px
full = 678.6953125px
```
So comparing theses variables fails and overflow will not be toggled.
Better to use elements offsetHeight and compare equal-or-higher with full.