### PR TITLE
Adding thousands separator to x-mask $money

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -160,9 +160,9 @@ export function buildUp(template, input) {
     return output
 }
 
-function formatMoney(input, delimeter = '.', thousands) {
-    thousands = (delimeter === ',' && thousands === undefined)
-        ? '.' : ','
+function formatMoney(input, delimeter = '.', thousands = ',') {
+    thousands = (delimeter === ',' && thousands === ',')
+        ? '.' : thousands
 
     let addThousands = (input, thousands) => {
         let output = ''

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -119,3 +119,18 @@ test('$money swapping commas and periods',
         get('input').type(',89').should(haveValue('1.234.567,89'))
     },
 )
+
+test('$money adding custom thousands separator',
+    [html`<input x-data x-mask:function="$money($input, ',', ' ')">`],
+    ({ get }) => {
+        get('input').type('30,00').should(haveValue('30,00'))
+        get('input').type('5').should(haveValue('30,00'))
+        get('input').type('{backspace}').should(haveValue('30,0'))
+        get('input').type('5').should(haveValue('30,05'))
+        get('input').type('{selectAll}{backspace}').should(haveValue(''))
+        get('input').type('123').should(haveValue('123'))
+        get('input').type('4').should(haveValue('1 234'))
+        get('input').type('567').should(haveValue('1 234 567'))
+        get('input').type(',89').should(haveValue('1 234 567,89'))
+    },
+)


### PR DESCRIPTION
Just a small addition to the new x-mask:dynamic $money to reflect a PHP function behaviour to format numbers and currencies:
https://www.php.net/manual/en/function.number-format.php

In addition to the decimal delimeter swapping, you can specify the thousands separator, for example by a space for the french notation:

```html
<input x-mask:dynamic="$money($input, ',', ' ')">
```

This does not affect the default behaviour for US formatting and the default swapping specified into the documentation.
I will eventually modify the mask documentation if you consider this PR relevant.

Thanks for this great mask plugin!