### PR TITLE
:bug: Fixes proxy stack setters bug

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -64,14 +64,14 @@ let mergeProxyTrap = {
         )
     },
 
-    set({ objects }, name, value) {
-        return Reflect.set(
-            objects.find((obj) =>
+    set({ objects }, name, value, thisProxy) {
+        const target = objects.find((obj) =>
                 Object.prototype.hasOwnProperty.call(obj, name)
-            ) || objects[objects.length-1],
-            name,
-            value
-        )
+            ) || objects[objects.length - 1];
+        const descriptor = Object.getOwnPropertyDescriptor(target, name);
+        if (descriptor?.set && descriptor?.get)
+            return Reflect.set(target, name, value, thisProxy);
+        return Reflect.set(target, name, value);
     },
 }
 

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -1,43 +1,58 @@
 import { haveText, html, test } from "../utils";
 
-test('properly merges the datastack',
-    [html`
-        <div x-data="{ foo: 'fizz' }">
-            <div x-data="{ bar: 'buzz' }">
-                <span x-text="foo + bar"></span>
+test(
+    "properly merges the datastack",
+    [
+        html`
+            <div x-data="{ foo: 'fizz' }">
+                <div x-data="{ bar: 'buzz' }">
+                    <span x-text="foo + bar"></span>
+                </div>
             </div>
-        </div>
-    `], ({ get }) => {
-    get('span').should(haveText('fizzbuzz'));
-});
-
-test('merges stack from bottom up', 
-    [html`
-        <div x-data="{ foo: 'fizz' }">
-            <div x-data="{ foo: 'buzz', get bar() { return this.foo } }">
-                <span id="one" x-text="bar + foo"></span>
-            </div>
-            <span id="two" x-text="foo"></span>
-        </div>
-    `]
-    , ({ get }) => {
-    get('span#one').should(haveText('fizzbuzz'));
-    get('span#two').should(haveText('fizz'));
+        `,
+    ],
+    ({ get }) => {
+        get("span").should(haveText("fizzbuzz"));
     }
-)
+);
 
-test('handles getter setter pairs',
-    [html`
-        <div x-data="{ foo: 'fizzbuzz' }">
-            <div x-data="{ get bar() { return this.foo }, set bar(value) { this.foo = value } }">
-                <span id="one" x-text="bar" @click="bar = 'foobar'"></span>
+test(
+    "merges stack from bottom up",
+    [
+        html`
+            <div x-data="{ foo: 'fizz' }">
+                <div x-data="{ foo: 'buzz', get bar() { return this.foo } }">
+                    <span id="one" x-text="bar + foo"></span>
+                </div>
+                <span id="two" x-text="foo"></span>
             </div>
-            <span id="two" x-text="foo"></span>
-        </div>
-    `], ({ get }) => {
-    get('span#one').should(haveText('fizzbuzz'));
-    get('span#two').should(haveText('fizzbuzz'));
-    get('span#one').click();
-    get('span#one').should(haveText('foobar'));
-    get('span#two').should(haveText('foobar'));
-});
+        `,
+    ],
+    ({ get }) => {
+        get("span#one").should(haveText("buzzbuzz"));
+        get("span#two").should(haveText("fizz"));
+    }
+);
+
+test(
+    "handles getter setter pairs",
+    [
+        html`
+            <div x-data="{ foo: 'fizzbuzz' }">
+                <div
+                    x-data="{ get bar() { return this.foo }, set bar(value) { this.foo = value } }"
+                >
+                    <span id="one" x-text="bar" @click="bar = 'foobar'"></span>
+                </div>
+                <span id="two" x-text="foo"></span>
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("span#one").should(haveText("fizzbuzz"));
+        get("span#two").should(haveText("fizzbuzz"));
+        get("span#one").click();
+        get("span#one").should(haveText("foobar"));
+        get("span#two").should(haveText("foobar"));
+    }
+);

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -11,6 +11,21 @@ test('properly merges the datastack',
     get('span').should(haveText('fizzbuzz'));
 });
 
+test('merges stack from bottom up', 
+    [html`
+        <div x-data="{ foo: 'fizz' }">
+            <div x-data="{ foo: 'buzz', get bar() { return this.foo } }">
+                <span id="one" x-text="bar + foo"></span>
+            </div>
+            <span id="two" x-text="foo"></span>
+        </div>
+    `]
+    , ({ get }) => {
+    get('span#one').should(haveText('fizzbuzz'));
+    get('span#two').should(haveText('fizz'));
+    }
+)
+
 test('handles getter setter pairs',
     [html`
         <div x-data="{ foo: 'fizzbuzz' }">

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -1,0 +1,28 @@
+import { haveText, html, test } from "../utils";
+
+test('properly merges the datastack',
+    [html`
+        <div x-data="{ foo: 'fizz' }">
+            <div x-data="{ bar: 'buzz' }">
+                <span x-text="foo + bar"></span>
+            </div>
+        </div>
+    `], ({ get }) => {
+    get('span').should(haveText('fizzbuzz'));
+});
+
+test('handles getter setter pairs',
+    [html`
+        <div x-data="{ foo: 'fizzbuzz' }">
+            <div x-data="{ get bar() { return this.foo }, set bar(value) { this.foo = value } }">
+                <span id="one" x-text="bar" @click="bar = 'foobar'"></span>
+            </div>
+            <span id="two" x-text="foo"></span>
+        </div>
+    `], ({ get }) => {
+    get('span#one').should(haveText('fizzbuzz'));
+    get('span#two').should(haveText('fizzbuzz'));
+    get('span#one').click();
+    get('span#one').should(haveText('foobar'));
+    get('span#two').should(haveText('foobar'));
+});


### PR DESCRIPTION
Solves #3804 

This was a regression in the behaviors from the merge proxy optimization.

This still seems problematic in many ways. but this more faithfully represents the older logic.

If there is a getter setter pair, the `this` refers to the proxy stack. If it's just a setter, it doesn't (this was how the original logic worked).

Similarly to before, using getters/settings/methods,etc on the parent component can modify the child component when keys match. Not great, but that's how it has been.

It could be possible to instead limit it only to that level and parents, but that would change the behavior.

This also adds tests to ensure this continues to work :)