### PR TITLE
Add modifier `defer` to control deferring storage

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -8,8 +8,6 @@ export default function (Alpine) {
         return Alpine.interceptor((initialValue, getter, setter, path, key) => {
             let lookup = alias || `_x_${path}`
 
-            console.log('defer:', defer);
-
             let initial = storageHas(lookup, storage)
                 ? storageGet(lookup, storage)
                 : initialValue

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -2,10 +2,13 @@ export default function (Alpine) {
     let persist = () => {
         let alias
         let storage = localStorage
+        let defer = false
         let isInitial = true
 
         return Alpine.interceptor((initialValue, getter, setter, path, key) => {
             let lookup = alias || `_x_${path}`
+
+            console.log('defer:', defer);
 
             let initial = storageHas(lookup, storage)
                 ? storageGet(lookup, storage)
@@ -16,7 +19,7 @@ export default function (Alpine) {
             Alpine.effect(() => {
                 let value = getter()
 
-                if (!isInitial) storageSet(lookup, value, storage)
+                if (!defer || !isInitial) storageSet(lookup, value, storage)
 
                 setter(value)
 
@@ -26,7 +29,8 @@ export default function (Alpine) {
             return initial
         }, func => {
             func.as = key => { alias = key; return func },
-            func.using = target => { storage = target; return func }
+            func.using = target => { storage = target; return func },
+            func.defer = target => { defer = true; return func }
         })
     }
 

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -2,6 +2,7 @@ export default function (Alpine) {
     let persist = () => {
         let alias
         let storage = localStorage
+        let isInitial = true
 
         return Alpine.interceptor((initialValue, getter, setter, path, key) => {
             let lookup = alias || `_x_${path}`
@@ -15,9 +16,11 @@ export default function (Alpine) {
             Alpine.effect(() => {
                 let value = getter()
 
-                storageSet(lookup, value, storage)
+                if (!isInitial) storageSet(lookup, value, storage)
 
                 setter(value)
+
+                isInitial = false
             })
 
             return initial

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -33,6 +33,23 @@ test('can persist string',
     },
 )
 
+test('can defer persisting a string',
+    [html`
+        <div x-data="{ message: $persist('foo').defer() }">
+            <input x-model="message">
+
+            <span x-text="message"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('foo'))
+        get('input').clear().type('bar')
+        get('span').should(haveText('bar'))
+        reload()
+        get('span').should(haveText('bar'))
+    },
+)
+
 test('can persist array',
     [html`
         <div x-data="{ things: $persist(['foo', 'bar']) }">

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -67,6 +67,23 @@ test('can persist array',
     },
 )
 
+test('can defer persisting an array',
+    [html`
+        <div x-data="{ things: $persist(['foo', 'bar']).defer() }">
+            <button @click="things.push('baz')"></button>
+
+            <span x-text="things.join('-')"></span>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('span').should(haveText('foo-bar'))
+        get('button').click()
+        get('span').should(haveText('foo-bar-baz'))
+        reload()
+        get('span').should(haveText('foo-bar-baz'))
+    },
+)
+
 test('can persist object',
     [html`
         <div x-data="{ something: $persist({foo: 'bar'}) }">


### PR DESCRIPTION
The persist plugin right now stores the value immediately on initialization. This prevents me from being able to use it in quite a few  cases, where nothing should be stored in the browser before user interaction (GDPR compliance).

This PR attempts to solve this problem by adding a new modifier `$persist('my-value').defer()` that will wait for the first mutation of the data before storing it in the browser.

In my (manual) tests, it's already working fine for primitives, but for arrays and objects there seems to be something I'm missing (cypress tests are failing for arrays/objects right now). 

If anyone from the maintainers thinks this could be a useful feature, I would be very grateful if they could have a look at why this fails with arrays. (Something inside `Alpine.effect()`, I guess...)

Actually, I'll add a failing test for arrays, so that it's easier for you guys.