### PR TITLE
Don't restore cursor during initialization.

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -32,10 +32,10 @@ export default function (Alpine) {
                 // - Initializing the mask on the input if it has an initial value.
                 // - Running the template function to set up reactivity, so that
                 //   when a dependency inside it changes, the input re-masks.
-                processInputValue(el)
+                processInputValue(el, false)
             })
         } else {
-            processInputValue(el)
+            processInputValue(el, false)
         }
 
         el.addEventListener('input', () => processInputValue(el))


### PR DESCRIPTION
Don't restore the cursor's position during initialization in order to avoid the input from automatically taking focus. 