### PR TITLE
:recycle: improves merge proxies

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -33,6 +33,16 @@ export function closestDataProxy(el) {
     return mergeProxies(closestDataStack(el))
 }
 
+function collapseProxies() {
+    const keys = Reflect.ownKeys(this);
+    const collapsed = keys.reduce((acc, key) => {
+        console.log(key);
+        acc[key] = Reflect.get(this, key);
+        return acc;
+    }, {});
+    return collapsed;
+}
+
 export function mergeProxies(objects) {
     let thisProxy = new Proxy({}, {
         ownKeys: () => {
@@ -44,6 +54,7 @@ export function mergeProxies(objects) {
         },
 
         get: (target, name) => {
+            if (name == "toJSON") return collapseProxies;
             return (objects.find(obj => {
                 if (obj.hasOwnProperty(name)) {
                     let descriptor = Object.getOwnPropertyDescriptor(obj, name)

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -74,7 +74,7 @@ const mergeTraps = {
         return Reflect.set(
             objs.find((obj) =>
                 Object.prototype.hasOwnProperty.call(obj, name)
-            ) || objs.at(-1),
+            ) || objs[objs.length-1],
             name,
             value
         );

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -36,7 +36,6 @@ export function closestDataProxy(el) {
 function collapseProxies() {
     const keys = Reflect.ownKeys(this);
     const collapsed = keys.reduce((acc, key) => {
-        console.log(key);
         acc[key] = Reflect.get(this, key);
         return acc;
     }, {});

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -50,6 +50,7 @@ export function mergeProxies(objects) {
         },
 
         has: (target, name) => {
+            if (name == Symbol.unscopables) return false;
             return objects.some(obj => obj.hasOwnProperty(name))
         },
 


### PR DESCRIPTION
This PR refactors `mergeProxies` to increase performance and reduce memory costs.

- :bug: Allows JSON stringifying $data (solving an issue presented in discord)
- :recycle: Uses Reflect (to reduce code and memory)
- :zap: Shortcircuits on unscopables (to increase performance on every access of data in expressions)
- :recycle: Extract proxyTraps (to reduce memory)
- :white_check_mark: Uses legacy syntax (to pass tests)
