### PR TITLE
Bug - Multiple morph calls clash 

### DIFF
--- a/packages/morph/src/dom.js
+++ b/packages/morph/src/dom.js
@@ -1,0 +1,66 @@
+class DomManager {
+    el = undefined
+
+    constructor(el) {
+        this.el = el
+    }
+
+    traversals = {
+        'first': 'firstElementChild',
+        'next': 'nextElementSibling',
+        'parent': 'parentElement',
+    }
+
+    nodes() {
+        this.traversals = {
+            'first': 'firstChild',
+            'next': 'nextSibling',
+            'parent': 'parentNode',
+        }; return this
+    }
+
+    first() {
+        return this.teleportTo(this.el[this.traversals['first']])
+    }
+
+    next() {
+        return this.teleportTo(this.teleportBack(this.el[this.traversals['next']]))
+    }
+
+    before(insertee) {
+        this.el[this.traversals['parent']].insertBefore(insertee, this.el); return insertee
+    }
+
+    replace(replacement) {
+        this.el[this.traversals['parent']].replaceChild(replacement, this.el); return replacement
+    }
+
+    append(appendee) {
+        this.el.appendChild(appendee); return appendee
+    }
+
+    teleportTo(el) {
+        if (! el) return el
+        if (el._x_teleport) return el._x_teleport
+        return el
+    }
+
+    teleportBack(el) {
+        if (! el) return el
+        if (el._x_teleportBack) return el._x_teleportBack
+        return el
+    }
+}
+
+export function dom(el) {
+    return new DomManager(el)
+}
+
+export function createElement(html) {
+    return document.createRange().createContextualFragment(html).firstElementChild
+}
+
+export function textOrComment(el) {
+    return el.nodeType === 3
+        || el.nodeType === 8
+}

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -5,11 +5,9 @@ let resolveStep = () => {}
 let logger = () => {}
 
 export async function morph(from, toHtml, options) {
-    // We define a few private helper functions and variables in
-    // the scope of this function. We don't want them on the global
-    // namespace because, being async, multiple calls one after the
-    // other would run in a pseudo concurrent way and the last call
-    // would override the variables and setting of the first one.
+    // We're defining these globals and methods inside this function (instead of outside)
+    // because it's an async function and if run twice, they would overwrite
+    // each other.
 
     let fromEl
     let toEl
@@ -373,7 +371,3 @@ function initializeAlpineOnTo(from, to, childrenOnly) {
         window.Alpine.clone(from, to)
     }
 }
-
-
-
-

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -1,23 +1,333 @@
+import { dom, createElement, textOrComment} from './dom.js'
+
 let resolveStep = () => {}
 
 let logger = () => {}
 
-// Keep these global so that we can access them
-// from hooks while debugging.
-let fromEl 
-let toEl
-
-function breakpoint(message) {
-    if (! debug) return
-
-    logger((message || '').replace('\n', '\\n'), fromEl, toEl)
-
-    return new Promise(resolve => resolveStep = () => resolve())
-}
-
 export async function morph(from, toHtml, options) {
+    // We define a few private helper functions and variables in
+    // the scope of this function. We don't want them on the global
+    // namespace because, being async, multiple calls one after the
+    // other would run in a pseudo concurrent way and the last call
+    // would override the variables and setting of the first one.
+
+    let fromEl
+    let toEl
+    let key
+        ,lookahead
+        ,updating
+        ,updated
+        ,removing
+        ,removed
+        ,adding
+        ,added
+        ,debug
+
+
+    function breakpoint(message) {
+        if (! debug) return
+
+        logger((message || '').replace('\n', '\\n'), fromEl, toEl)
+
+        return new Promise(resolve => resolveStep = () => resolve())
+    }
+
+    function assignOptions(options = {}) {
+        let defaultGetKey = el => el.getAttribute('key')
+        let noop = () => {}
+
+        updating = options.updating || noop
+        updated = options.updated || noop
+        removing = options.removing || noop
+        removed = options.removed || noop
+        adding = options.adding || noop
+        added = options.added || noop
+        key = options.key || defaultGetKey
+        lookahead = options.lookahead || false
+        debug = options.debug || false
+    }
+
+    async function patch(from, to) {
+        // This is a time saver, however, it won't catch differences in nested <template> tags.
+        // I'm leaving this here as I believe it's an important speed improvement, I just
+        // don't see a way to enable it currently:
+        //
+        // if (from.isEqualNode(to)) return
+
+        if (differentElementNamesTypesOrKeys(from, to)) {
+            let result = patchElement(from, to)
+
+            await breakpoint('Swap elements')
+
+            return result
+        }
+
+        let updateChildrenOnly = false
+
+        if (shouldSkip(updating, from, to, () => updateChildrenOnly = true)) return
+
+        window.Alpine && initializeAlpineOnTo(from, to, () => updateChildrenOnly = true)
+
+        if (textOrComment(to)) {
+            await patchNodeValue(from, to)
+            updated(from, to)
+
+            return
+        }
+
+        if (! updateChildrenOnly) {
+            await patchAttributes(from, to)
+        }
+
+        updated(from, to)
+
+        await patchChildren(from, to)
+    }
+
+    function differentElementNamesTypesOrKeys(from, to) {
+        return from.nodeType != to.nodeType
+            || from.nodeName != to.nodeName
+            || getKey(from) != getKey(to)
+    }
+
+    function patchElement(from, to) {
+        if (shouldSkip(removing, from)) return
+
+        let toCloned = to.cloneNode(true)
+
+        if (shouldSkip(adding, toCloned)) return
+
+        dom(from).replace(toCloned)
+
+        removed(from)
+        added(toCloned)
+    }
+
+    async function patchNodeValue(from, to) {
+        let value = to.nodeValue
+
+        if (from.nodeValue !== value) {
+            from.nodeValue = value
+
+            await breakpoint('Change text node to: ' + value)
+        }
+    }
+
+    async function patchAttributes(from, to) {
+        if (from._x_isShown && ! to._x_isShown) {
+            return
+        }
+        if (! from._x_isShown && to._x_isShown) {
+            return
+        }
+
+        let domAttributes = Array.from(from.attributes)
+        let toAttributes = Array.from(to.attributes)
+
+        for (let i = domAttributes.length - 1; i >= 0; i--) {
+            let name = domAttributes[i].name;
+
+            if (! to.hasAttribute(name)) {
+                from.removeAttribute(name)
+
+                await breakpoint('Remove attribute')
+            }
+        }
+
+        for (let i = toAttributes.length - 1; i >= 0; i--) {
+            let name = toAttributes[i].name
+            let value = toAttributes[i].value
+
+            if (from.getAttribute(name) !== value) {
+                from.setAttribute(name, value)
+
+                await breakpoint(`Set [${name}] attribute to: "${value}"`)
+            }
+        }
+    }
+
+    async function patchChildren(from, to) {
+        let domChildren = from.childNodes
+        let toChildren = to.childNodes
+
+        let toKeyToNodeMap = keyToMap(toChildren)
+        let domKeyDomNodeMap = keyToMap(domChildren)
+
+        let currentTo = dom(to).nodes().first()
+        let currentFrom = dom(from).nodes().first()
+
+        let domKeyHoldovers = {}
+
+        while (currentTo) {
+            let toKey = getKey(currentTo)
+            let domKey = getKey(currentFrom)
+
+            // Add new elements
+            if (! currentFrom) {
+                if (toKey && domKeyHoldovers[toKey]) {
+                    let holdover = domKeyHoldovers[toKey]
+
+                    dom(from).append(holdover)
+                    currentFrom = holdover
+
+                    await breakpoint('Add element (from key)')
+                } else {
+                    let added = addNodeTo(currentTo, from) || {}
+
+                    await breakpoint('Add element: ' + (added.outerHTML || added.nodeValue))
+
+                    currentTo = dom(currentTo).nodes().next()
+
+                    continue
+                }
+            }
+
+            if (lookahead) {
+                let nextToElementSibling = dom(currentTo).next()
+
+                let found = false
+
+                while (!found && nextToElementSibling) {
+                    if (currentFrom.isEqualNode(nextToElementSibling)) {
+                        found = true
+
+                        currentFrom = addNodeBefore(currentTo, currentFrom)
+
+                        domKey = getKey(currentFrom)
+
+                        await breakpoint('Move element (lookahead)')
+                    }
+
+                    nextToElementSibling = dom(nextToElementSibling).next()
+                }
+            }
+
+            if (toKey !== domKey) {
+                if (! toKey && domKey) {
+                    domKeyHoldovers[domKey] = currentFrom
+                    currentFrom = addNodeBefore(currentTo, currentFrom)
+                    domKeyHoldovers[domKey].remove()
+                    currentFrom = dom(currentFrom).nodes().next()
+                    currentTo = dom(currentTo).nodes().next()
+
+                    await breakpoint('No "to" key')
+
+                    continue
+                }
+
+                if (toKey && ! domKey) {
+                    if (domKeyDomNodeMap[toKey]) {
+                        currentFrom = dom(currentFrom).replace(domKeyDomNodeMap[toKey])
+
+                        await breakpoint('No "from" key')
+                    }
+                }
+
+                if (toKey && domKey) {
+                    domKeyHoldovers[domKey] = currentFrom
+                    let domKeyNode = domKeyDomNodeMap[toKey]
+
+                    if (domKeyNode) {
+                        currentFrom = dom(currentFrom).replace(domKeyNode)
+
+                        await breakpoint('Move "from" key')
+                    } else {
+                        domKeyHoldovers[domKey] = currentFrom
+                        currentFrom = addNodeBefore(currentTo, currentFrom)
+                        domKeyHoldovers[domKey].remove()
+                        currentFrom = dom(currentFrom).next()
+                        currentTo = dom(currentTo).next()
+
+                        await breakpoint('Swap elements with keys')
+
+                        continue
+                    }
+                }
+            }
+
+            // Get next from sibling before patching in case the node is replaced
+            let currentFromNext = currentFrom && dom(currentFrom).nodes().next()
+
+            // Patch elements
+            await patch(currentFrom, currentTo)
+
+            currentTo = currentTo && dom(currentTo).nodes().next()
+            currentFrom = currentFromNext
+        }
+
+        // Cleanup extra froms.
+        let removals = []
+
+        // We need to collect the "removals" first before actually
+        // removing them so we don't mess with the order of things.
+        while (currentFrom) {
+            if(! shouldSkip(removing, currentFrom)) removals.push(currentFrom)
+
+            currentFrom = dom(currentFrom).nodes().next()
+        }
+
+        // Now we can do the actual removals.
+        while (removals.length) {
+            let domForRemoval = removals.shift()
+
+            domForRemoval.remove()
+
+            await breakpoint('remove el')
+
+            removed(domForRemoval)
+        }
+    }
+
+    function getKey(el) {
+        return el && el.nodeType === 1 && key(el)
+    }
+
+    function keyToMap(els) {
+        let map = {}
+
+        els.forEach(el => {
+            let theKey = getKey(el)
+
+            if (theKey) {
+                map[theKey] = el
+            }
+        })
+
+        return map
+    }
+
+    function addNodeTo(node, parent) {
+        if(! shouldSkip(adding, node)) {
+            let clone = node.cloneNode(true)
+
+            dom(parent).append(clone)
+
+            added(clone)
+
+            return clone
+        }
+
+        return null;
+    }
+
+    function addNodeBefore(node, beforeMe) {
+        if(! shouldSkip(adding, node)) {
+            let clone = node.cloneNode(true)
+
+            dom(beforeMe).before(clone)
+
+            added(clone)
+
+            return clone
+        }
+
+        return beforeMe
+    }
+
+    // Finally we morph the element
+
     assignOptions(options)
-    
+
     fromEl = from
     toEl = createElement(toHtml)
 
@@ -45,324 +355,12 @@ morph.log = (theLogger) => {
     logger = theLogger
 }
 
-let key
-,lookahead
-,updating
-,updated
-,removing
-,removed
-,adding
-,added
-,debug
-
-let noop = () => {}
-
-function assignOptions(options = {}) {
-    let defaultGetKey = el => el.getAttribute('key')
-
-    updating = options.updating || noop
-    updated = options.updated || noop
-    removing = options.removing || noop
-    removed = options.removed || noop
-    adding = options.adding || noop
-    added = options.added || noop
-    key = options.key || defaultGetKey
-    lookahead = options.lookahead || false
-    debug = options.debug || false
-}
-
-function createElement(html) {
-    return document.createRange().createContextualFragment(html).firstElementChild
-}
-
-async function patch(from, to) {
-    // This is a time saver, however, it won't catch differences in nested <template> tags.
-    // I'm leaving this here as I believe it's an important speed improvement, I just
-    // don't see a way to enable it currently:
-    //
-    // if (from.isEqualNode(to)) return
-
-    if (differentElementNamesTypesOrKeys(from, to)) {
-        let result = patchElement(from, to)
-
-        await breakpoint('Swap elements')
-
-        return result
-    }
-
-    let updateChildrenOnly = false
-
-    if (shouldSkip(updating, from, to, () => updateChildrenOnly = true)) return
-
-    window.Alpine && initializeAlpineOnTo(from, to, () => updateChildrenOnly = true)
-
-    if (textOrComment(to)) {
-        await patchNodeValue(from, to)
-        updated(from, to)
-
-        return
-    }
-
-    if (! updateChildrenOnly) {
-        await patchAttributes(from, to)
-    }
-
-    updated(from, to)
-
-    await patchChildren(from, to)
-}
-
-function differentElementNamesTypesOrKeys(from, to) {
-    return from.nodeType != to.nodeType
-        || from.nodeName != to.nodeName
-        || getKey(from) != getKey(to)
-}
-
-function textOrComment(el) {
-    return el.nodeType === 3
-        || el.nodeType === 8
-}
-
-function patchElement(from, to) {
-    if (shouldSkip(removing, from)) return
-
-    let toCloned = to.cloneNode(true)
-
-    if (shouldSkip(adding, toCloned)) return
-
-    dom(from).replace(toCloned)
-
-    removed(from)
-    added(toCloned)
-}
-
-async function patchNodeValue(from, to) {
-    let value = to.nodeValue
-
-    if (from.nodeValue !== value) {
-        from.nodeValue = value
-
-        await breakpoint('Change text node to: ' + value)
-    }
-}
-
-async function patchAttributes(from, to) {
-    if (from._x_isShown && ! to._x_isShown) {
-        return
-    }
-    if (! from._x_isShown && to._x_isShown) {
-        return
-    }
-
-    let domAttributes = Array.from(from.attributes)
-    let toAttributes = Array.from(to.attributes)
-
-    for (let i = domAttributes.length - 1; i >= 0; i--) {
-        let name = domAttributes[i].name;
-
-        if (! to.hasAttribute(name)) {
-            from.removeAttribute(name)
-
-            await breakpoint('Remove attribute')
-        }
-    }
-
-    for (let i = toAttributes.length - 1; i >= 0; i--) {
-        let name = toAttributes[i].name
-        let value = toAttributes[i].value
-
-        if (from.getAttribute(name) !== value) {
-            from.setAttribute(name, value)
-
-            await breakpoint(`Set [${name}] attribute to: "${value}"`)
-        }
-    }
-}
-
-async function patchChildren(from, to) {
-    let domChildren = from.childNodes
-    let toChildren = to.childNodes
-
-    let toKeyToNodeMap = keyToMap(toChildren)
-    let domKeyDomNodeMap = keyToMap(domChildren)
-
-    let currentTo = dom(to).nodes().first()
-    let currentFrom = dom(from).nodes().first()
-
-    let domKeyHoldovers = {}
-
-    while (currentTo) {
-        let toKey = getKey(currentTo)
-        let domKey = getKey(currentFrom)
-
-        // Add new elements
-        if (! currentFrom) {
-            if (toKey && domKeyHoldovers[toKey]) {
-                let holdover = domKeyHoldovers[toKey]
-
-                dom(from).append(holdover)
-                currentFrom = holdover
-
-                await breakpoint('Add element (from key)')
-            } else {
-                let added = addNodeTo(currentTo, from) || {}
-
-                await breakpoint('Add element: ' + (added.outerHTML || added.nodeValue))
-
-                currentTo = dom(currentTo).nodes().next()
-
-                continue
-            }
-        }
-
-        if (lookahead) {
-            let nextToElementSibling = dom(currentTo).next()
-
-            let found = false
-
-            while (!found && nextToElementSibling) {
-                if (currentFrom.isEqualNode(nextToElementSibling)) {
-                    found = true
-
-                    currentFrom = addNodeBefore(currentTo, currentFrom)
-
-                    domKey = getKey(currentFrom)
-
-                    await breakpoint('Move element (lookahead)')
-                }
-
-                nextToElementSibling = dom(nextToElementSibling).next()
-            }
-        }
-
-        if (toKey !== domKey) {
-            if (! toKey && domKey) {
-                domKeyHoldovers[domKey] = currentFrom
-                currentFrom = addNodeBefore(currentTo, currentFrom)
-                domKeyHoldovers[domKey].remove()
-                currentFrom = dom(currentFrom).nodes().next()
-                currentTo = dom(currentTo).nodes().next()
-
-                await breakpoint('No "to" key')
-
-                continue
-            }
-
-            if (toKey && ! domKey) {
-                if (domKeyDomNodeMap[toKey]) {
-                    currentFrom = dom(currentFrom).replace(domKeyDomNodeMap[toKey])
-
-                    await breakpoint('No "from" key')
-                }
-            }
-
-            if (toKey && domKey) {
-                domKeyHoldovers[domKey] = currentFrom
-                let domKeyNode = domKeyDomNodeMap[toKey]
-
-                if (domKeyNode) {
-                    currentFrom = dom(currentFrom).replace(domKeyNode)
-
-                    await breakpoint('Move "from" key')
-                } else {
-                    domKeyHoldovers[domKey] = currentFrom
-                    currentFrom = addNodeBefore(currentTo, currentFrom)
-                    domKeyHoldovers[domKey].remove()
-                    currentFrom = dom(currentFrom).next()
-                    currentTo = dom(currentTo).next()
-
-                    await breakpoint('Swap elements with keys')
-
-                    continue
-                }
-            }
-        }
-
-        // Get next from sibling before patching in case the node is replaced
-        let currentFromNext = currentFrom && dom(currentFrom).nodes().next()
-
-        // Patch elements
-        await patch(currentFrom, currentTo)
-
-        currentTo = currentTo && dom(currentTo).nodes().next()
-        currentFrom = currentFromNext
-    }
-
-    // Cleanup extra froms.
-    let removals = []
-    
-    // We need to collect the "removals" first before actually
-    // removing them so we don't mess with the order of things.
-    while (currentFrom) {
-        if(! shouldSkip(removing, currentFrom)) removals.push(currentFrom)
-
-        currentFrom = dom(currentFrom).nodes().next()
-    }
-
-    // Now we can do the actual removals.
-    while (removals.length) {
-        let domForRemoval = removals.shift()
-
-        domForRemoval.remove()
-
-        await breakpoint('remove el')
-
-        removed(domForRemoval)
-    }
-}
-
-function getKey(el) {
-    return el && el.nodeType === 1 && key(el)
-}
-
-function keyToMap(els) {
-    let map = {}
-
-    els.forEach(el => {
-        let theKey = getKey(el)
-
-        if (theKey) {
-            map[theKey] = el
-        }
-    })
-
-    return map
-}
-
 function shouldSkip(hook, ...args) {
     let skip = false
 
     hook(...args, () => skip = true)
 
     return skip
-}
-
-function addNodeTo(node, parent) {
-    if(! shouldSkip(adding, node)) {
-        let clone = node.cloneNode(true)
-
-        dom(parent).append(clone)
-
-        added(clone)
-
-        return clone
-    }
-
-    return null;
-}
-
-function addNodeBefore(node, beforeMe) {
-    if(! shouldSkip(adding, node)) {
-        let clone = node.cloneNode(true)
-
-        dom(beforeMe).before(clone)
-
-        added(clone)
-
-        return clone
-    }
-
-    return beforeMe
 }
 
 function initializeAlpineOnTo(from, to, childrenOnly) {
@@ -376,60 +374,6 @@ function initializeAlpineOnTo(from, to, childrenOnly) {
     }
 }
 
-function dom(el) {
-    return new DomManager(el)
-}
 
-class DomManager {
-    el = undefined
 
-    constructor(el) {
-        this.el = el
-    }
 
-    traversals = {
-        'first': 'firstElementChild',
-        'next': 'nextElementSibling',
-        'parent': 'parentElement',
-    }
-
-    nodes() {
-        this.traversals = {
-            'first': 'firstChild',
-            'next': 'nextSibling',
-            'parent': 'parentNode',
-        }; return this
-    }
-
-    first() {
-        return this.teleportTo(this.el[this.traversals['first']])
-    }
-
-    next() {
-        return this.teleportTo(this.teleportBack(this.el[this.traversals['next']]))
-    }
-
-    before(insertee) {
-        this.el[this.traversals['parent']].insertBefore(insertee, this.el); return insertee
-    }
-
-    replace(replacement) {
-        this.el[this.traversals['parent']].replaceChild(replacement, this.el); return replacement
-    }
-
-    append(appendee) {
-        this.el.appendChild(appendee); return appendee
-    }
-
-    teleportTo(el) {
-        if (! el) return el
-        if (el._x_teleport) return el._x_teleport
-        return el
-    }
-
-    teleportBack(el) {
-        if (! el) return el
-        if (el._x_teleportBack) return el._x_teleportBack
-        return el
-    }
-}

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -256,7 +256,7 @@ test('can morph text nodes',
     },
 )
 
-test.only('can morph with added element before and siblings are different',
+test('can morph with added element before and siblings are different',
     [html`
         <button>
             <div>
@@ -284,5 +284,21 @@ test.only('can morph with added element before and siblings are different',
                 <div>second</div>
                 <div data="true">third</div>
             `))
+    },
+)
+
+test('can morph multiple nodes',
+    [html`
+        <div x-data>
+            <p></p>
+            <p></p>
+        </div>
+    `],
+    ({ get }, reload, window, document) => {
+        let paragraphs = document.querySelectorAll('p')
+        window.Alpine.morph(paragraphs[0], '<p>1</p')
+        window.Alpine.morph(paragraphs[1], '<p>2</p')
+        get('p:nth-of-type(1)').should(haveText('1'))
+        get('p:nth-of-type(2)').should(haveText('2'))
     },
 )


### PR DESCRIPTION
When running `Alpine.morph()` immediately after another `Alpine.morph()` call, because they are async, they run in a pseudo-concurrent way. Due to the use of global variables, the second run overrides the first one altering the result of the first morph call, see https://codepen.io/SimoTod/pen/vYpKmVZ (expecting 1-2 but getting 2-2).

To make sure that variables are not shared I moved them and most of the functions inside the morph function itself. It could probably be refactored to be a class but I didn't want to make the review more complicated so I changed as little as possible (git is already a bit rubbish at showing this kind of diff, it's probably easier to pull the file locally and compare it with the current version with a split editor).