### PR TITLE
Add condition to $nextTick

### DIFF
--- a/packages/alpinejs/src/nextTick.js
+++ b/packages/alpinejs/src/nextTick.js
@@ -3,7 +3,7 @@ let tickStack = []
 
 let isHolding = false
 
-export function nextTick(callback = () => {}) {
+export function nextTick(callback = () => {}, condition = true) {
   queueMicrotask(() => {
     isHolding || setTimeout(() => {
       releaseNextTicks()
@@ -12,7 +12,7 @@ export function nextTick(callback = () => {}) {
 
   return new Promise((res) => {
     tickStack.push(() => {
-        callback();
+        if (condition) callback();
         res();
     });
   })

--- a/packages/alpinejs/src/nextTick.js
+++ b/packages/alpinejs/src/nextTick.js
@@ -3,7 +3,7 @@ let tickStack = []
 
 let isHolding = false
 
-export function nextTick(callback = () => {}, condition = true) {
+export function nextTick(callback = () => {}, runCallback = true) {
   queueMicrotask(() => {
     isHolding || setTimeout(() => {
       releaseNextTicks()
@@ -12,7 +12,7 @@ export function nextTick(callback = () => {}, condition = true) {
 
   return new Promise((res) => {
     tickStack.push(() => {
-        if (condition) callback();
+        if (runCallback) callback();
         res();
     });
   })


### PR DESCRIPTION
This pr adds condition to `$nextTick` magic method.
It can be useful in situations when for example you have accordion, and you want to scroll into view only when it gets expanded. So we are goint to use `$nextTick` to achieve that, but we don't want to scroll into view when it gets hidden.

```html
<div x-data="{
        expanded: false,
        toggle() {
            this.expanded = ! this.expanded;
            $nextTick(() => $refs.element.scrollIntoView(), this.expanded);
        },
    }">
    <button @click="toggle">Toggle Content</button>
 
    <div x-ref="element" x-show="expanded" x-collapse>
        ...
    </div>
</div>
```

So here we are passing second param to the `$nextTick` that will represent the condition.
If condition is true, the `callback` will run, otherwise it will not.