### PR TITLE
Document the built-in `destroy()` lifecycle method

### DIFF
--- a/packages/docs/src/en/essentials/lifecycle.md
+++ b/packages/docs/src/en/essentials/lifecycle.md
@@ -28,6 +28,23 @@ Alpine.data('dropdown', () => ({
 }))
 ```
 
+<a name="element-destruction"></a>
+## Element destruction
+
+The `destroy()` method, if present, is called when an element is removed from the DOM.
+
+Alpine will automatically call any `destroy()` methods stored on a data object. For example:
+
+```js
+Alpine.data('dropdown', () => ({
+    destroy() {
+      // I get called before the element using this data is removed from the DOM.
+    }
+}))
+```
+
+This method can be used to clean up any logic before destroying a component, e.g. removing event listeners.
+
 <a name="after-a-state-change"></a>
 ## After a state change
 


### PR DESCRIPTION
I recently discovered that Alpine has a built-in (but undocumented) `destroy()` lifecycle method, as discussed [here](https://github.com/alpinejs/alpine/discussions/3420).

Having used it for personal purposes, I have found the method to work as expected (cleanup logic is executed before the element is removed from the DOM). It even [has tests already written for it](https://github.com/alpinejs/alpine/blob/main/tests/cypress/integration/custom-data.spec.js#L144)!

This pull request contains a bit of documentation explaining the use of this method.