### PR TITLE
:sparkles: Names expression evaluators

### DIFF
--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -78,7 +78,14 @@ function generateFunctionFromString(expression, el) {
 
     const safeAsyncFunction = () => {
         try {
-            return new AsyncFunction(['__self', 'scope'], `with (scope) { __self.result = ${rightSideSafeExpression} }; __self.finished = true; return __self.result;`)
+            const func = new AsyncFunction(
+                ["__self", "scope"],
+                `with (scope) { __self.result = ${rightSideSafeExpression} }; __self.finished = true; return __self.result;`
+            );
+            Object.defineProperty(func, "name", {
+                value: `ALPINE ${expression}`,
+            });
+            return func;
         } catch ( error ) {
             handleError( error, el, expression )
             return Promise.resolve()

--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -83,7 +83,7 @@ function generateFunctionFromString(expression, el) {
                 `with (scope) { __self.result = ${rightSideSafeExpression} }; __self.finished = true; return __self.result;`
             );
             Object.defineProperty(func, "name", {
-                value: `ALPINE ${expression}`,
+                value: `[Alpine] ${expression}`,
             });
             return func;
         } catch ( error ) {

--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -78,14 +78,16 @@ function generateFunctionFromString(expression, el) {
 
     const safeAsyncFunction = () => {
         try {
-            const func = new AsyncFunction(
+            let func = new AsyncFunction(
                 ["__self", "scope"],
                 `with (scope) { __self.result = ${rightSideSafeExpression} }; __self.finished = true; return __self.result;`
-            );
+            )
+            
             Object.defineProperty(func, "name", {
                 value: `[Alpine] ${expression}`,
-            });
-            return func;
+            })
+            
+            return func
         } catch ( error ) {
             handleError( error, el, expression )
             return Promise.resolve()


### PR DESCRIPTION
This PR adds the expression as a name to the evaluator function. While Alpine logging information about the expression is helpful, many tools like sentry won't fully track or associate those warning logs with the actual error.

This change allows the expression to show as the name of the function in the stack trace itself making hunting down errors much easier.

<img width="837" alt="Screenshot 2023-09-15 at 1 35 53 PM" src="https://github.com/alpinejs/alpine/assets/43540491/a39ef965-e59c-4f24-a5a5-d1c9429a5b3f">
