### PR TITLE
Add ability to get registered data

### DIFF
--- a/packages/alpinejs/src/datas.js
+++ b/packages/alpinejs/src/datas.js
@@ -1,7 +1,11 @@
 
 let datas = {}
 
-export function data(name, callback) {
+export function data(name, callback = null) {
+    if (callback === null) {
+        return datas[name]
+    }
+
     datas[name] = callback
 }
 


### PR DESCRIPTION
This PR adds the ability to get registered data in `Alpine.data()`. This will allow a use case like this:

```js
Alpine.data('Component1', {
  // bla bla
});

Alpine.data('Component2', {
  // bla bla
});

Alpine.data('Component3', {
  ...Alpine.data('Component1'),
  ...Alpine.data('Component2'),
});
```