### PR TITLE
:bug: fixes improper use of nullish coalescing

### DIFF
--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -27,11 +27,8 @@ export function directive(name, callback) {
                 );
                 return;
             }
-            const pos = directiveOrder.indexOf(directive)
-                ?? directiveOrder.indexOf('DEFAULT');
-            if (pos >= 0) {
-                directiveOrder.splice(pos, 0, name);
-            }
+            const pos = directiveOrder.indexOf(directive);
+            directiveOrder.splice(pos >= 0 ? pos : directiveOrder.indexOf('DEFAULT'), 0, name);
         }
     }
 }


### PR DESCRIPTION
`Array.prototype.indexOf` returns `-1` when an item is not found, which would never utilize the nullish coalescence.

To satisfy the apparent intent, this instead simply uses a ternary in the target index of splice

@SimoTod 