### PR TITLE
:bug: Prevents double bundling of Alpine in UI Package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7825,17 +7825,19 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.12.0",
+            "version": "3.12.1",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
             }
         },
         "packages/collapse": {
-            "version": "3.12.0",
+            "name": "@alpinejs/collapse",
+            "version": "3.12.1",
             "license": "MIT"
         },
         "packages/csp": {
+            "name": "@alpinejs/csp",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7843,17 +7845,21 @@
             }
         },
         "packages/docs": {
-            "version": "3.12.0-revision.1",
+            "name": "@alpinejs/docs",
+            "version": "3.12.1-revision.2",
             "license": "MIT"
         },
         "packages/focus": {
-            "version": "3.12.0",
+            "name": "@alpinejs/focus",
+            "version": "3.12.1",
             "license": "MIT",
             "dependencies": {
-                "focus-trap": "^6.6.1"
+                "focus-trap": "^6.6.1",
+                "tabbable": "^5.3.3"
             }
         },
         "packages/history": {
+            "name": "@alpinejs/history",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7861,18 +7867,22 @@
             }
         },
         "packages/intersect": {
-            "version": "3.12.0",
+            "name": "@alpinejs/intersect",
+            "version": "3.12.1",
             "license": "MIT"
         },
         "packages/mask": {
-            "version": "3.12.0",
+            "name": "@alpinejs/mask",
+            "version": "3.12.1",
             "license": "MIT"
         },
         "packages/morph": {
-            "version": "3.12.0",
+            "name": "@alpinejs/morph",
+            "version": "3.12.1",
             "license": "MIT"
         },
         "packages/navigate": {
+            "name": "@alpinejs/navigate",
             "version": "3.10.2",
             "license": "MIT",
             "dependencies": {
@@ -7880,12 +7890,20 @@
             }
         },
         "packages/persist": {
-            "version": "3.12.0",
+            "name": "@alpinejs/persist",
+            "version": "3.12.1",
             "license": "MIT"
         },
         "packages/ui": {
-            "version": "3.12.0-beta.0",
-            "license": "MIT"
+            "name": "@alpinejs/ui",
+            "version": "3.12.1-beta.0",
+            "license": "MIT",
+            "devDependencies": {
+                "alpinejs": "file:../alpinejs"
+            },
+            "peerDependencies": {
+                "alpinejs": "^3.10.0"
+            }
         }
     }
 }

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -14,6 +14,7 @@
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
     "dependencies": {
-        "focus-trap": "^6.6.1"
+        "focus-trap": "^6.6.1",
+        "tabbable": "^5.3.3"
     }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,5 +13,10 @@
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
-    "dependencies": {}
+    "devDependencies": {
+        "alpinejs": "file:../alpinejs"
+    },
+    "peerDependencies": {
+        "alpinejs": "^3.10.0"
+    }
 }

--- a/packages/ui/src/list-context.js
+++ b/packages/ui/src/list-context.js
@@ -1,4 +1,4 @@
-import Alpine from "../../alpinejs/src/alpine"
+import Alpine from "alpinejs";
 
 export function generateContext(multiple, orientation) {
     return {


### PR DESCRIPTION
Before this, the `@alpinejs/ui` package included inside itself a whole other copy of `alpinejs` since it referenced the internal file, not through the module system. This causes a few issues during actual runtime.

This also fixes the long standing issue where `tabbable` was not actually available to the `focus` plugin.