### PR TITLE
Bug: Updates correct scope when x-for looping over element with x-data

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -166,7 +166,7 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
                 marker.remove()
             })
 
-            refreshScope(elForSpot, scopes[keys.indexOf(keyForSpot)])
+            refreshScope(elForSpot, scopes[keys.indexOf(keyForSpot)], true)
         }
 
         // We can now create and add new elements.
@@ -184,6 +184,7 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
             let clone = document.importNode(templateEl.content, true).firstElementChild
 
             addScopeToNode(clone, reactive(scope), templateEl)
+            clone._x_forScope = clone._x_dataStack[0]
 
             mutateDom(() => {
                 lastEl.after(clone)
@@ -202,7 +203,7 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
         // data it depends on in case the data has changed in an
         // "unobservable" way.
         for (let i = 0; i < sames.length; i++) {
-            refreshScope(lookup[sames[i]], scopes[keys.indexOf(sames[i])])
+            refreshScope(lookup[sames[i]], scopes[keys.indexOf(sames[i])], true)
         }
 
         // Now we'll log the keys (and the order they're in) for comparing

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -15,8 +15,8 @@ export function hasScope(node) {
     return !! node._x_dataStack
 }
 
-export function refreshScope(element, scope) {
-    let existingScope = element._x_dataStack[0]
+export function refreshScope(element, scope, fromXFor = false) {
+    let existingScope = (fromXFor && element._x_forScope) || element._x_dataStack[0]
 
     Object.entries(scope).forEach(([key, value]) => {
         existingScope[key] = value

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -559,3 +559,26 @@ test('renders children using directives injected by x-html correctly',
         get('p:nth-of-type(2) span').should(haveText('bar'))
     }
 )
+
+test(
+    'handles x-data directly inside x-for',
+    html`
+        <div x-data="{ items: [{x:0, k:1},{x:1, k:2}] }">
+            <button x-on:click="items = [{x:3, k:1},{x:4, k:2}]">update</button>
+            <template x-for="item in items" :key="item.k">
+                <div :id="'item-' + item.k" x-data="{ inner: true }">
+                    <span x-text="item.x.toString()"></span>:
+                    <span x-text="item.k"></span>
+                </div>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('#item-1 span:nth-of-type(1)').should(haveText('0'))
+        get('#item-2 span:nth-of-type(1)').should(haveText('1'))
+        get('button').click()
+        get('#item-1 span:nth-of-type(1)').should(haveText('3'))
+        get('#item-2 span:nth-of-type(1)').should(haveText('4'))
+    }
+);
+


### PR DESCRIPTION
solves #3447  (demos and discussion exist there)

```html
<template x-for="item in my_array" :key="item.k">
        <div x-data="{ foo: 'bar' }" >
            <div x-text="item.x"></div>
        </div>
    </template>
 ```
 
 When looping over an iterable with x-for, and the first child has an `x-data` scope, if the array changed, now containing new objects but which had the same `key` value, the scope would impropely update.
 
 This fixes that.
 
 ## The cause

The x-for does update the scope of the child, but it naively would update only the newest scope on the element. The problem is that this would be, during the update, the scope created by the `x-data` and not the `x-for`. The effects registered to the looped over object/values would be within the context of the `x-for` provided synthetic scope. This scope would continue to have the initial value.

## The fix

Store reference to the scope provided by `x-for` and use that to directly update the synthetic scope, instead of naively updating the latest scope.