### PR TITLE
More plugin Shapes

### DIFF
--- a/packages/alpinejs/src/plugin.js
+++ b/packages/alpinejs/src/plugin.js
@@ -1,7 +1,5 @@
-import Alpine from './alpine'
+import Alpine from "./alpine";
 
-export function plugin(callback, ...callbacks) {
-    if (callbacks.length) plugin(callbacks)
-    if (Array.isArray(callback)) callback.forEach(cb => cb(Alpine));
-    else callback(Alpine)
+export function plugin(...callbacks) {
+    callbacks.flat(Infinity).forEach((callback) => callback(Alpine));
 }

--- a/packages/alpinejs/src/plugin.js
+++ b/packages/alpinejs/src/plugin.js
@@ -1,5 +1,7 @@
 import Alpine from './alpine'
 
-export function plugin(callback) {
-    callback(Alpine)
+export function plugin(callback, ...callbacks) {
+    if (callbacks.length) plugin(callbacks)
+    if (Array.isArray(callback)) callback.forEach(cb => cb(Alpine));
+    else callback(Alpine)
 }


### PR DESCRIPTION
This change allows `Alpine.plugin` to accept infinitely nested arrays of plugin callbacks as well as just multiple arguments.

So while before you'd have to do

```js
Alpine.plugin(collapse)
Alpine.plugin(morph)
Alpine.plugin(ui)
```

Now you could do
```js
Alpine.plugin(collapse, morph, ui)

// or...

Alpine.plugin([collapse, morph, ui])

// or even...
Alpine.plugin(collapse, [morph, [ui]])
```

In production apps, I find it is helpful to have Alpine data and stores and such in their own files as plugin functions, as opposed to needing to bring them all together and call Alpine.data or Alpine.store on them collectively. A file can handle any stores or data it needs, and label itself, etc.

then when they are imported to be added, needing to ensure the list is flat and looping ourselves. It's relatively low cost to use this method to just allow these options out of the box to let people build their app modularly.

All the modules could import Alpine directly, but I think this is a good way as well.