### PR TITLE
Fix mask plugin not formatting initial value when using x-model

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -1,8 +1,9 @@
-
 export default function (Alpine) {
     Alpine.directive('mask', (el, { value, expression }, { effect, evaluateLater }) => {
         let templateFn = () => expression
         let lastInputValue = ''
+
+        let nextTick = callback => requestAnimationFrame(() => requestAnimationFrame(callback))
 
         if (['function', 'dynamic'].includes(value)) {
             // This is an x-mask:function directive.
@@ -32,10 +33,10 @@ export default function (Alpine) {
                 // - Initializing the mask on the input if it has an initial value.
                 // - Running the template function to set up reactivity, so that
                 //   when a dependency inside it changes, the input re-masks.
-                processInputValue(el)
+                nextTick(() => processInputValue(el));
             })
         } else {
-            processInputValue(el)
+            nextTick(() => processInputValue(el));
         }
 
         el.addEventListener('input', () => processInputValue(el))

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -178,3 +178,10 @@ test('$money mask should remove letters or non numeric characters',
         get('input').type('40').should(haveValue('40'))
     }
 )
+
+test('$money formats existing x-model value',
+    [html`<input x-data="{ value: 12_123 }" x-model="value" x-mask:dynamic="$money" />`],
+    ({ get }) => {
+        get('input').should(haveValue('12,123'))
+    }
+)


### PR DESCRIPTION
### Fixed

- Fixes the `$money` mask plugin which was not formatting the initial value when using `x-model`. I noticed this while I was using `wire:model`, which also doesn't get the mask applied on the initial value. Not sure if this fixes it for `wire:model`, but at least this fixes it for the `x-model`.

---

How to reproduce it:

- Alpine: https://jsbin.com/peteribaga/1/edit?html,output
- Livewire: https://laravelplayground.com/#/snippets/cd7aab0a-9445-4bf8-9c58-73f6776628e4