### PR TITLE
Introduce x-model modifier to preference text over value

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -100,14 +100,10 @@ function generateAssignmentFunction(el, modifiers, expression) {
                         return safeParseNumber(rawValue)
                     })
                     : Array.from(event.target.selectedOptions).map(option => {
-                        if(modifiers.includes('text')) {
-                            return option.text
-                        } else if (modifiers.includes('prefer-text')) {
-                            return option.text || option.value
-                        } else {
-                            return option.value || option.text
-                        }
+                        return option.value || option.text
                     })
+            } else if (el.tagName.toLowerCase() === 'select' && modifiers.includes('text')) {
+                return event.target.options[event.target.selectedIndex].text || event.target.value
             } else {
                 let rawValue = event.target.value
                 return modifiers.includes('number')

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -100,7 +100,13 @@ function generateAssignmentFunction(el, modifiers, expression) {
                         return safeParseNumber(rawValue)
                     })
                     : Array.from(event.target.selectedOptions).map(option => {
-                        return option.value || option.text
+                        if(modifiers.includes('text')) {
+                            return option.text
+                        } else if (modifiers.includes('prefer-text')) {
+                            return option.text || option.value
+                        } else {
+                            return option.value || option.text
+                        }
                     })
             } else {
                 let rawValue = event.target.value

--- a/packages/docs/src/en/directives/model.md
+++ b/packages/docs/src/en/directives/model.md
@@ -337,6 +337,19 @@ The default throttle interval is 250 milliseconds, you can easily customize this
 <input type="text" x-model.throttle.500ms="search">
 ```
 
+<a name="text"></a>
+### `.text`
+
+The HTML element `select` will return the value of the currently selected option when queried, and the inner text only when `value` is missing. To override this default behaviour add `.text` modifier.
+
+```alpine
+<select x-model.text="select">
+  <option value="role1" selected>Admin</option>
+  <option value="role2">User</option>
+</select>
+```
+
+
 <a name="programmatic access"></a>
 ## Programmatic access
 

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -110,3 +110,21 @@ test('x-model can be accessed programmatically',
         get('span').should(haveText('bob'))
     }
 )
+
+test('x-model text modifier for `text` should set x-data to the inner text of an option list',
+    html`
+    <div x-data="{select: $el.querySelector('option').text}">
+        <select name="user[role]" x-model.text="select">
+          <option value="role1" selected="">Admin</option>
+          <option value="role2">User</option>
+        </select>
+
+        <span x-text="select"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('Admin'))
+        get('select').select('User')
+        get('span').should(haveText('User'))
+    }
+)


### PR DESCRIPTION
Adds two new modifiers `.text` and `.prefer-text` for use with Select and Options tags.

### Current behaviour
If you have the following code:

```html
<select name="user[role]" x-model="select">
  <option value="role1" selected="">Admin</option>
  <option value="role2">User</option>
</select>
```

The text inside `<span x-text="select"></span>` would be `role1`.

However, 

```html
<select name="user[role]" x-model="select">
  <option selected="">Admin</option>
  <option>User</option>
</select>
```

The text inside `<span x-text="select"></span>` would be `Admin`.

### PR behaviour

#### Using .text modifier

```html
<select name="user[role]" x-model.text="select">
  <option value="role1" selected="">Admin</option>
  <option value="role2">User</option>
</select>
```

The text inside `<span x-text="select"></span>` would be `Admin`.

#### Using .prefer-text modifier
The text inside `<span x-text="select"></span>` would be `Admin` provided an inner was present. Failing that it would fall back to value.