### PR TITLE
Replace brotli-size with zlib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
             },
             "devDependencies": {
                 "axios": "^0.21.1",
-                "brotli-size": "^4.0.0",
                 "chalk": "^4.1.1",
                 "cypress": "^7.0.0",
                 "cypress-plugin-tab": "^1.0.5",
@@ -1838,17 +1837,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/brotli-size": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "duplexer": "0.1.1"
-            },
-            "engines": {
-                "node": ">= 10.16.0"
-            }
-        },
         "node_modules/browser-process-hrtime": {
             "version": "1.0.0",
             "dev": true,
@@ -2585,10 +2573,6 @@
             "bin": {
                 "dot-json": "bin/dot-json.js"
             }
-        },
-        "node_modules/duplexer": {
-            "version": "0.1.1",
-            "dev": true
         },
         "node_modules/ecc-jsbn": {
             "version": "0.1.2",
@@ -8322,13 +8306,6 @@
                 "fill-range": "^7.0.1"
             }
         },
-        "brotli-size": {
-            "version": "4.0.0",
-            "dev": true,
-            "requires": {
-                "duplexer": "0.1.1"
-            }
-        },
         "browser-process-hrtime": {
             "version": "1.0.0",
             "dev": true
@@ -8821,10 +8798,6 @@
                 "docopt": "~0.6.2",
                 "underscore-keypath": "~0.0.22"
             }
-        },
-        "duplexer": {
-            "version": "0.1.1",
-            "dev": true
         },
         "ecc-jsbn": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     ],
     "devDependencies": {
         "axios": "^0.21.1",
-        "brotli-size": "^4.0.0",
         "chalk": "^4.1.1",
         "cypress": "^7.0.0",
         "cypress-plugin-tab": "^1.0.5",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
 let { writeToPackageDotJson, getFromPackageDotJson } = require('./utils');
 let fs = require('fs');
-let brotliSize = require('brotli-size');
+let zlib = require('zlib');
 
 ([
     // Packages:
@@ -94,7 +94,7 @@ function build(options) {
 }
 
 function outputSize(package, file) {
-    let size = bytesToSize(brotliSize.sync(fs.readFileSync(file)))
+    let size = bytesToSize(zlib.brotliCompressSync(fs.readFileSync(file)).length)
 
     console.log("\x1b[32m", `${package}: ${size}`)
 }


### PR DESCRIPTION
#### Summary

Replaces `brotli-size` with `node:zlib`. Tested, and both produce the exact same output.

#### Why?

> [`brotli-size` is] only used to indicate during building the current size of the bundled packages, so it has no actually effect.
> 
> `brotli-size` was a convenience package for compressing and displaying the size, while nodejs `zlib` is a core module that can brotli compress and then we can easily get the buffer size from there without involving third party code.
> 
> Here it looks like it's even an exact API match. So its just knocking off an unneeded dev dependency.

&mdash; @ekwoka ([source](https://github.com/alpinejs/alpine/pull/3449#issuecomment-1457698301))