### PR TITLE
$focus: Add 'onlyTabbables' modifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7825,17 +7825,19 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.12.0",
+            "version": "3.12.2",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
             }
         },
         "packages/collapse": {
-            "version": "3.12.0",
+            "name": "@alpinejs/collapse",
+            "version": "3.12.2",
             "license": "MIT"
         },
         "packages/csp": {
+            "name": "@alpinejs/csp",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7843,17 +7845,20 @@
             }
         },
         "packages/docs": {
-            "version": "3.12.0-revision.1",
+            "name": "@alpinejs/docs",
+            "version": "3.12.2-revision.1",
             "license": "MIT"
         },
         "packages/focus": {
-            "version": "3.12.0",
+            "name": "@alpinejs/focus",
+            "version": "3.12.2",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.6.1"
             }
         },
         "packages/history": {
+            "name": "@alpinejs/history",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7861,18 +7866,22 @@
             }
         },
         "packages/intersect": {
-            "version": "3.12.0",
+            "name": "@alpinejs/intersect",
+            "version": "3.12.2",
             "license": "MIT"
         },
         "packages/mask": {
-            "version": "3.12.0",
+            "name": "@alpinejs/mask",
+            "version": "3.12.2",
             "license": "MIT"
         },
         "packages/morph": {
-            "version": "3.12.0",
+            "name": "@alpinejs/morph",
+            "version": "3.12.2",
             "license": "MIT"
         },
         "packages/navigate": {
+            "name": "@alpinejs/navigate",
             "version": "3.10.2",
             "license": "MIT",
             "dependencies": {
@@ -7880,11 +7889,13 @@
             }
         },
         "packages/persist": {
-            "version": "3.12.0",
+            "name": "@alpinejs/persist",
+            "version": "3.12.2",
             "license": "MIT"
         },
         "packages/ui": {
-            "version": "3.12.0-beta.0",
+            "name": "@alpinejs/ui",
+            "version": "3.12.1-beta.0",
             "license": "MIT"
         }
     }

--- a/packages/docs/src/en/plugins/focus.md
+++ b/packages/docs/src/en/plugins/focus.md
@@ -312,6 +312,7 @@ This plugin offers many smaller utilities for managing focus within a page. Thes
 | `focusable(el)`   | Detect whether or not an element is focusable |
 | `focusables()`   | Get all "focusable" elements within the current element |
 | `tabbables()`   | Get all "tabbable" elements within the current element |
+| `onlyTabbables()` | Specifies that any focus "action" should only act on `focusable` elements. (next, previous, within, etc.) |
 | `focused()`   | Get the currently focused element on the page |
 | `lastFocused()`   | Get the last focused element on the page |
 | `within(el)`   | Specify an element to scope the `$focus` magic to (the current element by default) |

--- a/packages/docs/src/en/plugins/focus.md
+++ b/packages/docs/src/en/plugins/focus.md
@@ -311,6 +311,7 @@ This plugin offers many smaller utilities for managing focus within a page. Thes
 | `focus(el)`   | Focus the passed element (handling annoyances internally: using nextTick, etc.) |
 | `focusable(el)`   | Detect whether or not an element is focusable |
 | `focusables()`   | Get all "focusable" elements within the current element |
+| `tabbables()`   | Get all "tabbable" elements within the current element |
 | `focused()`   | Get the currently focused element on the page |
 | `lastFocused()`   | Get the last focused element on the page |
 | `within(el)`   | Specify an element to scope the `$focus` magic to (the current element by default) |

--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -25,7 +25,7 @@ export default function (Alpine) {
             withTabbables() { this.__tabbableOnly = true; return this },
             tabbables() { return this.withTabbables() },
             focusable(el) {
-                return __tabbableOnly ? isTabbable(el) : isFocusable(el)
+                return this.__tabbableOnly ? isTabbable(el) : isFocusable(el)
             },
             previouslyFocused() {
                 return lastFocused

--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -22,10 +22,12 @@ export default function (Alpine) {
             noscroll() { this.__noscroll = true; return this },
             withWrapAround() { this.__wrapAround = true; return this },
             wrap() { return this.withWrapAround() },
-            withTabbables() { this.__tabbableOnly = true; return this },
-            tabbables() { return this.withTabbables() },
+            onlyTabbables() { this.__tabbableOnly = true; return this },
             focusable(el) {
-                return this.__tabbableOnly ? isTabbable(el) : isFocusable(el)
+                return isFocusable(el)
+            },
+            tabbable(el) {
+                return isTabbable(el)
             },
             previouslyFocused() {
                 return lastFocused
@@ -39,9 +41,16 @@ export default function (Alpine) {
             focusables() {
                 if (Array.isArray(within)) return within
 
-                return (this.__tabbableOnly ? tabbable : focusable)(within, { displayCheck: 'none' });
+                return focusable(within, { displayCheck: 'none' })
             },
-            all() { return this.focusables() },
+            tabbables() {
+                if (Array.isArray(within)) return within
+
+                return tabbable(within, { displayCheck: 'none' })
+            },
+            all() {
+                return this.__tabbableOnly ? this.tabbables() : this.focusables()
+            },
             isFirst(el) {
                 let els = this.all()
 

--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -1,5 +1,5 @@
 import { createFocusTrap } from 'focus-trap'
-import { focusable, isFocusable } from 'tabbable'
+import { focusable, isFocusable, isTabbable } from 'tabbable'
 
 export default function (Alpine) {
     let lastFocused
@@ -16,13 +16,16 @@ export default function (Alpine) {
         return {
             __noscroll: false,
             __wrapAround: false,
+            __tabbableOnly: false,
             within(el) { within = el; return this },
             withoutScrolling() { this.__noscroll = true; return this },
             noscroll() { this.__noscroll = true; return this },
             withWrapAround() { this.__wrapAround = true; return this },
             wrap() { return this.withWrapAround() },
+            withTabbables() { this.__tabbableOnly = true; return this },
+            tabbables() { return this.withTabbables() },
             focusable(el) {
-                return isFocusable(el)
+                return __tabbableOnly ? isTabbable(el) : isFocusable(el)
             },
             previouslyFocused() {
                 return lastFocused

--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -1,5 +1,5 @@
 import { createFocusTrap } from 'focus-trap'
-import { focusable, isFocusable, isTabbable } from 'tabbable'
+import { focusable, tabbable, isFocusable, isTabbable } from 'tabbable'
 
 export default function (Alpine) {
     let lastFocused
@@ -39,7 +39,7 @@ export default function (Alpine) {
             focusables() {
                 if (Array.isArray(within)) return within
 
-                return focusable(within, { displayCheck: 'none' })
+                return (this.__tabbableOnly ? tabbable : focusable)(within, { displayCheck: 'none' });
             },
             all() { return this.focusables() },
             isFirst(el) {

--- a/tests/cypress/integration/plugins/focus.spec.js
+++ b/tests/cypress/integration/plugins/focus.spec.js
@@ -203,8 +203,8 @@ test('$focus.focusable',
 test('$focus.tabbables.focusable',
     [html`
         <div x-data>
-            <button id="1" tabindex="-1" x-text="$focus.tabbables().focusable($el)"></button>
-            <button id="2" x-text="$focus.tabbables().focusable($el)"></button>
+            <button id="1" tabindex="-1" x-text="$focus.tabbable($el)"></button>
+            <button id="2" x-text="$focus.tabbable($el)"></button>
         </div>
     `],
     ({ get }) => {
@@ -220,22 +220,6 @@ test('$focus.focusables',
             <div x-ref="container">
                 <button>1</button>
                 <div>2</div>
-                <button>3</button>
-            </div>
-        </div>
-    `],
-    ({ get }) => {
-        get('h1').should(haveText('2'))
-    },
-)
-
-test('$focus.tabbables.focusables',
-    [html`
-        <div x-data>
-            <h1 x-text="$focus.tabbables().within($refs.container).focusables().length"></h1>
-            <div x-ref="container">
-                <button>1</button>
-                <button tabindex="-1">2</button>
                 <button>3</button>
             </div>
         </div>
@@ -320,6 +304,38 @@ test('$focus.prev',
     ({ get }) => {
         get('#1').click()
         get('#1').should(haveText('2'))
+    },
+)
+
+test('$focus.onlyTabbables.next',
+    [html`
+        <div x-data>
+            <div x-ref="first">
+                <button id="1" @click="$focus.onlyTabbables().within($refs.first).next(); $nextTick(() => $el.textContent = $focus.focused().textContent)">1</button>
+                <button tabindex="-1">2</button>
+                <button>3</button>
+            </div>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').click()
+        get('#1').should(haveText('3'))
+    },
+)
+
+test('$focus.onlyTabbables.prev',
+    [html`
+        <div x-data>
+            <div x-ref="first">
+                <button>3</button>
+                <button tabindex="-1">2</button>
+                <button id="1" @click="$focus.onlyTabbables().within($refs.first).prev(); $nextTick(() => $el.textContent = $focus.focused().textContent)">1</button>
+            </div>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').click()
+        get('#1').should(haveText('3'))
     },
 )
 

--- a/tests/cypress/integration/plugins/focus.spec.js
+++ b/tests/cypress/integration/plugins/focus.spec.js
@@ -200,6 +200,19 @@ test('$focus.focusable',
     },
 )
 
+test('$focus.tabbables.focusable',
+    [html`
+        <div x-data>
+            <button id="1" tabindex="-1" x-text="$focus.tabbables().focusable($el)"></button>
+            <button id="2" x-text="$focus.tabbables().focusable($el)"></button>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveText('false'))
+        get('#2').should(haveText('true'))
+    },
+)
+
 test('$focus.focusables',
     [html`
         <div x-data>
@@ -207,6 +220,22 @@ test('$focus.focusables',
             <div x-ref="container">
                 <button>1</button>
                 <div>2</div>
+                <button>3</button>
+            </div>
+        </div>
+    `],
+    ({ get }) => {
+        get('h1').should(haveText('2'))
+    },
+)
+
+test('$focus.tabbables.focusables',
+    [html`
+        <div x-data>
+            <h1 x-text="$focus.within($refs.container).tabbables().focusables().length"></h1>
+            <div x-ref="container">
+                <button>1</button>
+                <button tabindex="-1">2</button>
                 <button>3</button>
             </div>
         </div>

--- a/tests/cypress/integration/plugins/focus.spec.js
+++ b/tests/cypress/integration/plugins/focus.spec.js
@@ -232,7 +232,7 @@ test('$focus.focusables',
 test('$focus.tabbables.focusables',
     [html`
         <div x-data>
-            <h1 x-text="$focus.within($refs.container).tabbables().focusables().length"></h1>
+            <h1 x-text="$focus.tabbables().within($refs.container).focusables().length"></h1>
             <div x-ref="container">
                 <button>1</button>
                 <button tabindex="-1">2</button>


### PR DESCRIPTION
This PR adds `tabbables` modifier to `$focus` plugin to allow traversing ONLY the tabbable elements.
