### PR TITLE
:bug: Gracefully handles bad throws

### DIFF
--- a/packages/alpinejs/src/utils/error.js
+++ b/packages/alpinejs/src/utils/error.js
@@ -6,8 +6,10 @@ export function tryCatch(el, expression, callback, ...args) {
     }
 }
 
-export function handleError(error, el, expression = undefined) {
-    Object.assign( error, { el, expression } )
+export function handleError(error , el, expression = undefined) {
+    error = Object.assign( 
+        error ?? { message: 'No error message given.' }, 
+        { el, expression } )
 
     console.warn(`Alpine Expression Error: ${error.message}\n\n${ expression ? 'Expression: \"' + expression + '\"\n\n' : '' }`, el)
 


### PR DESCRIPTION
solves #3569 

Apparently some things out there might throw `undefined` or `null` causing the error handler to fail.

This just intercepts it and provides a default message in the event such a thing happens.