### PR TITLE
add `x-ref` binding example

### DIFF
--- a/packages/docs/src/en/directives/bind.md
+++ b/packages/docs/src/en/directives/bind.md
@@ -174,6 +174,7 @@ The object keys can be anything you would normally write as an attribute name in
             open: false,
 
             trigger: {
+                ['x-ref']: 'trigger',
                 ['@click']() {
                     this.open = true
                 },


### PR DESCRIPTION
based on the current documentation I was trying to setup an `x-ref` via a binding with 

```js
trigger: {
    ['x-ref']() {
        return 'trigger';
    },
},
```

which does not work.

After some trial and error I got it to work with 

```js
trigger: {
    ['x-ref']: 'trigger',
},
```

so I figured I'd add it to the docs so no one needs to struggle like I did 😄 