### PR TITLE
add configurable flag to $persist property definition

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -27,7 +27,7 @@ export default function (Alpine) {
         })
     }
 
-    Object.defineProperty(Alpine, '$persist', { get: () => persist() })
+    Object.defineProperty(Alpine, '$persist', { get: () => persist(), configurable: true })
     Alpine.magic('persist', persist)
     Alpine.persist = (key, { get, set }, storage = localStorage) => {
         let initial = storageHas(key, storage)


### PR DESCRIPTION
This pull request adds a configurable flag to the definition of the $persist property. Previously, attempting to redefine the $persist property would throw an error.

<img width="452" alt="Screenshot 2023-04-25 at 12 33 37" src="https://user-images.githubusercontent.com/47005900/234278764-f7585229-f958-4bb0-9b0e-c3e7943f894c.png">

I would specifically receive this error when the `alpine:init` event was triggered again in order to initialize newly added Alpine components.

With this change, the property can be redefined without issue. Please review and merge if acceptable.