### PR TITLE
:bug: Joins selectors to meet spec

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -27,7 +27,7 @@ export function start() {
     })
 
     let outNestedComponents = el => ! closestRoot(el.parentElement, true)
-    Array.from(document.querySelectorAll(allSelectors()))
+    Array.from(document.querySelectorAll(allSelectors().join(',')))
         .filter(outNestedComponents)
         .forEach(el => {
             initTree(el)


### PR DESCRIPTION
While an array of strings can work when the runtime chooses to coerce the array to a string, it is outside of the DOM spec, which allows only a string. Some DOM runtimes, like Happy-dom do not support selectors that are arrays.

This just brings the code inline with the spec.