### PR TITLE
Replace inital-focus with x-dialog:focus

### DIFF
--- a/packages/ui/src/dialog.js
+++ b/packages/ui/src/dialog.js
@@ -5,6 +5,7 @@ export default function (Alpine) {
         else if (directive.value === 'panel')       handlePanel(el, Alpine)
         else if (directive.value === 'title')       handleTitle(el, Alpine)
         else if (directive.value === 'description') handleDescription(el, Alpine)
+        else if (directive.value === 'focus')       handleFocus(el, Alpine)
         else                                        handleRoot(el, Alpine)
     })
 
@@ -34,14 +35,6 @@ function handleRoot(el, Alpine) {
                     // If the user chose to use :open and @close instead of x-model.
                     (Alpine.bound(el, 'open') !== undefined) && Alpine.effect(() => {
                         this.__isOpenState = Alpine.bound(el, 'open')
-                    })
-
-                    if (Alpine.bound(el, 'initial-focus') !== undefined) this.$watch('__isOpenState', () => {
-                        if (! this.__isOpenState) return
-
-                        setTimeout(() => {
-                            Alpine.bound(el, 'initial-focus').focus()
-                        }, 0);
                     })
                 },
                 __isOpenState: false,
@@ -94,3 +87,14 @@ function handleDescription(el, Alpine) {
     })
 }
 
+function handleFocus(el, Alpine) {
+    Alpine.bind(el, {
+        'x-effect'() {
+            if (! this.__isOpenState) return
+
+            setTimeout(() => {
+                el.focus();
+            }, 0);
+        },
+    });
+}

--- a/packages/ui/src/dialog.js
+++ b/packages/ui/src/dialog.js
@@ -94,7 +94,7 @@ function handleFocus(el, Alpine) {
 
             setTimeout(() => {
                 el.focus();
-            }, 0);
+            }, 50);
         },
     });
 }


### PR DESCRIPTION
I think it would be more comfortable to add `x-dialog:focus` instead of `:initial-focus`.

Based on https://github.com/alpinejs/alpine/discussions/3155