### PR TITLE
Add $fetch

### DIFF
--- a/packages/alpinejs/src/magics/$fetch.js
+++ b/packages/alpinejs/src/magics/$fetch.js
@@ -1,0 +1,51 @@
+import { magic } from "../magics";
+
+magic('fetchjson', () => {
+    return async (
+        url,
+        jsonItem = null,
+        method = "GET"
+    ) => {
+        let response = await xfetch(url = url, jsonItem = jsonItem, method = method)
+        return await response;
+    }
+})
+
+magic('fetch', () => {
+    return async (
+        url,
+        method = "GET"
+    ) => {
+        let response = await xfetch(url = url, jsonItem = null, method = method)
+        return await response;
+    }
+})
+
+
+// Actual fetch function
+async function xfetch(url, jsonItem = null, method = 'GET') {
+
+    if (jsonItem == null) {
+
+        return fetch(url, {method: method})
+            .then((response) => response.text())
+            .then((responseText) => {
+                return responseText
+            })
+            .catch((error) => {
+              console.log(error)
+            });
+
+    } else {
+
+        return fetch(url, {method: method})
+            .then((response) => response.json())
+            .then((responseJson) => {
+                return responseJson[jsonItem]
+            })
+            .catch((error) => {
+              console.log(error)
+            });
+
+    }
+}

--- a/packages/alpinejs/src/magics/index.js
+++ b/packages/alpinejs/src/magics/index.js
@@ -10,6 +10,7 @@ import './$root'
 import './$refs'
 import './$id'
 import './$el'
+import './$fetch'
 
 // Register warnings for people using plugin syntaxes and not loading the plugin itself:
 warnMissingPluginMagic('Focus', 'focus', 'focus')

--- a/tests/cypress/integration/magics/$fetch.spec.js
+++ b/tests/cypress/integration/magics/$fetch.spec.js
@@ -1,0 +1,17 @@
+import { haveText, html, test } from '../../utils'
+
+test('$fetch should get data from an api',
+    html`
+        <div x-data="{ apiResult: 'Empty' }">
+            <button
+                x-text="apiResult"
+                @click="apiResult = await $fetch('https://weathermockapi.herokuapp.com/hello_world')"
+            ></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').should(haveText('Empty'))
+        get('button').click()
+        get('button').should(haveText('Hello, World!'))
+    }
+)


### PR DESCRIPTION
This is my implementation of adding two new magics: `$fetch` and `$fetchjson`.

As discussed in [this discussion](https://github.com/alpinejs/alpine/discussions/3068#discussioncomment-3328978), I think Alpine currently lacks a straightforward way to request data from a server and populate it into an element.

This pull request takes my alpine-fetch library and implements it directly into Alpine. I recognise you might not want to merge this right away (would need to be documented first, in any case) but I've opened this for discussion.


### Making requests with Alpine today

It's quite hard work and verbose:

````
<div x-data="{
        result: null,
        async retrieveData() {
            this.result = await (await fetch('/endpoint')).text();
        }
     }"
     x-init="retrieveData()"
>
     <span x-text="result"></span>
</div>
````

(I'm aware this is a Javascript issue, not an Alpine issue)

### Making requests with $fetch

Much more intuitive as it abstracts away all of the promises and asyncs and other stuff that stump new JS devs.

Fetch some text and put it into a span:

````
<div x-data>
    <span x-text="await $fetch('/endpoint)"></span>
</div>
````

or fetch some JSON and put a particular element into a span:

````
<div x-data>
    <span x-text="await $fetchjson('https://weathermockapi.herokuapp.com/some_json', jsonItem='weather')"></span>
</div>
````

or load it into a x-data and use it wherever you want:

````
<div x-data="{ hello_world: await $fetch('https://weathermockapi.herokuapp.com/hello_world' }">
    <span x-text="hello_world"></span>
    <span x-text="hello_world"></span>
</div>
````

### Links

More examples: https://hankhank10.github.io/alpine-fetch/
