### PR TITLE
Form reset support for x-model

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,11 @@
     <!-- <script src="https://unpkg.com/alpinejs@3.0.0/dist/cdn.min.js" defer></script> -->
 
     <!-- Play around. -->
-    <div x-data="{ open: false, foo: '' }">
+    <div x-data="{ open: false }">
+        <button @click="open = !open">Toggle</button>
 
-        <span x-text="foo"></span>
-        <form>
-            <input x-model="foo" />
-            <button type="reset">Reset</button>
-        </form>
-        <a href="https://www.google.com">link</a>
+        <span x-show="open">
+            Content...
+        </span>
     </div>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,13 @@
     <!-- <script src="https://unpkg.com/alpinejs@3.0.0/dist/cdn.min.js" defer></script> -->
 
     <!-- Play around. -->
-    <div x-data="{ open: false }">
-        <button @click="open = !open">Toggle</button>
+    <div x-data="{ open: false, foo: '' }">
 
-        <span x-show="open">
-            Content...
-        </span>
+        <span x-text="foo"></span>
+        <form>
+            <input x-model="foo" />
+            <button type="reset">Reset</button>
+        </form>
+        <a href="https://www.google.com">link</a>
     </div>
 </html>

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -35,6 +35,17 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
 
     cleanup(() => el._x_removeModelListeners['default']())
 
+    // If the input/select/textarea element is linked to a form
+    // we listen for the reset event on the parent form (the event
+    // does not trigger on the single inputs) and update
+    // on nextTick so the page doesn't end up out of sync
+    if (el.form) {
+        let removeResetListener = on(el.form, 'reset', [], (e) => {
+            nextTick(() => el._x_model && el._x_model.set(el.value))
+        })
+        cleanup(() => removeResetListener())
+    }
+
     // Allow programmatic overiding of x-model.
     let evaluateSetModel = evaluateLater(el, `${expression} = __placeholder`)
     el._x_model = {

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -1,6 +1,7 @@
 import { evaluateLater } from '../evaluator'
 import { directive } from '../directives'
 import { mutateDom } from '../mutation'
+import { nextTick } from '../nextTick'
 import bind from '../utils/bind'
 import on from '../utils/on'
 

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -110,3 +110,22 @@ test('x-model can be accessed programmatically',
         get('span').should(haveText('bob'))
     }
 )
+
+test('x-model updates value when the form is reset',
+    html`
+    <div x-data="{ foo: '' }">
+        <form>
+            <input x-model="foo"></input>
+            <button type="reset">Reset</button>
+        </form>
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('baz')
+        get('span').should(haveText('baz'))
+        get('button').click()
+        get('span').should(haveText(''))
+    }
+)


### PR DESCRIPTION
If an element using x-model is included in a form and the form provides a reset button, clicking said button will desync the UI from the alpine state (all input elements get emptied but the Alpine scope won't see the update).

Failing test before fix: https://github.com/SimoTod/alpine/runs/8214754814?check_suite_focus=true#step:6:572