### PR TITLE
Exclude dependencies from non-CDN builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
             "workspaces": [
                 "packages/*"
             ],
-            "dependencies": {
-                "nprogress": "^0.2.0"
-            },
             "devDependencies": {
                 "axios": "^0.21.1",
                 "chalk": "^4.1.1",
@@ -4933,7 +4930,8 @@
         },
         "node_modules/nprogress": {
             "version": "0.2.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+            "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
         },
         "node_modules/nwsapi": {
             "version": "2.2.0",
@@ -7104,7 +7102,10 @@
         "packages/navigate": {
             "name": "@alpinejs/navigate",
             "version": "3.10.2",
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "nprogress": "^0.2.0"
+            }
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
@@ -7152,7 +7153,10 @@
             "version": "file:packages/morph"
         },
         "@alpinejs/navigate": {
-            "version": "file:packages/navigate"
+            "version": "file:packages/navigate",
+            "requires": {
+                "nprogress": "^0.2.0"
+            }
         },
         "@alpinejs/persist": {
             "version": "file:packages/persist"
@@ -10370,7 +10374,9 @@
             }
         },
         "nprogress": {
-            "version": "0.2.0"
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+            "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
         },
         "nwsapi": {
             "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
         "jest": "jest test",
         "update-docs": "node ./scripts/update-docs.js",
         "release": "node ./scripts/release.js"
-    },
-    "dependencies": {
-        "nprogress": "^0.2.0"
     }
 }

--- a/packages/navigate/package.json
+++ b/packages/navigate/package.json
@@ -5,5 +5,8 @@
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",
-    "module": "dist/module.esm.js"
+    "module": "dist/module.esm.js",
+    "dependencies": {
+        "nprogress": "^0.2.0"
+    }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -61,6 +61,7 @@ function bundleFile(package, file) {
                 entryPoints: [`packages/${package}/builds/${file}`],
                 outfile: `packages/${package}/dist/${file.replace('.js', '.esm.js')}`,
                 bundle: true,
+                packages: 'external',
                 platform: 'neutral',
                 mainFields: ['module', 'main'],
             })
@@ -69,6 +70,7 @@ function bundleFile(package, file) {
                 entryPoints: [`packages/${package}/builds/${file}`],
                 outfile: `packages/${package}/dist/${file.replace('.js', '.cjs.js')}`,
                 bundle: true,
+                packages: 'external',
                 target: ['node10.4'],
                 platform: 'node',
             }).then(() => {


### PR DESCRIPTION
#### Summary

Marks packages as "external" for non-CDN builds. Currently, if you install `v3.12.0` of alpinejs, you will pull down `@vue/reactivity` and it's dependency into `node_modules` while also having it bundled within alpinejs. This PR excludes those dependencies only from the ESM / CJS bundles.

See somewhat related discussion / recommendation [here](https://github.com/alpinejs/alpine/discussions/3434).