### PR TITLE
:bug: Fixes reference to incorrect attribute

### DIFF
--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -446,8 +446,6 @@ function getFirstNode(parent) {
 function getNextSibling(parent, reference) {
     if (reference._x_teleport) {
         return reference._x_teleport
-    } else if (reference._x_teleportBack) {
-        return reference._x_teleportBack
     }
 
     let next

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -446,8 +446,8 @@ function getFirstNode(parent) {
 function getNextSibling(parent, reference) {
     if (reference._x_teleport) {
         return reference._x_teleport
-    } else if (reference.teleportBack) {
-        return reference.teleportBack
+    } else if (reference._x_teleportBack) {
+        return reference._x_teleportBack
     }
 
     let next


### PR DESCRIPTION
Seems like this is an incorrect reference, since `_x_teleportBack` exists in the codebase but `teleportBack` does not.

Edit: Turns out it isn't even needed at all, and the typo is what was letting it not break.


Obligatory: TypeScript would have prevented this.