### PR TITLE
docs: Fix a few typos

### DIFF
--- a/packages/docs/src/en/advanced/extending.md
+++ b/packages/docs/src/en/advanced/extending.md
@@ -228,7 +228,7 @@ Now if the directive is removed from this element or the element is removed itse
 ### Custom order
 
 By default, any new directive will run after the majority of the standard ones (with the exception of `x-teleport`). This is usually acceptable but some times you might need to run your custom directive before another specific one.
-This can be achieved by chaining the `.before() function to `Alpine.directive()` and specifing which directive needs to run after your custom one.
+This can be achieved by chaining the `.before() function to `Alpine.directive()` and specifying which directive needs to run after your custom one.
  
 ```js
 Alpine.directive('foo', (el, { value, modifiers, expression }) => {

--- a/tests/cypress/integration/plugins/navigate.spec.js
+++ b/tests/cypress/integration/plugins/navigate.spec.js
@@ -1,6 +1,6 @@
 import { beEqualTo, beVisible, haveAttribute, haveFocus, haveText, html, notBeVisible, test } from '../../utils'
 
-// Test persistant peice of layout
+// Test persistent piece of layout
 // Handle non-origin links and such
 // Handle 404
 // Middle/command click link in new tab works?


### PR DESCRIPTION
There are small typos in:
- packages/docs/src/en/advanced/extending.md
- tests/cypress/integration/plugins/navigate.spec.js

Fixes:
- Should read `specifying` rather than `specifing`.
- Should read `piece` rather than `peice`.
- Should read `persistent` rather than `persistant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md