### PR TITLE
Feat: create new prefix parameter to magic method $money

### DIFF
--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -184,3 +184,16 @@ You can also override the default precision of 2 digits by using any desired num
     <input type="text" x-mask:dynamic="$money($input, '.', ',', 4)"  placeholder="0.0001">
 </div>
 <!-- END_VERBATIM -->
+
+
+You can also add a prefix to your input by passing it as the fifth optional argument:
+
+```alpine
+<input x-mask:dynamic="$money($input, '.', ',', 4, '$')">
+```
+
+<!-- START_VERBATIM -->
+<div class="demo" x-data>
+    <input type="text" x-mask:dynamic="$money($input, '.', ',', 4, '$')"  placeholder="$0,00">
+</div>
+<!-- END_VERBATIM -->

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -170,7 +170,7 @@ export function buildUp(template, input) {
     return output
 }
 
-export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
+export function formatMoney(input, delimiter = '.', thousands, precision = 2, prefix = '') {
     if (input === '-') return '-'
     if (/^\D+$/.test(input)) return '9'
 
@@ -201,7 +201,7 @@ export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
 
     template = `${minus}${addThousands(template, thousands)}`
 
-    if (precision > 0 && input.includes(delimiter)) 
+    if (precision > 0 && input.includes(delimiter))
         template += `${delimiter}` + '9'.repeat(precision)
 
     queueMicrotask(() => {
@@ -212,5 +212,5 @@ export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
         }
     })
 
-    return template
+    return prefix + template
 }

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -223,3 +223,18 @@ test('$money with custom decimal precision',
         get('#3').type('1234.5678').should(haveValue('1,234.567'))
     }
 )
+
+test('$money with prefix',
+    [html`
+        <input id="0" x-data x-mask:dynamic="$money($input, ',', '.', 0, '$')" />
+        <input id="1" x-data x-mask:dynamic="$money($input, '.', ',', 1, '$ ')" />
+        <input id="2" x-data x-mask:dynamic="$money($input, ',', '.', 2, '£')" />
+        <input id="3" x-data x-mask:dynamic="$money($input, '.', ',', 3)" />
+    `],
+    ({ get }) => {
+        get('#0').type('1234.5678').should(haveValue('$12.345.678'))
+        get('#1').type('1234.5678').should(haveValue('$ 1,234.5'))
+        get('#2').type('1234,5678').should(haveValue('£1.234,56'))
+        get('#3').type('1234.5678').should(haveValue('1,234.567'))
+    }
+)


### PR DESCRIPTION
# Description

Added a new option to $money magic method called prefix, which enables the developer to add a prefix to the input field

## Files

- packages\mask\src\index.js
- tests\cypress\integration\plugins\mask.spec.js
- packages\docs\src\en\plugins\mask.md

## Tests

Tested if the new functionality is working as expected and tested if the other functionalities are not being impacted by the change.
