### PR TITLE
:construction_worker: Transpiles CDN builds to es2017

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -37,6 +37,7 @@ function bundleFile(package, file) {
                 outfile: `packages/${package}/dist/${file}`,
                 bundle: true,
                 platform: 'browser',
+                target: 'es2017',
                 define: { CDN: 'true' },
             })
 
@@ -47,6 +48,7 @@ function bundleFile(package, file) {
                 bundle: true,
                 minify: true,
                 platform: 'browser',
+                target: 'es2017',
                 define: { CDN: 'true' },
             }).then(() => {
                 outputSize(package, `packages/${package}/dist/${file.replace('.js', '.min.js')}`)


### PR DESCRIPTION
Addresses: #3619 

ES2017 is the lowest absolutely required version of Alpine and is a common target still (but hopefully not too long).

This PR targets CDN builds to es2017.

Transpiling of modules to other targets is left to the consumer, as it should be.