### PR TITLE
Added forward-slash named keyboard event

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -159,6 +159,7 @@ function keyToModifiers(key) {
         'right': 'arrow-right',
         'period': '.',
         'equal': '=',
+        'forward-slash': '/',
     }
 
     modifierToKeyMap[key] = key

--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -159,7 +159,6 @@ function keyToModifiers(key) {
         'right': 'arrow-right',
         'period': '.',
         'equal': '=',
-        'forward-slash': '/',
     }
 
     modifierToKeyMap[key] = key

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -89,6 +89,7 @@ For easy reference, here is a list of common keys you may want to listen for.
 | `.caps-lock`                | Caps Lock                   |
 | `.equal`                    | Equal, `=`                  |
 | `.period`                   | Period, `.`                 |
+| `.forward-slash`            | Foward Slash, `/`           |
 
 <a name="custom-events"></a>
 ## Custom events

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -89,7 +89,7 @@ For easy reference, here is a list of common keys you may want to listen for.
 | `.caps-lock`                | Caps Lock                   |
 | `.equal`                    | Equal, `=`                  |
 | `.period`                   | Period, `.`                 |
-| `.forward-slash`            | Foward Slash, `/`           |
+| `.slash`                    | Foward Slash, `/`           |
 
 <a name="custom-events"></a>
 ## Custom events


### PR DESCRIPTION
This PR adds a named key to `packages/alpinejs/utils/on.js`.

Analog to `.` (Period) and `=` (Equal), html attributes may also not contain the `/` ((Forward-Slash) character.