### PR TITLE
Bug (UI) Popover not focusing correctly

### DIFF
--- a/packages/ui/src/popover.js
+++ b/packages/ui/src/popover.js
@@ -152,7 +152,7 @@ function handlePanel(el, Alpine) {
             this.$data.__panelEl = this.$el
         },
         'x-effect'() {
-            this.$data.__isOpen && Alpine.bound(el, 'focus') && this.$focus.first()
+            this.$data.__isOpen && Alpine.bound(el, 'focus') && this.$nextTick(() => this.$focus.first())
         },
         'x-ref': 'panel',
         ':id'() { return this.$id('alpine-popover-panel') },


### PR DESCRIPTION
I believe the reason why the test fails inconsistently is that there is a race condition between showing the popup and focusing on the first element. If an element is not visible, it can't be focused. This means that the focus stays on the button and pressing `tab` is actually moving the focus inside the popover (rather than tabbing away).

I suppose this could also happen on a real website under certain conditions.