### PR TITLE
:recycle: Cleans Up Entangle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7825,7 +7825,7 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.12.3",
+            "version": "3.13.1",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7833,7 +7833,7 @@
         },
         "packages/collapse": {
             "name": "@alpinejs/collapse",
-            "version": "3.12.3",
+            "version": "3.13.1",
             "license": "MIT"
         },
         "packages/csp": {
@@ -7846,12 +7846,12 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.12.3-revision.1",
+            "version": "3.13.1-revision.1",
             "license": "MIT"
         },
         "packages/focus": {
             "name": "@alpinejs/focus",
-            "version": "3.12.1",
+            "version": "3.13.1",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.9.4",
@@ -7868,17 +7868,17 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.12.3",
+            "version": "3.13.1",
             "license": "MIT"
         },
         "packages/mask": {
             "name": "@alpinejs/mask",
-            "version": "3.12.3",
+            "version": "3.13.1",
             "license": "MIT"
         },
         "packages/morph": {
             "name": "@alpinejs/morph",
-            "version": "3.12.3",
+            "version": "3.13.1",
             "license": "MIT"
         },
         "packages/navigate": {
@@ -7891,19 +7891,14 @@
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.12.3",
+            "version": "3.13.1",
             "license": "MIT"
         },
         "packages/ui": {
             "name": "@alpinejs/ui",
-            "version": "3.12.3-beta.0",
+            "version": "3.13.1-beta.0",
             "license": "MIT",
-            "devDependencies": {
-                "alpinejs": "file:../alpinejs"
-            },
-            "peerDependencies": {
-                "alpinejs": "^3.10.0"
-            }
+            "devDependencies": {}
         }
     }
 }

--- a/packages/alpinejs/src/entangle.js
+++ b/packages/alpinejs/src/entangle.js
@@ -10,6 +10,7 @@ export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set:
         if (firstRun) {
             innerSet(outer)
             firstRun = false
+            outerHash = JSON.stringify(outer)
         } else {
             const outerHashLatest = JSON.stringify(outer)
 

--- a/packages/alpinejs/src/entangle.js
+++ b/packages/alpinejs/src/entangle.js
@@ -22,6 +22,8 @@ export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set:
                 outerHash = JSON.stringify(inner)
             }
         }
+        JSON.stringify(innerGet())
+        JSON.stringify(outerGet())
     })
 
     return () => {
@@ -29,6 +31,8 @@ export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set:
     }
 }
 
-function cloneIfObject (value) {
-    return typeof value === 'object' ? JSON.parse(JSON.stringify(value)) : value
+function cloneIfObject(value) {
+    return typeof value === 'object'
+        ? JSON.parse(JSON.stringify(value))
+        : value
 }

--- a/packages/alpinejs/src/entangle.js
+++ b/packages/alpinejs/src/entangle.js
@@ -8,17 +8,17 @@ export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set:
         const outer = outerGet()
         const inner = innerGet()
         if (firstRun) {
-            innerSet(outer)
+            innerSet(cloneIfObject(outer))
             firstRun = false
             outerHash = JSON.stringify(outer)
         } else {
             const outerHashLatest = JSON.stringify(outer)
 
             if (outerHashLatest !== outerHash) { // If outer changed...
-                innerSet(outer)
+                innerSet(cloneIfObject(outer))
                 outerHash = outerHashLatest
             } else { // If inner changed...
-                outerSet(inner)
+                outerSet(cloneIfObject(inner))
                 outerHash = JSON.stringify(inner)
             }
         }
@@ -27,4 +27,8 @@ export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set:
     return () => {
         release(reference)
     }
+}
+
+function cloneIfObject (value) {
+    return typeof value === 'object' ? JSON.parse(JSON.stringify(value)) : value
 }

--- a/tests/cypress/integration/entangle.spec.js
+++ b/tests/cypress/integration/entangle.spec.js
@@ -69,3 +69,38 @@ test.skip('can release entanglement',
         get('input[outer]').should(haveValue('foobar'))
     }
 )
+
+test(
+    "can handle undefined",
+    [
+        html`
+            <div x-data="{ outer: undefined }">
+                <input x-model="outer" outer />
+
+                <div
+                    x-data="{ inner: 'bar' }"
+                    x-init="() => {}; Alpine.entangle(
+            {
+                get() { return outer },
+                set(value) { outer = value },
+            },
+            {
+                get() { return inner },
+                set(value) { inner = value },
+            }
+        )"
+                >
+                    <input x-model="inner" inner />
+                </div>
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("input[outer]").should(haveValue(''));
+        get("input[inner]").should(haveValue(''));
+
+        get("input[inner]").type("bar");
+        get("input[inner]").should(haveValue("bar"));
+        get("input[outer]").should(haveValue("bar"));
+    }
+);


### PR DESCRIPTION
Just improves the logical flow of entangle to clean out unnecessary operations.

The whole stringify/parse thing seems unnecessary and there is nothing in the history to indicate why it was ever needed (and it didn't even do it in all cases). Seems like an unexpected behavior to have it clone the objects, and not explicitly reference the same object. I definitely wouldn't understand why using modelable with an object would not share references...It was just always rerunning the entangle if a property changed.

But this also allows an initial outer value of `undefined` which did not work before.

It can be reintroduced to actually clone (and do it for all cases) pretty simply, if you remember why that was a wanted behavior.

In fact, don't even need the hash really, could just directly reference the previous and compare.