### PR TITLE
:bug: Directs Vue Reactivity Import to Browser Version

### DIFF
--- a/packages/alpinejs/src/index.js
+++ b/packages/alpinejs/src/index.js
@@ -36,7 +36,7 @@ Alpine.setEvaluator(normalEvaluator)
  * Alpine that triggers an element with x-text="message"
  * to update its inner text when "message" is changed.
  */
-import { reactive, effect, stop, toRaw } from '@vue/reactivity'
+import { reactive, effect, stop, toRaw } from '@vue/reactivity/dist/reactivity.esm-browser'
 
 Alpine.setReactivityEngine({ reactive, effect, release: stop, raw: toRaw })
 

--- a/packages/csp/src/index.js
+++ b/packages/csp/src/index.js
@@ -2,7 +2,7 @@ import Alpine from 'alpinejs/src/alpine'
 
 Alpine.setEvaluator(cspCompliantEvaluator)
 
-import { reactive, effect, stop, toRaw } from '@vue/reactivity'
+import { reactive, effect, stop, toRaw } from '@vue/reactivity/dist/reactivity.esm-browser'
 Alpine.setReactivityEngine({ reactive, effect, release: stop, raw: toRaw })
 
 import 'alpinejs/src/magics/index'


### PR DESCRIPTION
## Problem

As mentioned [here](https://github.com/alpinejs/alpine/discussions/3573) and some other places, for people using outdated CDN systems for their JS, no longer bundling dependencies has caused some issues with @vue/reactivity.

Vue reactivity points to a version that is for the server, and bundlers are smart enough to handle this (and instead use the provided browser version right next to it).

However, some cdns that let people add packages in the browser do not do these kinds of checks, causing a failure.

Alpine used to prebundle all the dependencies, which masked this issue as Alpine's build step was handling this negotiation. However, prebundling dependencies is generally a bad practice as it can increase unneeded code duplication and reduce consumer control.


## Solution

This ~~solves~~ should solve the problem by pointing the imports directly at the browser safe version of the module so that modern bundlers, and outdated systems alike can use the correct browser-safe version of the reactivity engine.