### PR TITLE
X-html in x-for

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -187,9 +187,9 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
 
             mutateDom(() => {
                 lastEl.after(clone)
-            })
 
-            initTree(clone)
+                initTree(clone)
+            })
 
             if (typeof key === 'object') {
                 warn('x-for key cannot be an object, it must be a string or an integer', templateEl)

--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -187,9 +187,9 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
 
             mutateDom(() => {
                 lastEl.after(clone)
-
-                initTree(clone)
             })
+
+            initTree(clone)
 
             if (typeof key === 'object') {
                 warn('x-for key cannot be an object, it must be a string or an integer', templateEl)

--- a/packages/alpinejs/src/directives/x-html.js
+++ b/packages/alpinejs/src/directives/x-html.js
@@ -1,5 +1,6 @@
 import { evaluateLater } from '../evaluator'
 import { directive } from '../directives'
+import { initTree } from '../lifecycle'
 import { mutateDom } from '../mutation'
 
 directive('html', (el, { expression }, { effect, evaluateLater }) => {
@@ -7,7 +8,13 @@ directive('html', (el, { expression }, { effect, evaluateLater }) => {
 
     effect(() => {
         evaluate(value => {
-            el.innerHTML = value
+            mutateDom(() => {
+                el.innerHTML = value
+
+                el._x_ignoreSelf = true
+                initTree(el)
+                delete el._x_ignoreSelf
+            })
         })
     })
 })

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -545,3 +545,17 @@ test('x-for removed dom node does not evaluate child expressions after being rem
         get('span').should('not.exist')
     }
 )
+
+test('renders children using directives injected by x-html correctly',
+    html`
+        <div x-data="{foo: 'bar'}">
+            <template x-for="i in 2">
+                <p x-html="'<span x-text=&quot;foo&quot;></span>'"></p>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('p:nth-of-type(1) span').should(haveText('bar'))
+        get('p:nth-of-type(2) span').should(haveText('bar'))
+    }
+)


### PR DESCRIPTION
Currently, for newly created elements, the initTree callback is inside a mutate dom call which means that directives injected by `x-html` are not picked up by the mutation observer. It shouldn't be a big issue to move initTree outside of mutateDOm as we do for refreshScope when dealing with elements that are shuffled around.