### PR TITLE
Fix x-model event listener doubling when cloned

### DIFF
--- a/packages/alpinejs/src/clone.js
+++ b/packages/alpinejs/src/clone.js
@@ -2,7 +2,7 @@ import { effect, release, overrideEffect } from "./reactivity"
 import { initTree, isRoot } from "./lifecycle"
 import { walk } from "./utils/walk"
 
-let isCloning = false
+export let isCloning = false
 
 export function skipDuringClone(callback, fallback = () => {}) {
     return (...args) => isCloning ? fallback(...args) : callback(...args)

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -63,16 +63,12 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
         || modifiers.includes('lazy')
             ? 'change' : 'input'
 
-    let removeListener = {}
-
     // We only want to register the event listener when we're not cloning, since the
     // mutation observer handles initializing the x-model directive already when
     // the element is inserted into the DOM. Otherwise we register it twice.
-    if (!isCloning) {
-        removeListener = on(el, event, modifiers, (e) => {
-            setValue(getInputValue(el, modifiers, e, getValue()))
-        })
-    }
+    let removeListener = isCloning ? () => {} : on(el, event, modifiers, (e) => {
+        setValue(getInputValue(el, modifiers, e, getValue()))
+    })
 
     // Register the listener removal callback on the element, so that
     // in addition to the cleanup function, x-modelable may call it.

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -5,8 +5,9 @@ import { nextTick } from '../nextTick'
 import bind from '../utils/bind'
 import on from '../utils/on'
 import { warn } from '../utils/warn'
+import { skipDuringClone } from '../clone'
 
-directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
+directive('model', skipDuringClone((el, { modifiers, expression }, { effect, cleanup }) => {
     let scopeTarget = el
 
     if (modifiers.includes('parent')) {
@@ -119,7 +120,7 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
 
         el._x_forceModelUpdate(value)
     })
-})
+}))
 
 function getInputValue(el, modifiers, event, currentValue) {
     return mutateDom(() => {

--- a/tests/cypress/integration/clone.spec.js
+++ b/tests/cypress/integration/clone.spec.js
@@ -97,3 +97,34 @@ test('wont register listeners on clone',
         get('#copy span').should(haveText('1'))
     }
 )
+
+test('wont register extra listeners on x-model on clone',
+    html`
+        <script>
+            document.addEventListener('alpine:initialized', () => {
+                window.original = document.getElementById('original')
+                window.copy = document.getElementById('copy')
+            })
+        </script>
+
+        <button x-data @click="Alpine.clone(original, copy)">click</button>
+
+        <div x-data="{ checks: [] }" id="original">
+            <input type="checkbox" x-model="checks" value="1">
+            <span x-text="checks"></span>
+        </div>
+
+        <div x-data="{ checks: [] }" id="copy">
+            <input type="checkbox" x-model="checks" value="1">
+            <span x-text="checks"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#original span').should(haveText(''))
+        get('#copy span').should(haveText(''))
+        get('button').click()
+        get('#copy span').should(haveText(''))
+        get('#copy input').click()
+        get('#copy span').should(haveText('1'))
+    }
+)


### PR DESCRIPTION
### Problem
The `x-model` directive's event listeners are getting registered **twice** when an element is cloned with `Alpine.clone()`.

This happens once via `initTree()` when clone walks the DOM initializing stuff. Secondly, the mutation observer picks up on `x-model` and then registers the listeners again. A couple other things:

### Notes
- Only noticeable when `x-model` is bound to an array (i.e. checkboxes), but seems to happen for any input with `x-model`.
- Affects Livewire in particular, due to it cloning Alpine components when making DOM updates. livewire/livewire#5454.
- Tried writing a test for the event doubling on any input, but doesn't seem like JS has a native way to retrieve a list (or count) of attached event listeners.

### Questions
- This line doesn't feel great... thoughts? https://github.com/alpinejs/alpine/pull/3393/files#diff-a45b9bae1e2842675ba9349395f0347d4f2a53390bcca48d06fdfb4075e69b08R66
- Changes or other tests you'd like to see included?

Had to open a new PR, because the closed one (#3351) wasn't updated with the latest commits. 




  