### PR TITLE
Fix link in warning

### DIFF
--- a/packages/alpinejs/src/directives/index.js
+++ b/packages/alpinejs/src/directives/index.js
@@ -26,5 +26,5 @@ warnMissingPluginDirective('Intersect', 'intersect', 'intersect')
 warnMissingPluginDirective('Focus', 'trap', 'focus')
 
 function warnMissingPluginDirective(name, directiveName, slug) {
-    directive(directiveName, (el) => warn(`You can't use [x-${directiveName}] without first installing the "${name}" plugin here: https://alpine.dev/plugins/${slug}`, el))
+    directive(directiveName, (el) => warn(`You can't use [x-${directiveName}] without first installing the "${name}" plugin here: https://alpinejs.dev/plugins/${slug}`, el))
 }

--- a/packages/alpinejs/src/magics/index.js
+++ b/packages/alpinejs/src/magics/index.js
@@ -16,5 +16,5 @@ warnMissingPluginMagic('Focus', 'focus', 'focus')
 warnMissingPluginMagic('Persist', 'persist', 'persist')
 
 function warnMissingPluginMagic(name, magicName, slug) {
-    magic(magicName, (el) => warn(`You can't use [$${directiveName}] without first installing the "${name}" plugin here: https://alpine.dev/plugins/${slug}`, el))
+    magic(magicName, (el) => warn(`You can't use [$${directiveName}] without first installing the "${name}" plugin here: https://alpinejs.dev/plugins/${slug}`, el))
 }


### PR DESCRIPTION
The link in the warnings goes to `alpine.dev`, which doesn't resolve.

i guess it should be `alpinejs.dev`