### PR TITLE
:bug: Fixes reference bug for uninitalized variables

### DIFF
--- a/packages/navigate/src/page.js
+++ b/packages/navigate/src/page.js
@@ -54,7 +54,7 @@ function mergeNewHead(newHead) {
     // Only add scripts and styles that aren't already loaded on the page.
     let garbageCollector = document.createDocumentFragment()
 
-    for (child of Array.from(newHead.children)) {
+    for (const child of Array.from(newHead.children)) {
         if (isAsset(child)) {
             if (! headChildrenHtmlLookup.includes(child.outerHTML)) {
                 if (isScript(child)) {
@@ -71,12 +71,12 @@ function mergeNewHead(newHead) {
     // How to free up the garbage collector?
 
     // Remove existing non-asset elements like meta, base, title, template.
-    for (child of Array.from(document.head.children)) {
+    for (const child of Array.from(document.head.children)) {
         if (! isAsset(child)) child.remove()
     }
 
     // Add new non-asset elements left over in the new head element.
-    for (child of Array.from(newHead.children)) {
+    for (const child of Array.from(newHead.children)) {
         document.head.appendChild(child)
     }
 }
@@ -87,7 +87,7 @@ function cloneScriptTag(el) {
     script.textContent = el.textContent
     script.async = el.async
 
-    for (attr of el.attributes) {
+    for (const attr of el.attributes) {
         script.setAttribute(attr.name, attr.value)
     }
 

--- a/packages/navigate/src/page.js
+++ b/packages/navigate/src/page.js
@@ -49,36 +49,22 @@ function prepNewScriptTagsToRun(newBody) {
 }
 
 function mergeNewHead(newHead) {
-    let headChildrenHtmlLookup = Array.from(document.head.children).map(i => i.outerHTML)
-
-    // Only add scripts and styles that aren't already loaded on the page.
-    let garbageCollector = document.createDocumentFragment()
-
-    for (const child of Array.from(newHead.children)) {
-        if (isAsset(child)) {
-            if (! headChildrenHtmlLookup.includes(child.outerHTML)) {
-                if (isScript(child)) {
-                    document.head.appendChild(cloneScriptTag(child))
-                } else {
-                    document.head.appendChild(child)
-                }
-            } else {
-                garbageCollector.appendChild(child)
-            }
-        }
-    }
-
-    // How to free up the garbage collector?
+    let headChildrenHtmlLookup = Array.prototype.map.call(
+        document.head.childNodes,
+        (i) => i.outerHTML
+    );
 
     // Remove existing non-asset elements like meta, base, title, template.
-    for (const child of Array.from(document.head.children)) {
-        if (! isAsset(child)) child.remove()
-    }
+    document.head.childNodes.forEach((child) => {
+        if (!isAsset(child)) child.remove();
+    });
 
-    // Add new non-asset elements left over in the new head element.
-    for (const child of Array.from(newHead.children)) {
-        document.head.appendChild(child)
-    }
+    newHead.childNodes.forEach((child) => {
+        if (!isAsset(child) || !headChildrenHtmlLookup.includes(child.outerHTML)) 
+            document.head.appendChild(
+                isScript(child) ? cloneScriptTag(child) : child
+            );
+    });
 }
 
 function cloneScriptTag(el) {
@@ -95,12 +81,12 @@ function cloneScriptTag(el) {
 }
 
 function isAsset (el) {
-    return (el.tagName.toLowerCase() === 'link' && el.getAttribute('rel').toLowerCase() === 'stylesheet')
-        || el.tagName.toLowerCase() === 'style'
-        || el.tagName.toLowerCase() === 'script'
+    return (el instanceof HTMLLinkElement && el.getAttribute('rel').toLowerCase() === 'stylesheet')
+        || el instanceof HTMLStyleElement
+        || el instanceof HTMLScriptElement
 }
 
 function isScript (el)   {
-    return el.tagName.toLowerCase() === 'script'
+    return el instanceof HTMLScriptElement
 }
 


### PR DESCRIPTION
Addresses: #3671 

Theres also some other questions I have about further optimizations of this code.

- The `garbageCollector` stuff there is only increasing memory, not decreasing it
- quite a few extra calls to `Array.from` for using map, or just getting an array, but using `Array.prototype.map.call` can use the method without needing to create an intermediary array, as well as just using `childNodes` to get a NodeList that then also has `forEach` methods...

edit: added commit that does some refactoring. That's separate from the first that is the bug fix.