### PR TITLE
Remove space between logical not and variable for docs

### DIFF
--- a/packages/docs/src/en/directives/bind.md
+++ b/packages/docs/src/en/directives/bind.md
@@ -33,7 +33,7 @@ Here's a simple example of a simple dropdown toggle, but instead of using `x-sho
 
 ```alpine
 <div x-data="{ open: false }">
-  <button x-on:click="open = ! open">Toggle Dropdown</button>
+  <button x-on:click="open = !open">Toggle Dropdown</button>
 
   <div :class="open ? '' : 'hidden'">
     Dropdown Contents...
@@ -68,7 +68,7 @@ The inverse is also available to you. Suppose instead of `open`, we use a variab
 Alpine offers an additional syntax for toggling classes if you prefer. By passing a JavaScript object where the classes are the keys and booleans are the values, Alpine will know which classes to apply and which to remove. For example:
 
 ```alpine
-<div :class="{ 'hidden': ! show }">
+<div :class="{ 'hidden': !show }">
 ```
 
 This technique offers a unique advantage to other methods. When using object-syntax, Alpine will NOT preserve original classes applied to an element's `class` attribute.
@@ -76,7 +76,7 @@ This technique offers a unique advantage to other methods. When using object-syn
 For example, if you wanted to apply the "hidden" class to an element before Alpine loads, AND use Alpine to toggle its existence you can only achieve that behavior using object-syntax:
 
 ```alpine
-<div class="hidden" :class="{ 'hidden': ! show }">
+<div class="hidden" :class="{ 'hidden': !show }">
 ```
 
 In case that confused you, let's dig deeper into how Alpine handles `x-bind:class` differently than other attributes.

--- a/packages/docs/src/en/directives/data.md
+++ b/packages/docs/src/en/directives/data.md
@@ -13,7 +13,7 @@ Here's an example of a contrived dropdown component:
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle Content</button>
+    <button @click="open = !open">Toggle Content</button>
 
     <div x-show="open">
         Content...
@@ -52,7 +52,7 @@ Because `x-data` is evaluated as a normal JavaScript object, in addition to stat
 For example, let's extract the "Toggle Content" behavior into a method on  `x-data`.
 
 ```alpine
-<div x-data="{ open: false, toggle() { this.open = ! this.open } }">
+<div x-data="{ open: false, toggle() { this.open = !this.open } }">
     <button @click="toggle()">Toggle Content</button>
 
     <div x-show="open">
@@ -61,7 +61,7 @@ For example, let's extract the "Toggle Content" behavior into a method on  `x-da
 </div>
 ```
 
-Notice the added `toggle() { this.open = ! this.open }` method on `x-data`. This method can now be called from anywhere inside the component.
+Notice the added `toggle() { this.open = !this.open }` method on `x-data`. This method can now be called from anywhere inside the component.
 
 You'll also notice the usage of `this.` to access state on the object itself. This is because Alpine evaluates this data object like any standard JavaScript object with a `this` context.
 
@@ -88,7 +88,7 @@ Let's refactor our component to use a getter called `isOpen` instead of accessin
 <div x-data="{
   open: false,
   get isOpen() { return this.open },
-  toggle() { this.open = ! this.open },
+  toggle() { this.open = !this.open },
 }">
     <button @click="toggle()">Toggle Content</button>
 
@@ -160,7 +160,7 @@ Here's a quick example:
             open: false,
 
             toggle() {
-                this.open = ! this.open
+                this.open = !this.open
             },
         }))
     })

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -156,7 +156,7 @@ In the above example, clicking the button WON'T log the message. This is because
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle</button>
+    <button @click="open = !open">Toggle</button>
 
     <div x-show="open" @click.outside="open = false">
         Contents...

--- a/packages/docs/src/en/directives/show.md
+++ b/packages/docs/src/en/directives/show.md
@@ -11,7 +11,7 @@ Here's an example of a simple dropdown component using `x-show`.
 
 ```alpine
 <div x-data="{ open: false }">
-    <button x-on:click="open = ! open">Toggle Dropdown</button>
+    <button x-on:click="open = !open">Toggle Dropdown</button>
 
     <div x-show="open">
         Dropdown Contents...
@@ -30,7 +30,7 @@ If you want to apply smooth transitions to the `x-show` behavior, you can use it
 
 ```alpine
 <div x-data="{ open: false }">
-    <button x-on:click="open = ! open">Toggle Dropdown</button>
+    <button x-on:click="open = !open">Toggle Dropdown</button>
 
     <div x-show="open" x-transition>
         Dropdown Contents...

--- a/packages/docs/src/en/directives/teleport.md
+++ b/packages/docs/src/en/directives/teleport.md
@@ -27,7 +27,7 @@ Here's a contrived modal example:
 ```alpine
 <body>
     <div x-data="{ open: false }">
-        <button @click="open = ! open">Toggle Modal</button>
+        <button @click="open = !open">Toggle Modal</button>
 
         <template x-teleport="body">
             <div x-show="open">
@@ -46,7 +46,7 @@ Here's a contrived modal example:
 <!-- START_VERBATIM -->
 <div class="demo" x-ref="root" id="modal2">
     <div x-data="{ open: false }">
-        <button @click="open = ! open">Toggle Modal</button>
+        <button @click="open = !open">Toggle Modal</button>
 
         <template x-teleport="#modal2">
             <div x-show="open">
@@ -73,7 +73,7 @@ To make this experience more seamless, you can "forward" events by simply regist
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle Modal</button>
+    <button @click="open = !open">Toggle Modal</button>
 
     <template x-teleport="body" @click="open = false">
         <div x-show="open">
@@ -87,7 +87,7 @@ To make this experience more seamless, you can "forward" events by simply regist
 <!-- START_VERBATIM -->
 <div class="demo" x-ref="root" id="modal3">
     <div x-data="{ open: false }">
-        <button @click="open = ! open">Toggle Modal</button>
+        <button @click="open = !open">Toggle Modal</button>
 
         <template x-teleport="#modal3" @click="open = false">
             <div x-show="open">
@@ -110,14 +110,14 @@ Teleporting is especially helpful if you are trying to nest one modal within ano
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle Modal</button>
+    <button @click="open = !open">Toggle Modal</button>
 
     <template x-teleport="body">
         <div x-show="open">
             Modal contents...
             
             <div x-data="{ open: false }">
-                <button @click="open = ! open">Toggle Nested Modal</button>
+                <button @click="open = !open">Toggle Nested Modal</button>
 
                 <template x-teleport="body">
                     <div x-show="open">
@@ -133,14 +133,14 @@ Teleporting is especially helpful if you are trying to nest one modal within ano
 <!-- START_VERBATIM -->
 <div class="demo" x-ref="root" id="modal4">
     <div x-data="{ open: false }">
-        <button @click="open = ! open">Toggle Modal</button>
+        <button @click="open = !open">Toggle Modal</button>
 
         <template x-teleport="#modal4">
             <div x-show="open">
                 <div class="py-4">Modal contents...</div>
                 
                 <div x-data="{ open: false }">
-                    <button @click="open = ! open">Toggle Nested Modal</button>
+                    <button @click="open = !open">Toggle Nested Modal</button>
 
                     <template x-teleport="#modal4">
                         <div class="pt-4" x-show="open">

--- a/packages/docs/src/en/directives/transition.md
+++ b/packages/docs/src/en/directives/transition.md
@@ -19,7 +19,7 @@ The simplest way to achieve a transition using Alpine is by adding `x-transition
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle</button>
+    <button @click="open = !open">Toggle</button>
 
     <span x-show="open" x-transition>
         Hello 👋
@@ -30,7 +30,7 @@ The simplest way to achieve a transition using Alpine is by adding `x-transition
 <!-- START_VERBATIM -->
 <div class="demo">
     <div x-data="{ open: false }">
-        <button @click="open = ! open">Toggle</button>
+        <button @click="open = !open">Toggle</button>
 
         <span x-show="open" x-transition>
             Hello 👋
@@ -135,7 +135,7 @@ For direct control over exactly what goes into your transitions, you can apply C
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle</button>
+    <button @click="open = !open">Toggle</button>
 
     <div
         x-show="open"
@@ -152,7 +152,7 @@ For direct control over exactly what goes into your transitions, you can apply C
 <!-- START_VERBATIM -->
 <div class="demo">
     <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle</button>
+    <button @click="open = !open">Toggle</button>
 
     <div
         x-show="open"

--- a/packages/docs/src/en/essentials/state.md
+++ b/packages/docs/src/en/essentials/state.md
@@ -74,7 +74,7 @@ Alpine.data('dropdown', () => ({
     open: false,
 
     toggle() {
-        this.open = ! this.open
+        this.open = !this.open
     }
 }))
 ```

--- a/packages/docs/src/en/essentials/templating.md
+++ b/packages/docs/src/en/essentials/templating.md
@@ -58,7 +58,7 @@ Here's a simple toggle component using `x-show`.
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Expand</button>
+    <button @click="open = !open">Expand</button>
 
     <div x-show="open">
         Content...
@@ -68,7 +68,7 @@ Here's a simple toggle component using `x-show`.
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open" :aria-pressed="open">Expand</button>
+    <button @click="open = !open" :aria-pressed="open">Expand</button>
 
     <div x-show="open">
         Content...
@@ -91,7 +91,7 @@ Here is the same toggle from before, but this time using `x-if` instead of `x-sh
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Expand</button>
+    <button @click="open = !open">Expand</button>
 
     <template x-if="open">
         <div>
@@ -103,7 +103,7 @@ Here is the same toggle from before, but this time using `x-if` instead of `x-sh
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open" :aria-pressed="open">Expand</button>
+    <button @click="open = !open" :aria-pressed="open">Expand</button>
 
     <template x-if="open">
         <div>
@@ -130,7 +130,7 @@ Here is, again, the simple toggle example, but this time with transitions applie
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Expands</button>
+    <button @click="open = !open">Expands</button>
 
     <div x-show="open" x-transition>
         Content...
@@ -140,7 +140,7 @@ Here is, again, the simple toggle example, but this time with transitions applie
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open">Expands</button>
+    <button @click="open = !open">Expands</button>
 
     <div class="flex">
         <div x-show="open" x-transition style="will-change: transform;">
@@ -176,7 +176,7 @@ Let's say you wanted to make the duration of the transition longer, you can manu
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open">Expands</button>
+    <button @click="open = !open">Expands</button>
 
     <div class="flex">
         <div x-show="open" x-transition.duration.500ms style="will-change: transform;">
@@ -200,7 +200,7 @@ If you want to specify different values for in and out transitions, you can use 
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open">Expands</button>
+    <button @click="open = !open">Expands</button>
 
     <div class="flex">
         <div x-show="open" x-transition:enter.duration.500ms x-transition:leave.duration.1000ms style="will-change: transform;">
@@ -218,7 +218,7 @@ Additionally, you can add either `.opacity` or `.scale` to only transition that 
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open">Expands</button>
+    <button @click="open = !open">Expands</button>
 
     <div class="flex">
         <div x-show="open" x-transition:enter.opacity.duration.500 x-transition:leave.opacity.duration.250>
@@ -249,7 +249,7 @@ If you need more fine-grained control over the transitions in your application, 
 
 <!-- START_VERBATIM -->
 <div x-data="{ open: false }" class="demo">
-    <button @click="open = ! open">Expands</button>
+    <button @click="open = !open">Expands</button>
 
     <div class="flex">
         <div
@@ -281,7 +281,7 @@ Here is an example of a dynamically bound `class` attribute:
 <button
     x-data="{ red: false }"
     x-bind:class="red ? 'bg-red' : ''"
-    @click="red = ! red"
+    @click="red = !red"
 >
     Toggle Red
 </button>
@@ -292,7 +292,7 @@ Here is an example of a dynamically bound `class` attribute:
     <button
         x-data="{ red: false }"
         x-bind:style="red && 'background: red'"
-        @click="red = ! red"
+        @click="red = !red"
     >
         Toggle Red
     </button>
@@ -310,7 +310,7 @@ Toggling classes on and off based on data inside Alpine is a common need. Here's
 
 ```alpine
 <div x-data="{ open: true }">
-    <span :class="{ 'hidden': ! open }">...</span>
+    <span :class="{ 'hidden': !open }">...</span>
 </div>
 ```
 

--- a/packages/docs/src/en/globals/alpine-data.md
+++ b/packages/docs/src/en/globals/alpine-data.md
@@ -22,7 +22,7 @@ Here's a contrived `dropdown` component for example:
             open: false,
 
             toggle() {
-                this.open = ! this.open
+                this.open = !this.open
             }
         }))
     })
@@ -52,7 +52,7 @@ export default () => ({
     open: false,
 
     toggle() {
-        this.open = ! this.open
+        this.open = !this.open
     }
 })
 ```
@@ -123,7 +123,7 @@ Alpine.data('dropdown', () => ({
 
     trigger: {
         ['@click']() {
-            this.open = ! this.open
+            this.open = !this.open
         },
     },
 

--- a/packages/docs/src/en/globals/alpine-store.md
+++ b/packages/docs/src/en/globals/alpine-store.md
@@ -20,7 +20,7 @@ You can either define an Alpine store inside of an `alpine:init` listener (in th
             on: false,
 
             toggle() {
-                this.on = ! this.on
+                this.on = !this.on
             }
         })
     })
@@ -35,7 +35,7 @@ Alpine.store('darkMode', {
     on: false,
 
     toggle() {
-        this.on = ! this.on
+        this.on = !this.on
     }
 })
 
@@ -81,7 +81,7 @@ If you provide `init()` method in an Alpine store, it will be executed right aft
             on: false,
 
             toggle() {
-                this.on = ! this.on
+                this.on = !this.on
             }
         })
     })
@@ -98,7 +98,7 @@ If you don't need an entire object for a store, you can set and use any kind of 
 Here's the example from above but using it more simply as a boolean value:
 
 ```alpine
-<button x-data @click="$store.darkMode = ! $store.darkMode">Toggle Dark Mode</button>
+<button x-data @click="$store.darkMode = !$store.darkMode">Toggle Dark Mode</button>
 
 ...
 

--- a/packages/docs/src/en/magics/store.md
+++ b/packages/docs/src/en/magics/store.md
@@ -24,7 +24,7 @@ You can use `$store` to conveniently access global Alpine stores registered usin
             on: false,
 
             toggle() {
-                this.on = ! this.on
+                this.on = !this.on
             }
         })
     })
@@ -41,7 +41,7 @@ If you don't need an entire object for a store, you can set and use any kind of 
 Here's the example from above but using it more simply as a boolean value:
 
 ```alpine
-<button x-data @click="$store.darkMode = ! $store.darkMode">Toggle Dark Mode</button>
+<button x-data @click="$store.darkMode = !$store.darkMode">Toggle Dark Mode</button>
 
 ...
 

--- a/packages/docs/src/en/magics/watch.md
+++ b/packages/docs/src/en/magics/watch.md
@@ -9,7 +9,7 @@ You can "watch" a component property using the `$watch` magic method. For exampl
 
 ```alpine
 <div x-data="{ open: false }" x-init="$watch('open', value => console.log(value))">
-    <button @click="open = ! open">Toggle Open</button>
+    <button @click="open = !open">Toggle Open</button>
 </div>
 ```
 
@@ -32,7 +32,7 @@ When the `<button>` is pressed, `foo.bar` will be set to "bob", and "bob" will b
 
 ```alpine
 <div x-data="{ open: false }" x-init="$watch('open', (value, oldValue) => console.log(value, oldValue))">
-    <button @click="open = ! open">Toggle Open</button>
+    <button @click="open = !open">Toggle Open</button>
 </div>
 ```
 

--- a/packages/docs/src/en/plugins/collapse.md
+++ b/packages/docs/src/en/plugins/collapse.md
@@ -58,7 +58,7 @@ For example:
 
 ```alpine
 <div x-data="{ expanded: false }">
-    <button @click="expanded = ! expanded">Toggle Content</button>
+    <button @click="expanded = !expanded">Toggle Content</button>
 
     <p x-show="expanded" x-collapse>
         ...
@@ -68,7 +68,7 @@ For example:
 
 <!-- START_VERBATIM -->
 <div x-data="{ expanded: false }" class="demo">
-    <button @click="expanded = ! expanded">Toggle Content</button>
+    <button @click="expanded = !expanded">Toggle Content</button>
 
     <div x-show="expanded" x-collapse>
         <div class="pt-4">
@@ -88,7 +88,7 @@ You can customize the duration of the collapse/expand transition by appending th
 
 ```alpine
 <div x-data="{ expanded: false }">
-    <button @click="expanded = ! expanded">Toggle Content</button>
+    <button @click="expanded = !expanded">Toggle Content</button>
 
     <p x-show="expanded" x-collapse.duration.1000ms>
         ...
@@ -98,7 +98,7 @@ You can customize the duration of the collapse/expand transition by appending th
 
 <!-- START_VERBATIM -->
 <div x-data="{ expanded: false }" class="demo">
-    <button @click="expanded = ! expanded">Toggle Content</button>
+    <button @click="expanded = !expanded">Toggle Content</button>
 
     <div x-show="expanded" x-collapse.duration.1000ms>
         <div class="pt-4">
@@ -117,7 +117,7 @@ Sometimes, it's helpful to "cut-off" an element rather than fully hide it. By us
 
 ```alpine
 <div x-data="{ expanded: false }">
-    <button @click="expanded = ! expanded">Toggle Content</button>
+    <button @click="expanded = !expanded">Toggle Content</button>
 
     <p x-show="expanded" x-collapse.min.50px>
         ...
@@ -127,7 +127,7 @@ Sometimes, it's helpful to "cut-off" an element rather than fully hide it. By us
 
 <!-- START_VERBATIM -->
 <div x-data="{ expanded: false }" class="demo">
-    <button @click="expanded = ! expanded">Toggle Content</button>
+    <button @click="expanded = !expanded">Toggle Content</button>
 
     <div x-show="expanded" x-collapse.min.50px>
         <div class="pt-4">

--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -54,7 +54,7 @@ Alpine.plugin(mask)
 
 </div>
 </div>
-<button :aria-expanded="expanded" @click="expanded = ! expanded" class="text-cyan-600 font-medium underline">
+<button :aria-expanded="expanded" @click="expanded = !expanded" class="text-cyan-600 font-medium underline">
     <span x-text="expanded ? 'Hide' : 'Show more'">Show</span> <span x-text="expanded ? '↑' : '↓'">↓</span>
 </button>
  </div>

--- a/packages/docs/src/en/start-here.md
+++ b/packages/docs/src/en/start-here.md
@@ -116,7 +116,7 @@ Insert the following code into the `<body>` tag:
 
 ```alpine
 <div x-data="{ open: false }">
-    <button @click="open = ! open">Toggle</button>
+    <button @click="open = !open">Toggle</button>
 
     <div x-show="open" @click.outside="open = false">Contents...</div>
 </div>
@@ -125,7 +125,7 @@ Insert the following code into the `<body>` tag:
 <!-- START_VERBATIM -->
 <div class="demo">
     <div x-data="{ open: false }">
-        <button @click="open = ! open">Toggle</button>
+        <button @click="open = !open">Toggle</button>
         <div x-show="open" @click.outside="open = false">Contents...</div>
     </div>
 </div>

--- a/packages/docs/src/en/upgrade-guide.md
+++ b/packages/docs/src/en/upgrade-guide.md
@@ -239,7 +239,7 @@ One of Alpine's stories for re-using functionality is abstracting Alpine directi
             open: false,
 
             trigger: {
-                'x-on:click'() { this.open = ! this.open },
+                'x-on:click'() { this.open = !this.open },
             },
 
             dialogue: {


### PR DESCRIPTION
Hello there 👋 
When I go over the docs for Alpine.js I find expressions that make use of the logical not operator have a space between it and the corresponding variable. Like this:
```
this.open = ! this.open
```
It sounds a bit silly, but I found myself re-reading the expression to make sure I understood what I saw. Since the the [standard convention is to have no spaces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT), perhaps we could apply it here as well:
```
this.open = !this.open
```

Most the codebase files make use of this particular styling as well. It works, but it looks a bit odd.
I figured we could make it clear for the documentation examples 🙂 

If this gets approved maybe we could do the same for the codebase (separate PR). Let me know what you think.

