### PR TITLE
x-model.fill by input value on null or empty string

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -47,6 +47,10 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
         }
     }
 
+    if (modifiers.includes('fill') && el.hasAttribute('value') && (getValue() === null || getValue() === '')) {
+        setValue(el.value)
+    }
+    
     if (typeof expression === 'string' && el.type === 'radio') {
         // Radio buttons only work properly when they share a name attribute.
         // People might assume we take care of that for them, because

--- a/packages/docs/src/en/directives/model.md
+++ b/packages/docs/src/en/directives/model.md
@@ -340,7 +340,9 @@ The default throttle interval is 250 milliseconds, you can easily customize this
 <a name="fill"></a>
 ### `.fill`
 
-By adding `.fill` an empty value bound by `x-model` will be filled by the value attribute of the input.
+By default, if an input has a value attribute, it is ignored by Alpine and instead, the value of the input is set to the value of the property bound using `x-model`.
+
+But if a bound property is empty, then you can use an input's value attribute to populate the property by adding the `.fill` modifier.
 
 <div x-data="{ message: null }">
   <input x-model.fill="message" value="This is the default message.">

--- a/packages/docs/src/en/directives/model.md
+++ b/packages/docs/src/en/directives/model.md
@@ -337,6 +337,15 @@ The default throttle interval is 250 milliseconds, you can easily customize this
 <input type="text" x-model.throttle.500ms="search">
 ```
 
+<a name="fill"></a>
+### `.fill`
+
+By adding `.fill` an empty value bound by `x-model` will be filled by the value attribute of the input.
+
+<div x-data="{ message: null }">
+  <input x-model.fill="message" value="This is the default message.">
+</div>
+
 <a name="programmatic access"></a>
 ## Programmatic access
 

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -129,3 +129,27 @@ test('x-model updates value when the form is reset',
         get('span').should(haveText(''))
     }
 )
+
+test('x-model with fill modifier takes input value on null or empty string',
+    html`
+    <div x-data="{ a: 123, b: 0, c: '', d: null }">
+      <input x-model.fill="a" value="123456" />
+      <span id="a" x-text="a">
+      <input x-model.fill="b" value="123456" />
+      <span id="b" x-text="b">
+      <input x-model.fill="c" value="123456" />
+      <span id="c" x-text="c">
+      <input x-model.fill="d" value="123456" />
+      <span id="d" x-text="d">
+    </div>
+    `,
+    ({ get }) => {
+        get('#a').should(haveText('123'))
+        get('#b').should(haveText('0'))
+        get('#c').should(haveText('123456'))
+        get('#d').should(haveText('123456'))
+    }
+)
+
+
+

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -134,13 +134,13 @@ test('x-model with fill modifier takes input value on null or empty string',
     html`
     <div x-data="{ a: 123, b: 0, c: '', d: null }">
       <input x-model.fill="a" value="123456" />
-      <span id="a" x-text="a">
+      <span id="a" x-text="a"></span>
       <input x-model.fill="b" value="123456" />
-      <span id="b" x-text="b">
+      <span id="b" x-text="b"></span>
       <input x-model.fill="c" value="123456" />
-      <span id="c" x-text="c">
+      <span id="c" x-text="c"></span>
       <input x-model.fill="d" value="123456" />
-      <span id="d" x-text="d">
+      <span id="d" x-text="d"></span>
     </div>
     `,
     ({ get }) => {


### PR DESCRIPTION
Set an x-model bound value to the value of the input when the bound value is null or an empty string, 
but as stated in the original discussion this might actually be expected default behaviour. 

The implementation is currently using a "fill" modifier (name subject to change) for now, but might be better as default behaviour with a modifier for the possibility of overwriting any non-nullish value as well, as suggested by @ekwoka (https://github.com/alpinejs/alpine/discussions/1985#discussioncomment-4957333)

Original request by @motine here: https://github.com/alpinejs/alpine/discussions/1985


**Example usage:**
```
<div x-data="{ myValue: null }">
  <input x-model.fill="myValue" value="123456" />
</div>
```
**Result:**  
since `myValue` in the example is initially `null`, thanks to the modifier it will be set to `123456`
