### PR TITLE
Morph key lookup issue

### DIFF
--- a/packages/morph/src/dom.js
+++ b/packages/morph/src/dom.js
@@ -14,11 +14,17 @@ export let dom = {
     replace(children, old, replacement) {
         let index = children.indexOf(old)
 
+        let replacementIndex = children.indexOf(old)
+
         if (index === -1) throw 'Cant find element in children'
 
         old.replaceWith(replacement)
 
         children[index] = replacement
+
+        if (replacementIndex) {
+            children.splice(replacementIndex, 1)
+        }
 
         return children
     },

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -132,7 +132,7 @@ export function morph(from, toHtml, options) {
 
     function patchChildren(fromChildren, toChildren, appendFn) {
         // I think I can get rid of this for now:
-        let fromKeyDomNodeMap = {} // keyToMap(fromChildren)
+        let fromKeyDomNodeMap = keyToMap(fromChildren)
         let fromKeyHoldovers = {}
 
         let currentTo = dom.first(toChildren)

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -247,6 +247,35 @@ test('can morph using a custom key function',
     },
 )
 
+test('can morph using keys with existing key to be moved up',
+    [html`
+        <ul>
+            <li key="1">foo<input></li>
+            <li key="2">bar<input></li>
+            <li key="3">baz<input></li>
+        </ul>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+            <ul>
+                <li key="1">foo<input></li>
+                <li key="3">baz<input></li>
+            </ul>
+        `
+
+        get('li:nth-of-type(1) input').type('foo')
+        get('li:nth-of-type(3) input').type('baz')
+
+        get('ul').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('li').should(haveLength(2))
+        get('li:nth-of-type(1)').should(haveText('foo'))
+        get('li:nth-of-type(2)').should(haveText('baz'))
+        get('li:nth-of-type(1) input').should(haveValue('foo'))
+        get('li:nth-of-type(2) input').should(haveValue('baz'))
+    },
+)
+
 test('can morph text nodes',
     [html`<h2>Foo <br> Bar</h2>`],
     ({ get }, reload, window, document) => {


### PR DESCRIPTION
This PR fixes an issue with morph, where if the key already exists in the DOM and is to be moved up during morph, it wasn't getting moved correctly.

The reason was, that `fromKeyDomNodeMap` was empty, so the `fromKeyNode` in the below snippet was always empty, so the move "from" key was never running.

https://github.com/alpinejs/alpine/blob/a9206161f0bf878d41a001197553613cf31cbde9/packages/morph/src/morph.js#L259-L265

Removing the commented out `keyToMap(fromChildren)` got it working, but then caused an infinite loop. This was due to `dom.replace()` replacing the old with the new, but leaving the new one in its place in the array, causing two references to the dom node. So then when any `dom.()` methods run and try to find the index of the node, there would be two of them but only the first was ever returned. I opted to update `dom.replace()` but this could also be done in the above from key move code.

This fixes livewire/next#99

There is a failing test `directives/x-bind-style.spec.js ` but running those tests locally they pass, so I believe it's unrelated.

Hope this helps!