### PR TITLE
change "Alpine.store(...)" link to /globals/alpine-store

### DIFF
--- a/packages/docs/src/en/magics/store.md
+++ b/packages/docs/src/en/magics/store.md
@@ -6,7 +6,7 @@ title: store
 
 # $store
 
-You can use `$store` to conveniently access global Alpine stores registered using [`Alpine.store(...)`](/magics/store). For example:
+You can use `$store` to conveniently access global Alpine stores registered using [`Alpine.store(...)`](/globals/alpine-store). For example:
 
 ```alpine
 <button x-data @click="$store.darkMode.toggle()">Toggle Dark Mode</button>


### PR DESCRIPTION
currently Alpine.store(...) links to /magics/store, which is counter intuitive, hence change the like to the actual  Alpine.store(...) docs at  /globals/alpine-store