### PR TITLE
Fixed webpack 4 builds breaking due to nullish coalescing operator

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -134,7 +134,7 @@ function getInputValue(el, modifiers, event, currentValue) {
         // Safari autofill triggers event as CustomEvent and assigns value to target
         // so we return event.target.value instead of event.detail
         if (event instanceof CustomEvent && event.detail !== undefined)
-            return event.detail ?? event.target.value
+            return event.detail !== null && event.detail !== undefined ? event.detail : event.target.value
         else if (el.type === 'checkbox') {
             // If the data we are binding to is an array, toggle its value inside the array.
             if (Array.isArray(currentValue)) {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -174,7 +174,9 @@ export function formatMoney(input, delimiter = '.', thousands, precision = 2) {
     if (input === '-') return '-'
     if (/^\D+$/.test(input)) return '9'
 
-    thousands = thousands ?? (delimiter === "," ? "." : ",")
+    if (thousands === null || thousands === undefined) {
+        thousands = delimiter === "," ? "." : ","
+    }
 
     let addThousands = (input, thousands) => {
         let output = ''


### PR DESCRIPTION
### What's the issue?

After upgrading to the latest version of `alpinejs` in a webpack 4 project, I discovered that my build was broken due to webpack encountering the unexpected token `??` in Alpine's source. This is the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) and it was introduced in `alpinejs@3.12.1` (https://github.com/alpinejs/alpine/pull/3483). It's fairly common nowadays. It wasn't though when webpack 4 was a thing, and it turned out webpack 4 never got support for it. See this nice write-up of the same problem in a completely unrelated project: https://github.com/PaulLeCam/react-leaflet/issues/883

### Proposal

The problem could be solved on the consumer side by adding transpilation for `??`. I'd still suggest fixing it on the library side for the following reasons:

- this kind of deprecation should probably only occur in a major version
- the webpack 4 -> webpack 5 migration is pretty painful especially in complex setups and I suppose my project is not the only one that didn't yet make the jump
- `??` can easily be replaced and we get extended webpack 4 support with virtually no effort

What do you guys think?