### PR TITLE
Add x-on:.body modifier

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -18,6 +18,7 @@ export default function on (el, event, modifiers, callback) {
     if (modifiers.includes('capture')) options.capture = true
     if (modifiers.includes('window')) listenerTarget = window
     if (modifiers.includes('document')) listenerTarget = document
+    if (modifiers.includes('body')) listenerTarget = document.body
     if (modifiers.includes('prevent')) handler = wrapHandler(handler, (next, e) => { e.preventDefault(); next(e) })
     if (modifiers.includes('stop')) handler = wrapHandler(handler, (next, e) => { e.stopPropagation(); next(e) })
     if (modifiers.includes('self')) handler = wrapHandler(handler, (next, e) => { e.target === el && next(e) })

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -188,6 +188,13 @@ Adding `.window` to listeners is extremely useful for these sorts of cases where
 
 `.document` works similarly to `.window` only it registers listeners on the `document` global, instead of the `window` global.
 
+<a name="body"></a>
+### .body
+
+`.body` works similarly to `.document` and `.window` only it registers listeners on the `body` element.
+
+Using this modifier makes it easy to get reference to the event listener's parent element by using a CSS selector (e.g. `document.querySelector("body")`) while still providing a 'global' scope for the event.
+
 <a name="once"></a>
 ### .once
 

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -205,6 +205,21 @@ test('.document modifier',
     }
 )
 
+test('.body modifier',
+    html`
+       <div x-data="{ foo: 'bar' }">
+            <div x-on:click.body="foo = 'baz'"></div>
+
+            <span x-text="foo"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('span').click()
+        get('span').should(haveText('baz'))
+    }
+)
+
 test('.once modifier',
     html`
         <div x-data="{ count: 0 }">


### PR DESCRIPTION
This pull request adds a `.body` modifier to the `x-on` directive.

It is similar to the `.document` and `.window` modifiers, but with a small difference: **This modifier allows you to easily reference the event listener's parent element using a query selector (e.g. `document.querySelector('body')`).**

### Why?

The use case that inspired this change was that I wanted to dispatch an event from the server side using Phoenix LiveView, which requires a CSS selector as its target.

Although using the `.document` modifier _appears_ to attach the listener to the `<html>` element (at least according to the Chrome DevTools' 'Event Listener' panel), dispatching an event like so does not produce the desired result:

`document.querySelector('html').dispatchEvent(new CustomEvent('hello-world'))`

However, with the new `.body` modifier, you can now create 'global' event listeners that can be targeted by their query selector:

`document.querySelector('body').dispatchEvent(new CustomEvent('hello-world'))`

### Demo

CodePen demo here: https://codepen.io/arcanemachine/pen/XWBYxvg

---

P.S. There is a flaky Cypress test (#3394) that may cause the tests to fail, but it is unrelated to my pull request.