### PR TITLE
Adds autofocus awareness to the focus plugin

### DIFF
--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -106,6 +106,7 @@ export default function (Alpine) {
                 escapeDeactivates: false,
                 allowOutsideClick: true,
                 fallbackFocus: () => el,
+                initialFocus: el.querySelector('[autofocus]')
             })
 
             let undoInert = () => {}

--- a/tests/cypress/integration/plugins/focus.spec.js
+++ b/tests/cypress/integration/plugins/focus.spec.js
@@ -307,3 +307,29 @@ test('$focus.last',
         get('#1').should(haveText('3'))
     },
 )
+
+test('focuses element with autofocus',
+    [html`
+        <div x-data="{ open: false }">
+            <input type="text" id="1">
+            <button id="2" @click="open = true">open</button>
+            <div>
+                <div x-trap="open">
+                    <input type="text" id="3">
+                    <input autofocus type="text" id="4">
+                    <button @click="open = false" id="5">close</button>
+                </div>
+            </div>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').click()
+        get('#1').should(haveFocus())
+        get('#2').click()
+        get('#4').should(haveFocus())
+        cy.focused().tab()
+        get('#5').should(haveFocus())
+        cy.focused().tab()
+        get('#3').should(haveFocus())
+    }
+)


### PR DESCRIPTION
Currently, when using `x-trap`, the first child element in the tab order is focused per the `focus-trap` package defaults. This pull request adds a more sensible default by focusing the first element that has the `autofocus` attribute. If none is found, the first child element in the tab order is focused.

I could see this being especially helpful in the context of modals and drawers.