### PR TITLE
Add warning about x-if directive and livewire

### DIFF
--- a/packages/docs/src/en/directives/if.md
+++ b/packages/docs/src/en/directives/if.md
@@ -18,3 +18,5 @@ Because of this difference in behavior, `x-if` should not be applied directly to
 > Unlike `x-show`, `x-if`, does NOT support transitioning toggles with `x-transition`.
 
 > Remember: `<template>` tags can only contain one root level element.
+
+> Warning: `<template>` tags can't contains livewire component. Use `x-show` directive instead of `x-if`


### PR DESCRIPTION
Today, I past 4 hours of debugging about one Livewire component inside a `<template>` tag. 

The directive `x-if` don't work with any Livewire component, for this reason : The Livewire component generated by Laravel backend can't be removed and regenerated dynamically by JavaScript on the frontend.