### PR TITLE
Add missing x-data at x-for docs

### DIFF
--- a/packages/docs/src/en/directives/for.md
+++ b/packages/docs/src/en/directives/for.md
@@ -77,7 +77,7 @@ You can also access the index inside a dynamic `:key` expression.
 If you need to simply loop `n` number of times, rather than iterate through an array, Alpine offers a short syntax.
 
 ```alpine
-<ul>
+<ul x-data>
     <template x-for="i in 10">
         <li x-text="i"></li>
     </template>


### PR DESCRIPTION
The x-for range docs are missing the empty x-data.

I was testing some functionality and the x-for wasn't working, I checked the docs and copy-pasted the example, wasn't working either.

Finally had to check the test to find out why it wasn't working.
https://github.com/alpinejs/alpine/blob/3b152ced8bd57ced34cbf5bc544942c4f804ad28/tests/cypress/integration/directives/x-for.spec.js#L393-L402

Awesome work by the way Caleb.