### PR TITLE
Gracefully handle SecurityError exception if localStorage is unavailable

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -2,14 +2,15 @@ export default function (Alpine) {
     let persist = () => {
         let alias
         let storage
+
         try {
             storage = localStorage
-        }
-        catch (e) {
+        } catch (e) {
             console.error(e)
-            console.log(
-                '$persist is using temporary storage for default storage since localStorage is unavailable.')
-            const dummy = new Map();
+            console.warn('Alpine: $persist is using temporary storage since localStorage is unavailable.')
+
+            let dummy = new Map();
+
             storage = {
                 getItem: dummy.get.bind(dummy),
                 setItem: dummy.set.bind(dummy)

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -1,7 +1,25 @@
 export default function (Alpine) {
     let persist = () => {
         let alias
-        let storage = localStorage
+        let storage
+        try {
+            storage = localStorage
+        }
+        catch (e) {
+            console.error(e)
+            console.log(
+                '$persist is using temporary storage for default storage since localStorage is unavailable.')
+            storage = {
+                getItem(key) {
+                    window.tempStore = window.tempStore || {};
+                    return tempStore[key] ?? null;
+                },
+                setItem(key, value) {
+                    window.tempStore = window.tempStore || {};
+                    tempStore[key] = value;
+                }
+            }
+        }
 
         return Alpine.interceptor((initialValue, getter, setter, path, key) => {
             let lookup = alias || `_x_${path}`

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -9,15 +9,10 @@ export default function (Alpine) {
             console.error(e)
             console.log(
                 '$persist is using temporary storage for default storage since localStorage is unavailable.')
+            const dummy = new Map();
             storage = {
-                getItem(key) {
-                    window.tempStore = window.tempStore || {};
-                    return tempStore[key] ?? null;
-                },
-                setItem(key, value) {
-                    window.tempStore = window.tempStore || {};
-                    tempStore[key] = value;
-                }
+                getItem: dummy.get.bind(dummy),
+                setItem: dummy.set.bind(dummy)
             }
         }
 


### PR DESCRIPTION
If an exception is thrown when trying to assign `storage = localStorage`, the persist plugin currently fails with an unhandled exception. In Sentry logs I'm seeing this occur occasionally (about once per day) with Safari 16.x on iOS, and the issue renders the application unusable for these users. Using custom storage with `$persist(0).using(customStorage)` doesn't solve the issue since the exception will still be thrown.

This pull request suggests using a variable object on `window` for temporary storage as an alternative to persistent storage when localStorage is unavailable. A message is logged to the JS console to indicate that the value is being stored only temporarily. This alternative handles the exception and makes the application usable, even though the value will not be persisted between page loads.