### PR TITLE
Allow disabling x-mask with a `falsy` value

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -48,6 +48,9 @@ export default function (Alpine) {
 
             let template = templateFn(input)
 
+            // If a template value is `falsy`, then don't process the input value
+            if(!template) return false
+
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
                 return lastInputValue = el.value

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -49,7 +49,7 @@ export default function (Alpine) {
             let template = templateFn(input)
 
             // If a template value is `falsy`, then don't process the input value
-            if(!template) return false
+            if(!template || template === 'false') return false
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -60,6 +60,30 @@ test('x-mask with x-model',
     },
 )
 
+test('x-mask with a falsy input',
+    [html`<input x-data x-mask="">`],
+    ({ get }) => {
+	    get('input').type('1').should(haveValue('1'))
+	    get('input').type('2').should(haveValue('12'))
+	    get('input').type('ua').should(haveValue('12ua'))
+	    get('input').type('/').should(haveValue('12ua/'))
+	    get('input').type('cs').should(haveValue('12ua/cs'))
+	    get('input').type('  3').should(haveValue('12ua/cs  3'))
+    }
+)
+
+test('x-mask with a falsy string input',
+    [html`<input x-data x-mask="false">`],
+    ({ get }) => {
+	    get('input').type('1').should(haveValue('1'))
+	    get('input').type('2').should(haveValue('12'))
+	    get('input').type('ua').should(haveValue('12ua'))
+	    get('input').type('/').should(haveValue('12ua/'))
+	    get('input').type('cs').should(haveValue('12ua/cs'))
+	    get('input').type('  3').should(haveValue('12ua/cs  3'))
+    }
+)
+
 test('x-mask with non wildcard alpha-numeric characters (b)',
     [html`<input x-data x-mask="ba9*b">`],
     ({ get }) => {
@@ -68,7 +92,7 @@ test('x-mask with non wildcard alpha-numeric characters (b)',
         get('input').type('3').should(haveValue('ba3'))
         get('input').type('z').should(haveValue('ba3zb'))
         get('input').type('{backspace}{backspace}4').should(haveValue('ba34b'))
-    },
+    }
 )
 
 test('x-mask:dynamic',


### PR DESCRIPTION
Hi,

I have a specific use case for the Mask plugin, where the user selects an international phone code and the input value gets formatted accordingly.

<img width="691" alt="Screenshot 2022-05-20 at 12 22 01" src="https://user-images.githubusercontent.com/47005900/169517665-02491368-2dac-47ed-86a1-d9c8f4b483c3.png">

<img width="701" alt="Screenshot 2022-05-20 at 12 22 19" src="https://user-images.githubusercontent.com/47005900/169517686-247b0829-997a-457f-bd9c-97ff510de606.png">

However, the user should also have an option to type the number without being forced the format (in a case, the format is not available in the list). Example:

<img width="684" alt="Screenshot 2022-05-20 at 12 27 33" src="https://user-images.githubusercontent.com/47005900/169518401-be38b772-5034-4b8d-9c31-a78d8b95c472.png">

In the end, the example code looks like this:

```
x-mask:dynamic="selectValue ? `${options[selectValue].international} ${options[selectValue].format}` : false"

// Above translates to:
x-mask:dynamic="'cz' ? `+420 999 999 999` : false" --> +420 987 654 321

// Or:
x-mask:dynamic="null ? `` : false" --> no forced formatting
```

And that's what this PR allows for. Let me know if anything needs changing.