### PR TITLE
x-if warning if used on non-template

### DIFF
--- a/packages/alpinejs/src/directives/x-if.js
+++ b/packages/alpinejs/src/directives/x-if.js
@@ -5,8 +5,11 @@ import { initTree } from '../lifecycle'
 import { mutateDom } from '../mutation'
 import { walk } from "../utils/walk"
 import { dequeueJob } from '../scheduler'
+import { warn } from "../utils/warn"
 
 directive('if', (el, { expression }, { effect, cleanup }) => {
+    if (el.tagName.toLowerCase() !== 'template') warn('x-if can only be used on a <template> tag', el)
+
     let evaluate = evaluateLater(el, expression)
 
     let show = () => {


### PR DESCRIPTION
Added a warning if x-if is used on a tag other than template (similar to x-teleport warning).