### PR TITLE
Fix x-model checkbox weirdness

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -5,8 +5,9 @@ import { nextTick } from '../nextTick'
 import bind from '../utils/bind'
 import on from '../utils/on'
 import { warn } from '../utils/warn'
+import { skipDuringClone } from '../clone'
 
-directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
+directive('model', skipDuringClone((el, { modifiers, expression }, { effect, cleanup }) => {
     let scopeTarget = el
 
     if (modifiers.includes('parent')) {
@@ -119,7 +120,7 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
 
         el._x_forceModelUpdate(value)
     })
-})
+}))
 
 function getInputValue(el, modifiers, event, currentValue) {
     return mutateDom(() => {

--- a/tests/cypress/integration/clone.spec.js
+++ b/tests/cypress/integration/clone.spec.js
@@ -97,3 +97,34 @@ test('wont register listeners on clone',
         get('#copy span').should(haveText('1'))
     }
 )
+
+test('wont register extra listeners on x-model on clone',
+    html`
+        <script>
+            document.addEventListener('alpine:initialized', () => {
+                window.original = document.getElementById('original')
+                window.copy = document.getElementById('copy')
+            })
+        </script>
+
+        <button x-data @click="Alpine.clone(original, copy)">click</button>
+
+        <div x-data="{ checks: [] }" id="original">
+            <input type="checkbox" x-model="checks" value="1">
+            <span x-text="checks"></span>
+        </div>
+
+        <div x-data="{ checks: [] }" id="copy">
+            <input type="checkbox" x-model="checks" value="1">
+            <span x-text="checks"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#original span').should(haveText(''))
+        get('#copy span').should(haveText(''))
+        get('button').click()
+        get('#copy span').should(haveText(''))
+        get('#copy input').click()
+        get('#copy span').should(haveText('1'))
+    }
+)


### PR DESCRIPTION
Seems like `x-model` should also use the `skipForClone` function. Normally extra listeners wouldn't cause a problem, but if you're binding to an array (for example, with multiple checkboxes) it causes incorrect values to be bound. Each value is doubled after a clone happens. 

This was discovered while investigating https://github.com/livewire/livewire/pull/5454

I've included a test for this that fails prior to `skipForClone` being added. 