### PR TITLE
:memo: Provides more information in package.json

### DIFF
--- a/packages/alpinejs/package.json
+++ b/packages/alpinejs/package.json
@@ -3,6 +3,11 @@
     "version": "3.10.3",
     "description": "The rugged, minimal JavaScript framework",
     "homepage": "https://alpinejs.dev",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/alpinejs"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/alpinejs/package.json
+++ b/packages/alpinejs/package.json
@@ -2,6 +2,7 @@
     "name": "alpinejs",
     "version": "3.10.3",
     "description": "The rugged, minimal JavaScript framework",
+    "homepage": "https://alpinejs.dev",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/collapse",
     "version": "3.10.3",
     "description": "Collapse and expand elements with robust animations",
+    "homepage": "https://alpinejs.dev/plugins/collapse",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -3,6 +3,11 @@
     "version": "3.10.3",
     "description": "Collapse and expand elements with robust animations",
     "homepage": "https://alpinejs.dev/plugins/collapse",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/collapse"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -3,6 +3,11 @@
     "version": "3.10.3",
     "description": "Manage focus within a page",
     "homepage": "https://alpinejs.dev/plugins/focus",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/focus"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/focus",
     "version": "3.10.3",
     "description": "Manage focus within a page",
+    "homepage": "https://alpinejs.dev/plugins/focus",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/history",
     "version": "3.0.0-alpha.0",
     "description": "Sync Alpine data with the browser's query string",
+    "homepage": "https://alpinejs.dev/",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -3,6 +3,11 @@
     "version": "3.0.0-alpha.0",
     "description": "Sync Alpine data with the browser's query string",
     "homepage": "https://alpinejs.dev/",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/history"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/intersect/package.json
+++ b/packages/intersect/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/intersect",
     "version": "3.10.3",
     "description": "Trigger JavaScript when an element enters the viewport",
+    "homepage": "https://alpinejs.dev/plugins/intersect",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/intersect/package.json
+++ b/packages/intersect/package.json
@@ -3,6 +3,11 @@
     "version": "3.10.3",
     "description": "Trigger JavaScript when an element enters the viewport",
     "homepage": "https://alpinejs.dev/plugins/intersect",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/intersect"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/mask/package.json
+++ b/packages/mask/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/mask",
     "version": "3.10.3",
     "description": "An Alpine plugin for input masking",
+    "homepage": "https://alpinejs.dev/plugins/mask",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/mask/package.json
+++ b/packages/mask/package.json
@@ -3,6 +3,11 @@
     "version": "3.10.3",
     "description": "An Alpine plugin for input masking",
     "homepage": "https://alpinejs.dev/plugins/mask",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/mask"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/morph",
     "version": "3.10.3",
     "description": "Diff and patch a block of HTML on a page with an HTML template",
+    "homepage": "https://alpinejs.dev/plugins/persist",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -2,7 +2,12 @@
     "name": "@alpinejs/morph",
     "version": "3.10.3",
     "description": "Diff and patch a block of HTML on a page with an HTML template",
-    "homepage": "https://alpinejs.dev/plugins/persist",
+    "homepage": "https://alpinejs.dev/plugins/morph",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/morph"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -2,6 +2,12 @@
     "name": "@alpinejs/persist",
     "version": "3.10.3",
     "description": "Persist Alpine data across page loads",
+    "homepage": "https://alpinejs.dev/plugins/persist",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/persist"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,7 @@
     "name": "@alpinejs/ui",
     "version": "3.10.3-beta.2",
     "description": "Headless UI components for Alpine",
+    "homepage": "https://alpinejs.dev/components#headless",
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,11 @@
     "version": "3.10.3-beta.2",
     "description": "Headless UI components for Alpine",
     "homepage": "https://alpinejs.dev/components#headless",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/alpinejs/alpine.git",
+        "directory": "packages/ui"
+    },
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",


### PR DESCRIPTION
This allows IDEs and NPM to guide users towards relevant documentation.

For example, using the `npm docs alpinejs` command or hovering over the dependency in VSCode.

Looks like test failed from some incomplete code elsewhere.

Additionally, this adds repository information for use by various other tools (addressing: https://github.com/alpinejs/alpine/discussions/3147 )