### PR TITLE
Add Promise to $nextTick

### DIFF
--- a/packages/alpinejs/src/nextTick.js
+++ b/packages/alpinejs/src/nextTick.js
@@ -3,14 +3,19 @@ let tickStack = []
 
 let isHolding = false
 
-export function nextTick(callback) {
-    tickStack.push(callback)
-
-    queueMicrotask(() => {
-        isHolding || setTimeout(() => {
-            releaseNextTicks()
-        })
+export function nextTick(callback = () => {}) {
+  queueMicrotask(() => {
+    isHolding || setTimeout(() => {
+      releaseNextTicks()
     })
+  })
+
+  return new Promise((res) => {
+    tickStack.push(() => {
+        callback();
+        res();
+    });
+  })
 }
 
 export function releaseNextTicks() {

--- a/packages/docs/src/en/magics/nextTick.md
+++ b/packages/docs/src/en/magics/nextTick.md
@@ -21,3 +21,22 @@ title: nextTick
 ```
 
 In the above example, rather than logging "Hello" to the console, "Hello World!" will be logged because `$nextTick` was used to wait until Alpine was finished updating the DOM.
+
+<a name="promises"></a>
+
+## Promises
+
+`$nextTick` returns a promise, allowing the use of `$nextTick` to pause an async function until after pending dom updates. When used like this, `$nextTick` also does not require an argument to be passed.
+
+```alpine
+<div x-data="{ title: 'Hello' }">
+    <button
+        @click="
+            title = 'Hello World!';
+            await $nextTick();
+            console.log($el.innerText);
+        "
+        x-text="title"
+    ></button>
+</div>
+```


### PR DESCRIPTION
To bring the functionality more inline with [Vue's implementation](https://v2.vuejs.org/v2/api/?redirect=true#Vue-nextTick) of `$nextTick`, the magic returns a Promise that resolves when the callback is run.

This allows pausing your own functions until after pending DOM updates without needing to handle your own scheduling.

Shouldn't break anything since nobody should be assigning the output of `$nextTick` to anything anyway.

Side Story:
I was having issues with the reactivity related to an array between two components where the last update to the array would not be reflected in the DOM (and one or two other similar things) and I dove into the Vue reactivity docs and they mentioned using `$nextTick` when there are rendering issues, and I tried it and it worked for Alpine, even without the await 🤷, but I was curious about the implementation and potential benefits of enabling a very Alpiney options for waiting for DOM updates.