### PR TITLE
Allow for using x-show with an important modifier

### DIFF
--- a/packages/alpinejs/src/directives/x-show.js
+++ b/packages/alpinejs/src/directives/x-show.js
@@ -9,7 +9,9 @@ directive('show', (el, { modifiers, expression }, { effect }) => {
     // We're going to set this function on the element directly so that
     // other plugins like "Collapse" can overwrite them with their own logic.
     if (! el._x_doHide) el._x_doHide = () => {
-        mutateDom(() => el.style.display = 'none')
+        mutateDom(() => {
+            el.style.setProperty('display', 'none', modifiers.includes('important') ? 'important' : undefined)
+        })
     }
 
     if (! el._x_doShow) el._x_doShow = () => {

--- a/packages/docs/src/en/directives/show.md
+++ b/packages/docs/src/en/directives/show.md
@@ -37,3 +37,20 @@ If you want to apply smooth transitions to the `x-show` behavior, you can use it
     </div>
 </div>
 ```
+
+<a name="using-the-important-modifier"></a>
+## Using the important modifier
+
+Sometimes you need to apply a little more force to actually hide an element. In cases where you a CSS selector applies the `display` property with the `!important` flag, it will take precedence over the inline style set by Alpine.
+
+In these cases you may use the `.important` modifier to set the inline style to `display: none !important`.
+
+```alpine
+<div x-data="{ open: false }">
+    <button x-on:click="open = ! open">Toggle Dropdown</button>
+
+    <div x-show.important="open">
+        Dropdown Contents...
+    </div>
+</div>
+```

--- a/packages/docs/src/en/directives/show.md
+++ b/packages/docs/src/en/directives/show.md
@@ -41,7 +41,7 @@ If you want to apply smooth transitions to the `x-show` behavior, you can use it
 <a name="using-the-important-modifier"></a>
 ## Using the important modifier
 
-Sometimes you need to apply a little more force to actually hide an element. In cases where you a CSS selector applies the `display` property with the `!important` flag, it will take precedence over the inline style set by Alpine.
+Sometimes you need to apply a little more force to actually hide an element. In cases where a CSS selector applies the `display` property with the `!important` flag, it will take precedence over the inline style set by Alpine.
 
 In these cases you may use the `.important` modifier to set the inline style to `display: none !important`.
 

--- a/tests/cypress/integration/directives/x-show.spec.js
+++ b/tests/cypress/integration/directives/x-show.spec.js
@@ -159,3 +159,20 @@ test('x-show executes consecutive state changes in correct order',
         get('button#disable').should(beHidden())
     }
 )
+
+test('x-show toggles display: none; with the !important property when using the .important modifier while respecting other style attributes',
+    html`
+        <div x-data="{ show: true }">
+            <span x-show.important="show" style="color: blue;">thing</span>
+
+            <button x-on:click="show = false"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(beVisible())
+        get('span').should(haveAttribute('style', 'color: blue;'))
+        get('button').click()
+        get('span').should(beHidden())
+        get('span').should(haveAttribute('style', 'color: blue; display: none !important;'))
+    }
+)


### PR DESCRIPTION
Following up on [this discussion](https://github.com/alpinejs/alpine/discussions/1415).

There are cases where someone may use a class which itself sets the `display` property. If it is set with the `!important` property `x-show` stops working as expected because the class will always take precedence.

This PR adds an `.important` modifier to `x-show` which sets the inline style with `!important` itself.

I've added a test and updated the docs, please let me know if there are other changes needed :)