### PR TITLE
Make store setter a constructor also

### DIFF
--- a/packages/alpinejs/src/store.js
+++ b/packages/alpinejs/src/store.js
@@ -18,6 +18,8 @@ export function store(name, value) {
     }
 
     initInterceptors(stores[name])
+    
+    return stores[name]
 }
 
 export function getStores() { return stores }


### PR DESCRIPTION
Related: #3223 

It seems _constructor_ pattern is more widespread with store than _setter_. It's unlikely store is set multiple times during the app lifetime, whereas returning just created store is more natural (coming from [@preact/signals](https://www.npmjs.com/package/@preact/signals) or react hooks world).

```js
let store = Alpine.store('auth', {user});
onAuthChanged(user => store.user = user);
```