### PR TITLE
Allow x-modelable to be a descendant of x-model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,10 @@
             "resolved": "packages/intersect",
             "link": true
         },
+        "node_modules/@alpinejs/mask": {
+            "resolved": "packages/mask",
+            "link": true
+        },
         "node_modules/@alpinejs/morph": {
             "resolved": "packages/morph",
             "link": true
@@ -52,10 +56,6 @@
         },
         "node_modules/@alpinejs/portal": {
             "resolved": "packages/portal",
-            "link": true
-        },
-        "node_modules/@alpinejs/trap": {
-            "resolved": "packages/trap",
             "link": true
         },
         "node_modules/@babel/code-frame": {
@@ -7806,7 +7806,7 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.9.0",
+            "version": "3.10.2",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7814,7 +7814,7 @@
         },
         "packages/collapse": {
             "name": "@alpinejs/collapse",
-            "version": "3.9.0",
+            "version": "3.10.2",
             "license": "MIT"
         },
         "packages/csp": {
@@ -7827,11 +7827,12 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.9.0-revision.2",
+            "version": "3.10.2-revision.2",
             "license": "MIT"
         },
         "packages/focus": {
-            "version": "3.9.0",
+            "name": "@alpinejs/focus",
+            "version": "3.10.2",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.6.1"
@@ -7847,26 +7848,32 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.9.0",
+            "version": "3.10.2",
+            "license": "MIT"
+        },
+        "packages/mask": {
+            "version": "3.10.2",
             "license": "MIT"
         },
         "packages/morph": {
             "name": "@alpinejs/morph",
-            "version": "3.9.0",
+            "version": "3.10.2",
             "license": "MIT"
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.9.0",
+            "version": "3.10.2",
             "license": "MIT"
         },
         "packages/portal": {
+            "name": "@alpinejs/portal",
             "version": "3.6.1-beta.0",
             "license": "MIT"
         },
         "packages/trap": {
             "name": "@alpinejs/trap",
             "version": "0.0.1",
+            "extraneous": true,
             "dependencies": {
                 "focus-trap": "^6.6.1"
             }
@@ -7900,6 +7907,9 @@
         "@alpinejs/intersect": {
             "version": "file:packages/intersect"
         },
+        "@alpinejs/mask": {
+            "version": "file:packages/mask"
+        },
         "@alpinejs/morph": {
             "version": "file:packages/morph"
         },
@@ -7908,12 +7918,6 @@
         },
         "@alpinejs/portal": {
             "version": "file:packages/portal"
-        },
-        "@alpinejs/trap": {
-            "version": "file:packages/trap",
-            "requires": {
-                "focus-trap": "^6.6.1"
-            }
         },
         "@babel/code-frame": {
             "version": "7.14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,10 +42,6 @@
             "resolved": "packages/intersect",
             "link": true
         },
-        "node_modules/@alpinejs/mask": {
-            "resolved": "packages/mask",
-            "link": true
-        },
         "node_modules/@alpinejs/morph": {
             "resolved": "packages/morph",
             "link": true
@@ -56,6 +52,10 @@
         },
         "node_modules/@alpinejs/portal": {
             "resolved": "packages/portal",
+            "link": true
+        },
+        "node_modules/@alpinejs/trap": {
+            "resolved": "packages/trap",
             "link": true
         },
         "node_modules/@babel/code-frame": {
@@ -7806,7 +7806,7 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.10.2",
+            "version": "3.9.0",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7814,7 +7814,7 @@
         },
         "packages/collapse": {
             "name": "@alpinejs/collapse",
-            "version": "3.10.2",
+            "version": "3.9.0",
             "license": "MIT"
         },
         "packages/csp": {
@@ -7827,12 +7827,11 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.10.2-revision.2",
+            "version": "3.9.0-revision.2",
             "license": "MIT"
         },
         "packages/focus": {
-            "name": "@alpinejs/focus",
-            "version": "3.10.2",
+            "version": "3.9.0",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.6.1"
@@ -7848,32 +7847,26 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.10.2",
-            "license": "MIT"
-        },
-        "packages/mask": {
-            "version": "3.10.2",
+            "version": "3.9.0",
             "license": "MIT"
         },
         "packages/morph": {
             "name": "@alpinejs/morph",
-            "version": "3.10.2",
+            "version": "3.9.0",
             "license": "MIT"
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.10.2",
+            "version": "3.9.0",
             "license": "MIT"
         },
         "packages/portal": {
-            "name": "@alpinejs/portal",
             "version": "3.6.1-beta.0",
             "license": "MIT"
         },
         "packages/trap": {
             "name": "@alpinejs/trap",
             "version": "0.0.1",
-            "extraneous": true,
             "dependencies": {
                 "focus-trap": "^6.6.1"
             }
@@ -7907,9 +7900,6 @@
         "@alpinejs/intersect": {
             "version": "file:packages/intersect"
         },
-        "@alpinejs/mask": {
-            "version": "file:packages/mask"
-        },
         "@alpinejs/morph": {
             "version": "file:packages/morph"
         },
@@ -7918,6 +7908,12 @@
         },
         "@alpinejs/portal": {
             "version": "file:packages/portal"
+        },
+        "@alpinejs/trap": {
+            "version": "file:packages/trap",
+            "requires": {
+                "focus-trap": "^6.6.1"
+            }
         },
         "@babel/code-frame": {
             "version": "7.14.5",

--- a/packages/alpinejs/src/directives/x-modelable.js
+++ b/packages/alpinejs/src/directives/x-modelable.js
@@ -11,17 +11,18 @@ directive('modelable', (el, { expression }, { effect, evaluateLater }) => {
     innerSet(initialValue)
 
     queueMicrotask(() => {
-        if (! el._x_model) return
+        const modelEl = el.closest('[x-model]');
+        if (modelEl === null) return
 
         // Remove native event listeners as these are now bound with x-modelable.
         // The reason for this is that it's often useful to wrap <input> elements
         // in x-modelable/model, but the input events from the native input
         // override any functionality added by x-modelable causing confusion.
-        el._x_removeModelListeners['default']()
-    
-        let outerGet = el._x_model.get
-        let outerSet = el._x_model.set
-    
+        modelEl._x_removeModelListeners['default']()
+
+        let outerGet = modelEl._x_model.get
+        let outerSet = modelEl._x_model.set
+
         effect(() => innerSet(outerGet()))
         effect(() => outerSet(innerGet()))
     })

--- a/tests/cypress/integration/directives/x-modelable.spec.js
+++ b/tests/cypress/integration/directives/x-modelable.spec.js
@@ -68,3 +68,29 @@ test('x-modelable removes the event listener used by corresponding x-model',
         get('h2').should(haveText('foo'))
     }
 )
+
+test('x-modelable works as a descendant of an x-model',
+    html`
+        <div x-data="{ outer: 'foo' }">
+            <div x-data="{ inner: 'bar' }" x-model="outer">
+                <div x-modelable="inner">
+                    <h1 x-text="outer"></h1>
+                    <h2 x-text="inner"></h2>
+
+                    <button @click="inner = 'bob'" id="1">change inner</button>
+                    <button @click="outer = 'lob'" id="2">change outer</button>
+                </div>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('h1').should(haveText('foo'))
+        get('h2').should(haveText('foo'))
+        get('#1').click()
+        get('h1').should(haveText('bob'))
+        get('h2').should(haveText('bob'))
+        get('#2').click()
+        get('h1').should(haveText('lob'))
+        get('h2').should(haveText('lob'))
+    }
+)


### PR DESCRIPTION
With `x-modelable` being very helpful in templating, I find it hard to have both `x-model` and `x-modelable` attributes on the same element. Most of my components look something like below:

```
<div x-data="{ defaultData : 'Hello World' }"> 
    <x-fancy-input x-model="defaultData" x-data="{ options: { bold: true, onFocus: ()=>console.log('focused') } }"></x-fancy-input>
</div>

// component markup for <x-fancy-input> blade component
<div class="wrapper" {{ $attributes }}>
    <div x-data="fancyInput" x-modelable="parentModel">
        <textarea x-ref="input"></textarea>
    </div>
</div> 
<script>
Alpine.data('fancyInput', ...    
```

If the `x-modelable` directive is changed from `el._x_model` to `el.closest('[x-model]')` it will still select the current `<div>`, but if it doesn't exist, it will continue up the DOM tree until it is found. If one isn't found, it will return null, and the directive can be short-circuited at that point.    
    