### PR TITLE
Accept x-data="true" as a synonym for x-data="{}"

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -21,7 +21,7 @@ directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
 
     let data = evaluate(el, expression, { scope: dataProviderContext })
 
-    if (data === undefined) data = {}
+    if (data === undefined || data === true) data = {}
 
     injectMagics(data, el)
 


### PR DESCRIPTION
As per #3337, some frameworks (like htm) convert `<div x-data … />` to `<div x-data="true" … />` whereas Alpine.js currently only accepts the equivalent of `<div x-data="" … />`. This patch (based on https://github.com/alpinejs/alpine/discussions/3337#discussioncomment-4397836), also makes it accept `x-data="true"` to mean data is `{}`.