### PR TITLE
:sparkles: Allows returning a function from init to run after unmount

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -33,10 +33,10 @@ directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
 
     let initReturn;
     if ('init' in reactiveData) evaluate(el, function () { initReturn = reactiveData.init.call(this) })
-    console.error('initReturn', initReturn)
+
     cleanup(async () => {
         reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])
-        console.error('cleaning up data')
+
         if (initReturn instanceof Promise) initReturn = await initReturn
         if (typeof initReturn === 'function') evaluate(el, initReturn)
 

--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -31,10 +31,14 @@ directive('data', skipDuringClone((el, { expression }, { cleanup }) => {
 
     let undo = addScopeToNode(el, reactiveData)
 
-    reactiveData['init'] && evaluate(el, reactiveData['init'])
-
-    cleanup(() => {
+    let initReturn;
+    if ('init' in reactiveData) evaluate(el, function () { initReturn = reactiveData.init.call(this) })
+    console.error('initReturn', initReturn)
+    cleanup(async () => {
         reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])
+        console.error('cleaning up data')
+        if (initReturn instanceof Promise) initReturn = await initReturn
+        if (typeof initReturn === 'function') evaluate(el, initReturn)
 
         undo()
     })

--- a/tests/cypress/integration/custom-data.spec.js
+++ b/tests/cypress/integration/custom-data.spec.js
@@ -141,6 +141,49 @@ test('init functions have access to the parent scope',
     }
 )
 
+test('methods returned from init functions are called during data cleanup', 
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('test', () => ({
+                    init() {
+                        return () => document.querySelector('span').textContent = 'cleanedup'
+                    },
+                }))
+            })
+        </script>
+        <span></span>
+        <div x-data="test">
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('div').then(el => el.remove())
+        get('span').should(haveText('cleanedup'))
+    }
+)
+test('methods returned from async init functions are called during data cleanup', 
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.data('test', () => ({
+                    async init() {
+                        return () => document.querySelector('span').textContent = 'cleanedup'
+                    },
+                }))
+            })
+        </script>
+        <span></span>
+        <div x-data="test">
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('div').then(el => el.remove())
+        get('span').should(haveText('cleanedup'))
+    }
+)
+
 test('destroy functions inside custom datas are called automatically',
     html`
         <script>


### PR DESCRIPTION
This PR enables the common behavior in component based UI systems, where an `onmount` function can return a function that will then be called at cleanup.

This would be an alternative to `destroy`, especially for cleaning up any `effect` made in `init` but with the benefit of not needing to manage storing data outside of the closure.

This also handles `async init` methods that would return a promise that resolves to the cleanup