### PR TITLE
Fixed a variable typo

### DIFF
--- a/packages/alpinejs/src/magics/index.js
+++ b/packages/alpinejs/src/magics/index.js
@@ -16,5 +16,5 @@ warnMissingPluginMagic('Focus', 'focus', 'focus')
 warnMissingPluginMagic('Persist', 'persist', 'persist')
 
 function warnMissingPluginMagic(name, magicName, slug) {
-    magic(magicName, (el) => warn(`You can't use [$${directiveName}] without first installing the "${name}" plugin here: https://alpinejs.dev/plugins/${slug}`, el))
+    magic(magicName, (el) => warn(`You can't use [$${magicName}] without first installing the "${name}" plugin here: https://alpinejs.dev/plugins/${slug}`, el))
 }


### PR DESCRIPTION
Fixed an issue that causes an error to happen when the magic method is not registered: `caught ReferenceError: directiveName is not defined`