### PR TITLE
Fix typos

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -95,7 +95,7 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
         cleanup(() => removeResetListener())
     }
 
-    // Allow programmatic overiding of x-model.
+    // Allow programmatic overriding of x-model.
     el._x_model = {
         get() {
             return getValue()

--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -66,7 +66,7 @@ function generateFunctionFromString(expression, el) {
     let AsyncFunction = Object.getPrototypeOf(async function(){}).constructor
 
     // Some expressions that are useful in Alpine are not valid as the right side of an expression.
-    // Here we'll detect if the expression isn't valid for an assignement and wrap it in a self-
+    // Here we'll detect if the expression isn't valid for an assignment and wrap it in a self-
     // calling function so that we don't throw an error AND a "return" statement can b e used.
     let rightSideSafeExpression = 0
         // Support expressions starting with "if" statements like: "if (...) doSomething()"

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -155,11 +155,11 @@ function onMutate(mutations) {
             // New attribute.
             if (el.hasAttribute(name) && oldValue === null) {
                 add()
-            // Changed atttribute.
+            // Changed attribute.
             } else if (el.hasAttribute(name)) {
                 remove()
                 add()
-            // Removed atttribute.
+            // Removed attribute.
             } else {
                 remove()
             }

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -4,7 +4,7 @@ export default function (Alpine) {
 
         let options = {
             rootMargin: getRootMargin(modifiers),
-            threshold: getThreshhold(modifiers),
+            threshold: getThreshold(modifiers),
         }
 
         let observer = new IntersectionObserver(entries => {
@@ -26,7 +26,7 @@ export default function (Alpine) {
     })
 }
 
-function getThreshhold(modifiers) {
+function getThreshold(modifiers) {
     if (modifiers.includes('full')) return 0.99
     if (modifiers.includes('half')) return 0.5
     if (! modifiers.includes('threshold')) return 0

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -283,7 +283,7 @@ export function morph(from, toHtml, options) {
             currentFrom = currentFromNext
         }
 
-        // Cleanup extra froms.
+        // Cleanup extra forms.
         let removals = []
 
         // We need to collect the "removals" first before actually

--- a/packages/morph/src/old_morph.js
+++ b/packages/morph/src/old_morph.js
@@ -285,7 +285,7 @@ export async function morph(from, toHtml, options) {
             currentFrom = currentFromNext
         }
 
-        // Cleanup extra froms.
+        // Cleanup extra forms.
         let removals = []
 
         // We need to collect the "removals" first before actually

--- a/packages/ui/src/list-context.js
+++ b/packages/ui/src/list-context.js
@@ -175,7 +175,7 @@ export function generateContext(Alpine, multiple, orientation, activateSelectedO
          * Return true if the latest active element was activated
          * by the user (i.e. using the arrow keys) and false if was
          * activated automatically by alpine (i.e. first element automatically
-         * activeted after filtering the list)
+         * activated after filtering the list)
          */
         wasActivatedByKeyPress() {return this.activatedByKeyPress},
 
@@ -204,7 +204,7 @@ export function generateContext(Alpine, multiple, orientation, activateSelectedO
         },
 
         /**
-         * Handle active key traveral...
+         * Handle active key traversal...
          */
         nextKey() {
             if (! this.activeKey) return

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -171,7 +171,7 @@ test('$money with different thousands separator',
     }
 );
 
-test('$money works with permenant inserted at beginning',
+test('$money works with permanent inserted at beginning',
     [html`<input x-data x-mask:dynamic="$money">`],
     ({ get }) => {
         get('input').type('40.00').should(haveValue('40.00'))

--- a/tests/cypress/integration/plugins/ui/combobox.spec.js
+++ b/tests/cypress/integration/plugins/ui/combobox.spec.js
@@ -271,7 +271,7 @@ test('"name" prop',
     },
 );
 
-test('Preserves currenty active keyboard selection while options change from searching even if there\'s a selected option in the filtered results',
+test('Preserves currently active keyboard selection while options change from searching even if there\'s a selected option in the filtered results',
     [html`
         <div
             x-data="{


### PR DESCRIPTION
Found some misspellings.

There are some more in the benchmark. You may fix it.

```
./benchmarks/giant.html:4752:18: `simplfy` -> `simplify`
./benchmarks/giant.html:4756:18: `simplfy` -> `simplify`
./benchmarks/giant.html:4829:116: `simplfy` -> `simplify`
./benchmarks/giant.html:5675:23: `visibile` -> `visible`
./benchmarks/giant.html:5700:23: `visibile` -> `visible`
./benchmarks/giant.html:5794:23: `visibile` -> `visible`
./benchmarks/giant.html:8446:64: `transitionable` -> `transitional`
```
