### PR TITLE
Introduce x-teleport values/modifiers

### DIFF
--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -4,7 +4,7 @@ import { mutateDom } from "../mutation"
 import { addScopeToNode } from "../scope"
 import { warn } from "../utils/warn"
 
-directive('teleport', (el, { expression, value  }, { cleanup }) => {
+directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
     if (el.tagName.toLowerCase() !== 'template') warn('x-teleport can only be used on a <template> tag', el)
 
     let target = document.querySelector(expression)
@@ -31,10 +31,10 @@ directive('teleport', (el, { expression, value  }, { cleanup }) => {
     addScopeToNode(clone, {}, el)
 
     mutateDom(() => {
-        if (value === 'prepend') {
+        if (modifiers.includes('prepend')) {
             // insert element before the target
             target.parentNode.insertBefore(clone, target)
-        } else if (value === 'append') {
+        } else if (modifiers.includes('append')) {
             // insert element after the target
             target.parentNode.insertBefore(clone, target.nextSibling)
         } else {

--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -4,7 +4,7 @@ import { mutateDom } from "../mutation"
 import { addScopeToNode } from "../scope"
 import { warn } from "../utils/warn"
 
-directive('teleport', (el, { expression }, { cleanup }) => {
+directive('teleport', (el, { expression, value  }, { cleanup }) => {
     if (el.tagName.toLowerCase() !== 'template') warn('x-teleport can only be used on a <template> tag', el)
 
     let target = document.querySelector(expression)
@@ -31,7 +31,16 @@ directive('teleport', (el, { expression }, { cleanup }) => {
     addScopeToNode(clone, {}, el)
 
     mutateDom(() => {
-        target.appendChild(clone)
+        if (value === 'prepend') {
+            // insert element before the target
+            target.parentNode.insertBefore(clone, target)
+        } else if (value === 'append') {
+            // insert element after the target
+            target.parentNode.insertBefore(clone, target.nextSibling)
+        } else {
+            // origin
+            target.appendChild(clone)
+        }
 
         initTree(clone)
 

--- a/tests/cypress/integration/directives/x-teleport.spec.js
+++ b/tests/cypress/integration/directives/x-teleport.spec.js
@@ -19,6 +19,44 @@ test('can use a x-teleport',
     },
 )
 
+test('can use a x-teleport:append',
+    [html`
+        <div x-data="{ count: 1 }" id="a">
+            <button @click="count++">Inc</button>
+
+            <template x-teleport:append="#b">
+                <span x-text="count"></span>
+            </template>
+        </div>
+
+        <div id="b"></div>
+    `],
+    ({ get }) => {
+        get('#b + span').should(haveText('1'))
+        get('button').click()
+        get('#b + span').should(haveText('2'))
+    },
+)
+
+test('can use a x-teleport:prepend',
+    [html`
+        <div x-data="{ count: 1 }" id="a">
+            <button @click="count++">Inc</button>
+
+            <template x-teleport:prepend="#b">
+                <span x-text="count"></span>
+            </template>
+        </div>
+
+        <div id="b"></div>
+    `],
+    ({ get }) => {
+        get('#a + span').should(haveText('1'))
+        get('button').click()
+        get('#a + span').should(haveText('2'))
+    },
+)
+
 test('can teleport multiple',
     [html`
         <div x-data="{ count: 1 }" id="a">

--- a/tests/cypress/integration/directives/x-teleport.spec.js
+++ b/tests/cypress/integration/directives/x-teleport.spec.js
@@ -19,12 +19,12 @@ test('can use a x-teleport',
     },
 )
 
-test('can use a x-teleport:append',
+test('can use a x-teleport.append',
     [html`
         <div x-data="{ count: 1 }" id="a">
             <button @click="count++">Inc</button>
 
-            <template x-teleport:append="#b">
+            <template x-teleport.append="#b">
                 <span x-text="count"></span>
             </template>
         </div>
@@ -38,12 +38,12 @@ test('can use a x-teleport:append',
     },
 )
 
-test('can use a x-teleport:prepend',
+test('can use a x-teleport.prepend',
     [html`
         <div x-data="{ count: 1 }" id="a">
             <button @click="count++">Inc</button>
 
-            <template x-teleport:prepend="#b">
+            <template x-teleport.prepend="#b">
                 <span x-text="count"></span>
             </template>
         </div>


### PR DESCRIPTION
Sometimes it is needed to teleport a node after or before an existing node.

Example:
```html
<table>
  <template x-for="n in 10">
    <tr x-bind:id="`row-${n}`">
      <template x-teleport:append="#row-5">
        <tr>
          <td colspan="2">EVERYTHING ABOVE 5</td>
        </tr>
      </template>
      <td>#</td>
      <td x-text="n"></td>
    </tr>
  </template>
</table>
```
The example above will add a new `<tr>` correctly


Especially when you deal with `<tr>`, you are hitting a problem here because you can only have one single root element within a `<template>`. Sometimes, you need to have a second one.

With `x-teleport:append`, you can append a node as a sibling of the target instead of a child. Works same wise with `x-teleport:prepend`