### PR TITLE
:bug: Passes through modifiers in x-bind

### DIFF
--- a/packages/alpinejs/src/directives/x-bind.js
+++ b/packages/alpinejs/src/directives/x-bind.js
@@ -34,9 +34,19 @@ let handler = (el, { value, modifiers, expression, original }, { effect }) => {
             result = ''
         }
 
-        mutateDom(() => bind(el, value, result, modifiers))
+        const passThroughModifiers = modifiers.filter(mod => ! bindModifiers.includes(mod))
+        const boundModifiers = modifiers.filter(mod => bindModifiers.includes(mod))
+
+
+        mutateDom(() => bind(
+            el, 
+            [value, ...passThroughModifiers].join('.'), 
+            result, 
+            boundModifiers))
     }))
 }
+
+const bindModifiers = ['camel']
 
 // @todo: see if I can take advantage of the object created here inside the
 // non-inline handler above so we're not duplicating work twice...

--- a/tests/cypress/integration/directives/x-bind.spec.js
+++ b/tests/cypress/integration/directives/x-bind.spec.js
@@ -486,3 +486,16 @@ test('x-bind updates checked attribute and property after user interaction',
         get('input').should(haveProperty('checked', true))
     }
 )
+
+test('preserves bound modifiers', 
+    html`
+        <div x-data="{ props: {
+            'test:value.modifier': 'foobar'
+        } }">
+          <span x-bind="props"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveAttribute('test:value.modifier', 'foobar'))
+    }
+)


### PR DESCRIPTION
Fixes #3742 

When attempting to bind attributes that contain `.`, x-bind greedily consumes them even when they are not valid modifiers for x-bind.

this allow unrecognized bind modifiers to be passed through to the bound attribute

Maybe it should just pass all modifiers through for simplicity?