### PR TITLE
Adds hydration for x-for

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -25,7 +25,6 @@ directive('for', (el, { modifiers, expression }, { Alpine, effect, cleanup }) =>
         let curEl = el;
         while (curEl = curEl.nextElementSibling) {
             const key = curEl.getAttribute(':key')
-                curEl.getAttribute(':key')
             if (key === null) {
                 break
             }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alpinejs/docs",
-    "version": "3.12.2-revision.1",
+    "version": "3.12.2-revision.2",
     "description": "The documentation for Alpine",
     "author": "Caleb Porzio",
     "license": "MIT"

--- a/packages/docs/src/en/directives/for.md
+++ b/packages/docs/src/en/directives/for.md
@@ -107,3 +107,23 @@ but this code will work:
     </p>
 </template>
 ```
+
+<a name="hydrating-from-rendered-html"></a>
+## Hydrating from rendered HTML
+To allow server side rendering of the `x-for` loop, you can use the `.hydrate` modifier and `:key` on _both_ the template and the rendered elements as follows:
+```alpine
+<ul x-data="{ colors: [
+    { id: 1, label: 'Red' },
+    { id: 2, label: 'Orange' },
+    { id: 3, label: 'Yellow' },
+]}">
+    <template x-for="color in colors" :key="color.id">
+        <li x-text="color.label"></li>
+    </template>
+    <li :key="1">Red</li>
+    <li :key="2">Orange</li>
+    <li :key="3">Yellow</li>
+</ul>
+```
+
+On initialize, the `x-for` directive will find all continuous siblings of the `<template>` and populate the current state. It will then update the list with any differences to the data.

--- a/packages/docs/src/en/directives/for.md
+++ b/packages/docs/src/en/directives/for.md
@@ -120,10 +120,31 @@ To allow server side rendering of the `x-for` loop, you can use the `.hydrate` m
     <template x-for="color in colors" :key="color.id">
         <li x-text="color.label"></li>
     </template>
-    <li :key="1">Red</li>
-    <li :key="2">Orange</li>
-    <li :key="3">Yellow</li>
+    <li :key="1" x-text="color.label">Red</li>
+    <li :key="2" x-text="color.label">Orange</li>
+    <li :key="3" x-text="color.label">Yellow</li>
 </ul>
 ```
 
 On initialize, the `x-for` directive will find all continuous siblings of the `<template>` and populate the current state. It will then update the list with any differences to the data.
+
+### Note on removed items
+Items that are not present in `x-data` will be automatically removed upon hydration. However, if those items contain directives that reference the loop variable, you will get errors. If you need to support that scenario, it is recommended that you use Morph (see below).
+
+### Using with Morph
+If you are using Morph, you should leave the directives off of the static markup and Morph will automatically add them for you. This is force the static markup to also have a matching layout to the template when difference exist, while still allowing you to server render the template.
+
+```alpine
+<ul x-data="{ colors: [
+    { id: 1, label: 'Red' },
+    { id: 2, label: 'Orange' },
+    { id: 3, label: 'Yellow' },
+]}">
+    <template x-for.hydrate="color in colors" :key="color.id">
+        <li x-text="color.label" style="color: blue"></li>
+    </template>
+    <li :key="2">Orange</li>
+    <li :key="3">Red</li>
+    <li :key="1">Red</li>
+</ul>
+```

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -625,7 +625,7 @@ test('x-for hydration of server side rendering',
     }
 )
 
-test('x-for hydration of server side rendering with integer keys',
+test.noMorph('x-for hydration of server side rendering with integer keys without morph',
     html`
         <div x-data="{ items: [{x:0, k:1},{x:1, k:2}] }">
             <template x-for.hydrate.int="item in items" :key="item.k">
@@ -639,6 +639,82 @@ test('x-for hydration of server side rendering with integer keys',
     `,
     ({ get }) => {
         get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(1)').should((el) => expect(el).to.not.have.attr('x-text'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(2)').should((el) => expect(el).to.not.have.attr('x-text'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+    }
+)
+
+test.noMorph('x-for hydration reactivity on update without morph',
+    html`
+        <div x-data="{ items: [{x:0, k:'a'},{x:1, k:'b'}] }">
+            <button @click="items[0].x = 2">Update</button>
+            <template x-for.hydrate="item in items" :key="item.k">
+                <span x-text="item.x"></span>
+            </template>
+            <span :key="a" x-text="item.x">0</span>
+            <span :key="b" x-text="item.x">1</span>
+            <span>Unmanaged!</span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+        get('button').click()
+        get('span:nth-of-type(1)').should(haveText('2'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+    }
+)
+
+test.noMorph('x-for hydration reactivity on update without morph with removals',
+    html`
+        <div x-data="{ items: [{x:0, k:'a'},{x:1, k:'b'}] }">
+            <button @click="items[0].x = 2">Update</button>
+            <template x-for.hydrate="item in items" :key="item.k">
+                <span x-text="item.x"></span>
+            </template>
+            <span :key="a" x-text="item.x">0</span>
+            <span :key="b" x-text="item.x">1</span>
+            <span :key="c" x-text="item.x">2</span>
+            <span>Unmanaged!</span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+        get('button').click()
+        get('span:nth-of-type(1)').should(haveText('2'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+    },
+    true
+)
+
+test('x-for hydration reactivity on update with morph',
+    html`
+        <div x-data="{ items: [{x:0, k:'a'},{x:1, k:'b'}] }">
+            <button @click="items[0].x = 2">Update</button>
+            <template x-for.hydrate="item in items" :key="item.k">
+                <span x-text="item.x"></span>
+            </template>
+            <span :key="a">0</span>
+            <span :key="b">1</span>
+            <span :key="c">2</span>
+            <span>Unmanaged!</span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(1)').should((el) => expect(el).to.have.attr('x-text'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(2)').should((el) => expect(el).to.have.attr('x-text'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+        get('button').click()
+        get('span:nth-of-type(1)').should(haveText('2'))
         get('span:nth-of-type(2)').should(haveText('1'))
         get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
     }

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -605,3 +605,41 @@ test('x-for throws descriptive error when key is undefined',
     ({ get }) => {},
     true
 )
+
+test('x-for hydration of server side rendering',
+    html`
+        <div x-data="{ items: [{x:0, k:'a'},{x:1, k:'b'}] }">
+            <template x-for.hydrate="item in items" :key="item.k">
+                <span x-text="item.x"></span>
+            </template>
+            <span :key="a">0</span>
+            <span :key="b">1</span>
+            <span :key="c">2</span>
+            <span>Unmanaged!</span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+    }
+)
+
+test('x-for hydration of server side rendering with integer keys',
+    html`
+        <div x-data="{ items: [{x:0, k:1},{x:1, k:2}] }">
+            <template x-for.hydrate.int="item in items" :key="item.k">
+                <span x-text="item.x"></span>
+            </template>
+            <span :key="1">0</span>
+            <span :key="2">1</span>
+            <span :key="3">2</span>
+            <span>Unmanaged!</span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(2)').should(haveText('1'))
+        get('span:nth-of-type(3)').should(haveText('Unmanaged!'))
+    }
+)

--- a/tests/cypress/spec-no-morph.html
+++ b/tests/cypress/spec-no-morph.html
@@ -1,0 +1,56 @@
+<html>
+    <!-- Using a <blockquote> because it's an obscure tag -->
+    <!-- which allows us to use document.querySelector()  -->
+    <!-- with generic tags freely inside Cypress tests.   -->
+    <blockquote id="root">
+        <!-- This is where our test subjects will be injected. -->
+    </blockquote>
+
+    <script src="/../../packages/history/dist/cdn.js"></script>
+    <script src="/../../packages/persist/dist/cdn.js"></script>
+    <script src="/../../packages/focus/dist/cdn.js"></script>
+    <script src="/../../packages/intersect/dist/cdn.js"></script>
+    <script src="/../../packages/collapse/dist/cdn.js"></script>
+    <script src="/../../packages/mask/dist/cdn.js"></script>
+    <script src="/../../packages/ui/dist/cdn.js"></script>
+    <script>
+        let root = document.querySelector('#root')
+
+        // We aren't loading Alpine directly because we are expecting
+        // Cypress to inject HTML into "#root", THEN we'll call
+        // this function from Cypress to boot everything up.
+        root.evalScripts = (extraJavaScript) => {
+            // Load bespoke JavaScript.
+            if (extraJavaScript) {
+                let script = document.createElement('script')
+                script.src = `data:text/javascript;base64,${btoa(`
+                    document.addEventListener('alpine:init', () => {
+                        ${extraJavaScript}
+                    })
+                `)}`
+                root.after(script)
+            }
+
+            // Load all injected script tags.
+            root.querySelectorAll('script').forEach(el => {
+                eval(el.innerHTML)
+            })
+
+            // Load Alpine.
+            let script = document.createElement('script')
+
+            script.src = '/../../packages/alpinejs/dist/cdn.js'
+
+            root.after(script)
+
+            document.addEventListener('alpine:initialized', () => {
+                let readyEl = document.createElement('blockquote')
+                readyEl.setAttribute('alpine-is-ready', true)
+                readyEl.style.width = '1px'
+                readyEl.style.height = '1px'
+
+                document.querySelector('blockquote').after(readyEl)
+            })
+        }
+    </script>
+</html>

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -36,6 +36,12 @@ test.retry = (count) => (name, template, callback, handleExpectedErrors = false)
     })
 }
 
+test.noMorph = (name, template, callback, handleExpectedErrors = false) => {
+    it(name, () => {
+        injectHtmlAndBootAlpine(cy, template, callback, __dirname+'/spec-no-morph.html', handleExpectedErrors)
+    })
+}
+
 test.csp = (name, template, callback, handleExpectedErrors = false) => {
     it(name, () => {
         injectHtmlAndBootAlpine(cy, template, callback, __dirname+'/spec-csp.html', handleExpectedErrors)


### PR DESCRIPTION
This PR adds the ability to hydrate an `x-for` directive, allowing server side rendered loop results to be taken over for management by Alpine!

### Note #3624 was opened whilst I was working on this
I hadn't seen that #3624 until I was prepping to push my version. It takes a slightly different approach, doesn't support a couple things, but also works in my testing where #3624 didn't. Really happy to try and collaborate with @ekwoka to get a "best of both" solution!

From a user's perspective, it's almost identical. Though I had some issues with numeric vs string keys and added a `hydrate.int` modifier that typecast the keys and I opted for `:key` (for the exact reason called out in #3624.

Under the covers, the code is a little simpler, though possible more repetitive as scoping is duplicated rather than abstracted. This version _does_ handle additional keys that need to be removed (called out as a limitation in #3624), and opts to stop when it encounters an element without a `:key`, considering those to be the end of the scope of the loop.