### PR TITLE
Handle special binding case for 'checked' and 'selected'

### DIFF
--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -22,6 +22,14 @@ export default function bind(el, name, value, modifiers = []) {
         case 'class':
             bindClasses(el, value)
             break;
+        
+        // 'selected' and 'checked' are special attributes that aren't necessarily
+        // synced with their corresponding properties when updated, so both the 
+        // attribute and property need to be updated when bound.
+        case 'selected':
+        case 'checked':
+            bindAttributeAndPropery(el, name, value)
+            break;
 
         default:
             bindAttribute(el, name, value)
@@ -78,6 +86,11 @@ function bindStyles(el, value) {
     el._x_undoAddedStyles = setStyles(el, value)
 }
 
+function bindAttributeAndPropery(el, name, value) {
+    bindAttribute(el, name, value)
+    setPropertyIfChanged(el, name, value)
+}
+
 function bindAttribute(el, name, value) {
     if ([null, undefined, false].includes(value) && attributeShouldntBePreservedIfFalsy(name)) {
         el.removeAttribute(name)
@@ -91,6 +104,12 @@ function bindAttribute(el, name, value) {
 function setIfChanged(el, attrName, value) {
     if (el.getAttribute(attrName) != value) {
         el.setAttribute(attrName, value)
+    }
+}
+
+function setPropertyIfChanged(el, propName, value) {
+    if (el[propName] !== value) {
+        el[propName] = value
     }
 }
 

--- a/tests/cypress/integration/directives/x-bind.spec.js
+++ b/tests/cypress/integration/directives/x-bind.spec.js
@@ -1,4 +1,4 @@
-import { beHidden, beVisible, haveText, beChecked, haveAttribute, haveClasses, haveValue, notBeChecked, notHaveAttribute, notHaveClasses, test, html } from '../../utils'
+import { beHidden, beVisible, haveText, beChecked, haveAttribute, haveClasses, haveProperty, haveValue, notBeChecked, notHaveAttribute, notHaveClasses, test, html } from '../../utils';
 
 test('sets attribute bindings on initialize',
     html`
@@ -450,5 +450,24 @@ test('Can retrieve Alpine bound data with global bound method',
         get('#4').should(haveText('true'))
         get('#5').should(haveText(''))
         get('#6').should(haveText('bar'))
+    }
+)
+
+test('x-bind updates checked attribute and property after user interaction',
+    html`
+        <div x-data="{ checked: true }">
+            <button @click="checked = !checked">toggle</button>
+            <input type="checkbox" x-bind:checked="checked" @change="checked = $event.target.checked" />
+        </div>
+    `,
+    ({ get }) => {
+        get('input').should(haveAttribute('checked', 'checked'))
+        get('input').should(haveProperty('checked', true))
+        get('input').click()
+        get('input').should(notHaveAttribute('checked'))
+        get('input').should(haveProperty('checked', false))
+        get('button').click()
+        get('input').should(haveAttribute('checked', 'checked'))
+        get('input').should(haveProperty('checked', true))
     }
 )

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -97,6 +97,8 @@ export let haveAttribute = (name, value) => el => expect(el).to.have.attr(name, 
 
 export let notHaveAttribute = (name, value) => el => expect(el).not.to.have.attr(name, value)
 
+export let haveProperty = (name, value) => el => expect(el).to.have.prop(name, value)
+
 export let haveText = text => el => expect(el).to.have.text(text)
 
 export let notHaveText = text => el => expect(el).not.to.have.text(text)


### PR DESCRIPTION
I ran into an interesting issue with `x-bind` and the `checked` property today. [Here's the Twitter thread](https://twitter.com/inxilpro/status/1648402525966729219) summarizing the issue, and [here's a codesandbox demo](https://codesandbox.io/s/elated-sinoussi-jvdlrv) showing it in action.

Basically, the `value`, `checked` and `selected` properties are special in that they're not kept in sync with their corresponding attributes. That means that the following is perfectly legit javascript:

```js
element.setAttribute('checked', 'checked');
element.checked = false;
```

This will result in a checkbox that is not checked, but has a checked attribute set (which, as far as I can tell, is visually checked but not "technically" checked).

Anyway, 90% of the time this won't come up because both `x-bind:value` and `x-model` have special bind logic for checkbox values that set the property rather than the attribute:

https://github.com/alpinejs/alpine/blob/6142a83956685b4ddf67d95cf70a46fa3efe5fdf/packages/alpinejs/src/utils/bind.js#L54-L58

There are some cases, though, where you want to handle both sides of the binding on your own (in our case, the checkboxes are driven from Algolia instant search state, so changing the checkbox triggers an event that then updates the state). This PR makes that case possible.