### PR TITLE
x-mask custom decimal precision

### DIFF
--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -171,3 +171,16 @@ You may also choose to override the thousands separator by supplying a third opt
     <input type="text" x-mask:dynamic="$money($input, '.', ' ')"  placeholder="3 000.00">
 </div>
 <!-- END_VERBATIM -->
+
+
+You can also override the default precision of 2 digits by using any desired number digits as the fourth optional argument:
+
+```alpine
+<input x-mask:dynamic="$money($input, '.', ',', 8)">
+```
+
+<!-- START_VERBATIM -->
+<div class="demo" x-data>
+    <input type="text" x-mask:dynamic="$money($input, '.', ',', 8)"  placeholder="0.00000001">
+</div>
+<!-- END_VERBATIM -->

--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -173,14 +173,14 @@ You may also choose to override the thousands separator by supplying a third opt
 <!-- END_VERBATIM -->
 
 
-You can also override the default precision of 2 digits by using any desired number digits as the fourth optional argument:
+You can also override the default precision of 2 digits by using any desired number of digits as the fourth optional argument:
 
 ```alpine
-<input x-mask:dynamic="$money($input, '.', ',', 8)">
+<input x-mask:dynamic="$money($input, '.', ',', 4)">
 ```
 
 <!-- START_VERBATIM -->
 <div class="demo" x-data>
-    <input type="text" x-mask:dynamic="$money($input, '.', ',', 8)"  placeholder="0.00000001">
+    <input type="text" x-mask:dynamic="$money($input, '.', ',', 4)"  placeholder="0.0001">
 </div>
 <!-- END_VERBATIM -->

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -163,10 +163,18 @@ export function buildUp(template, input) {
     return output
 }
 
-export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
+export function formatMoney(input, options = {}) {
     if (/^\D+$/.test(input)) return '9'
-
-    thousands = thousands ?? (delimiter === "," ? "." : ",")
+    
+    let delimiter = options.delimiter ?? '.'
+    let thousands = options.thousands ?? (delimiter === ',' ? '.' : ',')
+    let precision = options.precision ?? 2
+    
+    // backwards compatibility for any formatMoney(input, delimiter = '.', thousands) calls
+    if (typeof options === 'string') {
+        delimiter = options
+        thousands = arguments[2] ?? (delimiter === ',' ? '.' : ',')
+    }
 
     let addThousands = (input, thousands) => {
         let output = ''

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -163,18 +163,10 @@ export function buildUp(template, input) {
     return output
 }
 
-export function formatMoney(input, options = {}) {
+export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
     if (/^\D+$/.test(input)) return '9'
-    
-    let delimiter = options.delimiter ?? '.'
-    let thousands = options.thousands ?? (delimiter === ',' ? '.' : ',')
-    let precision = options.precision ?? 2
-    
-    // backwards compatibility for any formatMoney(input, delimiter = '.', thousands) calls
-    if (typeof options === 'string') {
-        delimiter = options
-        thousands = arguments[2] ?? (delimiter === ',' ? '.' : ',')
-    }
+
+    thousands = thousands ?? (delimiter === "," ? "." : ",")
 
     let addThousands = (input, thousands) => {
         let output = ''

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -163,7 +163,7 @@ export function buildUp(template, input) {
     return output
 }
 
-export function formatMoney(input, delimiter = '.', thousands) {
+export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
     if (/^\D+$/.test(input)) return '9'
 
     thousands = thousands ?? (delimiter === "," ? "." : ",")
@@ -192,7 +192,8 @@ export function formatMoney(input, delimiter = '.', thousands) {
 
     template = addThousands(template, thousands)
 
-    if (input.includes(delimiter)) template += `${delimiter}99`
+    if (precision > 0 && input.includes(delimiter)) 
+        template += `${delimiter}` + '9'.repeat(precision)
 
     queueMicrotask(() => {
         if (this.el.value.endsWith(delimiter)) return

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -178,3 +178,18 @@ test('$money mask should remove letters or non numeric characters',
         get('input').type('40').should(haveValue('40'))
     }
 )
+
+test('$money with custom decimal precision',
+    [html`
+        <input id="0" x-data x-mask:dynamic="$money($input, '.', ',', 0)" />
+        <input id="1" x-data x-mask:dynamic="$money($input, '.', ',', 1)" />
+        <input id="2" x-data x-mask:dynamic="$money($input, '.', ',', 2)" />
+        <input id="3" x-data x-mask:dynamic="$money($input, '.', ',', 3)" />
+    `],
+    ({ get }) => {
+        get('#0').type('1234.5678').should(haveValue('12,345,678'))
+        get('#1').type('1234.5678').should(haveValue('1,234.5'))
+        get('#2').type('1234.5678').should(haveValue('1,234.56'))
+        get('#3').type('1234.5678').should(haveValue('1,234.567'))
+    }
+)

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -181,15 +181,17 @@ test('$money mask should remove letters or non numeric characters',
 
 test('$money with custom decimal precision',
     [html`
-        <input id="0" x-data x-mask:dynamic="$money($input, '.', ',', 0)" />
-        <input id="1" x-data x-mask:dynamic="$money($input, '.', ',', 1)" />
-        <input id="2" x-data x-mask:dynamic="$money($input, '.', ',', 2)" />
-        <input id="3" x-data x-mask:dynamic="$money($input, '.', ',', 3)" />
+        <input id="0" x-data x-mask:dynamic="$money($input, { precision: 0 })" />
+        <input id="10" x-data x-mask:dynamic="$money($input, { precision: 0 })" value="1234.5678" />
+        <input id="1" x-data x-mask:dynamic="$money($input, { precision: 1 })" />
+        <input id="2" x-data x-mask:dynamic="$money($input, { delimiter: ',', precision: 2 })" />
+        <input id="3" x-data x-mask:dynamic="$money($input, { precision: 3, thousands: ' ', delimiter: ',' })" />
     `],
     ({ get }) => {
         get('#0').type('1234.5678').should(haveValue('12,345,678'))
+        get('#10').should(haveValue('1,234'))
         get('#1').type('1234.5678').should(haveValue('1,234.5'))
-        get('#2').type('1234.5678').should(haveValue('1,234.56'))
-        get('#3').type('1234.5678').should(haveValue('1,234.567'))
+        get('#2').type('1234,5678').should(haveValue('1.234,56'))
+        get('#3').type('1234,5678').should(haveValue('1 234,567'))
     }
 )

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -181,17 +181,15 @@ test('$money mask should remove letters or non numeric characters',
 
 test('$money with custom decimal precision',
     [html`
-        <input id="0" x-data x-mask:dynamic="$money($input, { precision: 0 })" />
-        <input id="10" x-data x-mask:dynamic="$money($input, { precision: 0 })" value="1234.5678" />
-        <input id="1" x-data x-mask:dynamic="$money($input, { precision: 1 })" />
-        <input id="2" x-data x-mask:dynamic="$money($input, { delimiter: ',', precision: 2 })" />
-        <input id="3" x-data x-mask:dynamic="$money($input, { precision: 3, thousands: ' ', delimiter: ',' })" />
+        <input id="0" x-data x-mask:dynamic="$money($input, '.', ',', 0)" />
+        <input id="1" x-data x-mask:dynamic="$money($input, '.', ',', 1)" />
+        <input id="2" x-data x-mask:dynamic="$money($input, '.', ',', 2)" />
+        <input id="3" x-data x-mask:dynamic="$money($input, '.', ',', 3)" />
     `],
     ({ get }) => {
         get('#0').type('1234.5678').should(haveValue('12,345,678'))
-        get('#10').should(haveValue('1,234'))
         get('#1').type('1234.5678').should(haveValue('1,234.5'))
-        get('#2').type('1234,5678').should(haveValue('1.234,56'))
-        get('#3').type('1234,5678').should(haveValue('1 234,567'))
+        get('#2').type('1234.5678').should(haveValue('1,234.56'))
+        get('#3').type('1234.5678').should(haveValue('1,234.567'))
     }
 )


### PR DESCRIPTION
Allows for custom decimal precision using x-mask $money magic as requested here: https://github.com/alpinejs/alpine/discussions/2873

Example usage:
- To allow for a decimal precision of 3 digits: `<input x-data x-mask:dynamic="$money($input, '.', ',', 3)">`
- To only allow for round numbers: `<input x-data x-mask:dynamic="$money($input, '.', ',', 0)">`

It defaults to 2, so the current behaviour without specified precision should still be the same:
`<input x-data x-mask:dynamic="$money($input)">`