### PR TITLE
Fix intermittent rounding issue

### DIFF
--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -56,7 +56,7 @@ export default function (Alpine) {
                     start: { height: current+'px' },
                     end: { height: full+'px' },
                 }, () => el._x_isShown = true, () => {
-                    if (el.style.height == `${full}px`) {
+                    if (Math.floor(el.style.height.replace('px', '')) == Math.floor(full)) {
                         el.style.overflow = null
                     }
                 })


### PR DESCRIPTION
We are having an issue with collapse which occasionally occurs where overflow:hidden isn't removed because of a rounding difference between el.style.height and full. In our example el.style.height comes out to 86.9705px whereas `${full}px` comes out to 86.97048950195312px. Since they don't match exactly, the overflow:hidden isn't removed and the element doesn't fully expand.

This PR uses Math.floor to compare the numbers. I'm open to other ways of addressing this issue though, we could maybe round full to 4 decimals? I'm not sure if 4 decimals is standard for el.style.height or not 