### PR TITLE
bump focus-trap version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7825,17 +7825,19 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.12.0",
+            "version": "3.12.3",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
             }
         },
         "packages/collapse": {
-            "version": "3.12.0",
+            "name": "@alpinejs/collapse",
+            "version": "3.12.3",
             "license": "MIT"
         },
         "packages/csp": {
+            "name": "@alpinejs/csp",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7843,17 +7845,20 @@
             }
         },
         "packages/docs": {
-            "version": "3.12.0-revision.1",
+            "name": "@alpinejs/docs",
+            "version": "3.12.3-revision.1",
             "license": "MIT"
         },
         "packages/focus": {
-            "version": "3.12.0",
+            "name": "@alpinejs/focus",
+            "version": "3.12.3",
             "license": "MIT",
             "dependencies": {
-                "focus-trap": "^6.6.1"
+                "focus-trap": "^6.9.4"
             }
         },
         "packages/history": {
+            "name": "@alpinejs/history",
             "version": "3.0.0-alpha.0",
             "license": "MIT",
             "dependencies": {
@@ -7861,18 +7866,22 @@
             }
         },
         "packages/intersect": {
-            "version": "3.12.0",
+            "name": "@alpinejs/intersect",
+            "version": "3.12.3",
             "license": "MIT"
         },
         "packages/mask": {
-            "version": "3.12.0",
+            "name": "@alpinejs/mask",
+            "version": "3.12.3",
             "license": "MIT"
         },
         "packages/morph": {
-            "version": "3.12.0",
+            "name": "@alpinejs/morph",
+            "version": "3.12.3",
             "license": "MIT"
         },
         "packages/navigate": {
+            "name": "@alpinejs/navigate",
             "version": "3.10.2",
             "license": "MIT",
             "dependencies": {
@@ -7880,11 +7889,13 @@
             }
         },
         "packages/persist": {
-            "version": "3.12.0",
+            "name": "@alpinejs/persist",
+            "version": "3.12.3",
             "license": "MIT"
         },
         "packages/ui": {
-            "version": "3.12.0-beta.0",
+            "name": "@alpinejs/ui",
+            "version": "3.12.3-beta.0",
             "license": "MIT"
         }
     }

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -14,6 +14,6 @@
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
     "dependencies": {
-        "focus-trap": "^6.6.1"
+        "focus-trap": "^6.9.4"
     }
 }

--- a/tests/cypress/integration/directives/x-bind-style.spec.js
+++ b/tests/cypress/integration/directives/x-bind-style.spec.js
@@ -40,7 +40,7 @@ test('style attribute object binding with CSS variable',
         </div>
     `,
     ({ get }) => {
-        get('div').should(haveAttribute('style', '--MyCSS-Variable: 0.25;'))
+        get('div').should(haveAttribute('style', '--MyCSS-Variable:0.25;'))
     }
 )
 
@@ -62,7 +62,7 @@ test('CSS custom properties are set',
         </div>
     `,
     ({ get }) => {
-        get('span').should(haveAttribute('style', 'color: var(--custom-prop); --custom-prop: #f00;'))
+        get('span').should(haveAttribute('style', 'color: var(--custom-prop); --custom-prop:#f00;'))
     }
 )
 
@@ -73,6 +73,6 @@ test('existing CSS custom properties are preserved',
         </div>
     `,
     ({ get }) => {
-        get('span').should(haveAttribute('style', 'color: var(--custom-prop-b); --custom-prop-a: red; --custom-prop-b: var(--custom-prop-a);'))
+        get('span').should(haveAttribute('style', 'color: var(--custom-prop-b); --custom-prop-a: red; --custom-prop-b:var(--custom-prop-a);'))
     }
 )


### PR DESCRIPTION
Shadow DOM support  is added by focus-trap in 6.8.0 , updating the dependency so that x-trap working with Shadow DOM . 
https://github.com/alpinejs/alpine/discussions/3663