### PR TITLE
Attempt memory leak fix from using magics

### DIFF
--- a/packages/alpinejs/src/magics.js
+++ b/packages/alpinejs/src/magics.js
@@ -19,9 +19,12 @@ export function injectMagics(obj, el) {
                 
                 onElRemoved(el, cleanup)
 
-                return callback(el, utilities)
-            },
+                const value = callback(el, utilities)
+                Object.defineProperty(this, `$${name}`, { value: value });
 
+                return value
+            },
+            configurable: true,
             enumerable: false,
         })
     })

--- a/packages/alpinejs/src/magics.js
+++ b/packages/alpinejs/src/magics.js
@@ -11,20 +11,24 @@ export function magic(name, callback) {
 
 export function injectMagics(obj, el) {
     Object.entries(magics).forEach(([name, callback]) => {
-        Object.defineProperty(obj, `$${name}`, {
-            get() {
+        let memoizedUtilities = null;
+        function getUtilities() {
+            if (memoizedUtilities) {
+                return memoizedUtilities;
+            } else {
                 let [utilities, cleanup] = getElementBoundUtilities(el)
                 
-                utilities = {interceptor, ...utilities}
+                memoizedUtilities = {interceptor, ...utilities}
                 
                 onElRemoved(el, cleanup)
-
-                const value = callback(el, utilities)
-                Object.defineProperty(this, `$${name}`, { value: value });
-
-                return value
+                return memoizedUtilities;
+            }
+        }
+        
+        Object.defineProperty(obj, `$${name}`, {
+            get() {
+                return callback(el, getUtilities());
             },
-            configurable: true,
             enumerable: false,
         })
     })


### PR DESCRIPTION
From https://github.com/alpinejs/alpine/issues/2847 :
> High frequency evaluations of alpine strings that use magics (requestAnimationFrame usage in our case) exacerbate a leak we have found.
> What we observe is that _x_cleanups will grow by 1 every time you use a magic property in an evaluated string, which will eventually cause our web page to crash running out of memory.
> Here is a minimal reproduction of the issue: https://codesandbox.io/s/alpine-memory-broken-mlip56?file=/index.html
> Resize the preview window on that page and you should see that _x_cleanups for the div with id "leaky" grows.

We have two thoughts about potential fixes for this behavior in `injectMagics` function:

1. To memoize the setup/cleanup mechanism to only run once, lazily evaluated.
2. To clean up the previous call eagerly when setting up the new value.

We have an implementation for option 1 (this PR), but that assumes that the `magic` plugin function is only called once for a magic.

I.E. If we had a plugin that did something like this:

```javascript
magic("myplugin", implementation1);
// some time later
magic("myplugin", implementation2);
```

The existing implementation would support this behavior, and option 2 would mitigate this downside, but require mutation.js to have a 'removeOnElRemovedCallback' kinda like this that we didn't quite know how to implement in fullness:

```javascript
export function removeOnElRemovedCallback(el, callback) {
  el._x_cleanups = el._x_cleanups.filter(cb => cb !== callback);
}
```

Sorry I couldn't figure out how to get codesandbox to host my fixed version to illustrate :(