### PR TITLE
Fix x-show updating DOM inconsistently if state changes too fast

### DIFF
--- a/packages/alpinejs/src/directives/x-transition.js
+++ b/packages/alpinejs/src/directives/x-transition.js
@@ -131,7 +131,8 @@ window.Element.prototype._x_toggleAndCascadeWithTransitions = function (el, valu
     // it keeps running in background. setTimeout has a lower priority in the
     // event loop so it would skip nested transitions but when the tab is
     // hidden, it's not relevant.
-    let clickAwayCompatibleShow = () => {document.visibilityState === 'visible' ? requestAnimationFrame(show) : setTimeout(show)}
+    const nextTick = document.visibilityState === 'visible' ? requestAnimationFrame : setTimeout;
+    let clickAwayCompatibleShow = () => nextTick(show);
 
     if (value) {
         if (el._x_transition && (el._x_transition.enter || el._x_transition.leave)) {
@@ -167,7 +168,7 @@ window.Element.prototype._x_toggleAndCascadeWithTransitions = function (el, valu
 
             closest._x_hideChildren.push(el)
         } else {
-            queueMicrotask(() => {
+            nextTick(() => {
                 let hideAfterChildren = el => {
                     let carry = Promise.all([
                         el._x_hidePromise,

--- a/tests/cypress/integration/directives/x-show.spec.js
+++ b/tests/cypress/integration/directives/x-show.spec.js
@@ -148,7 +148,7 @@ test('x-show executes consecutive state changes in correct order',
     html`
         <div
             x-data="{ isEnabled: false }"
-            x-init="$watch('isEnabled', () => if (this.isEnabled) this.isEnabled = false)"
+            x-init="$watch('isEnabled', () => { if (isEnabled) isEnabled = false })"
         >
             <button id="enable" x-show="!isEnabled" @click="isEnabled = true"></button>
             <button id="disable" x-show="isEnabled" @click="isEnabled = false"></button>

--- a/tests/cypress/integration/directives/x-show.spec.js
+++ b/tests/cypress/integration/directives/x-show.spec.js
@@ -143,3 +143,19 @@ test('x-show takes precedence over style bindings for display property',
         get('span:nth-of-type(2)').should(haveAttribute('style', 'color: red; display: none;'))
     }
 )
+
+test('x-show executes consecutive state changes in correct order',
+    html`
+        <div
+            x-data="{ isEnabled: false }"
+            x-init="$watch('isEnabled', () => if (this.isEnabled) this.isEnabled = false)"
+        >
+            <button id="enable" x-show="!isEnabled" @click="isEnabled = true"></button>
+            <button id="disable" x-show="isEnabled" @click="isEnabled = false"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button#enable').should(beVisible())
+        get('button#disable').should(beHidden())
+    }
+)


### PR DESCRIPTION
This fixes a bug where multiple consecutive state changes in a short time cause x-show to update the DOM in an inconsistent way so that elements that should be hidden are visible. Demo: https://codepen.io/mgschoen/pen/XWZqprb 

This is caused by using `requestAnimationFrame` or `setTimeout` for the `show()` method, but `queueMicrotask()` for the `hide()` method, causing `hide()` calls from multiple state updates to be fired before the first `show()` call, effectively showing elements that should actually be hidden.

This bug has also been reported in https://github.com/alpinejs/alpine/issues/2803#issuecomment-1126751072