### PR TITLE
fix: reset input on init so default value is displayed

### DIFF
--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -1,74 +1,83 @@
-import { generateContext, renderHiddenInputs } from './list-context'
+import { generateContext, renderHiddenInputs } from "./list-context";
 
 export default function (Alpine) {
-    Alpine.directive('combobox', (el, directive, { evaluate }) => {
-        if      (directive.value === 'input')        handleInput(el, Alpine)
-        else if (directive.value === 'button')       handleButton(el, Alpine)
-        else if (directive.value === 'label')        handleLabel(el, Alpine)
-        else if (directive.value === 'options')      handleOptions(el, Alpine)
-        else if (directive.value === 'option')       handleOption(el, Alpine, directive, evaluate)
-        else                                         handleRoot(el, Alpine)
-    }).before('bind')
+    Alpine.directive("combobox", (el, directive, { evaluate }) => {
+        if (directive.value === "input") handleInput(el, Alpine);
+        else if (directive.value === "button") handleButton(el, Alpine);
+        else if (directive.value === "label") handleLabel(el, Alpine);
+        else if (directive.value === "options") handleOptions(el, Alpine);
+        else if (directive.value === "option")
+            handleOption(el, Alpine, directive, evaluate);
+        else handleRoot(el, Alpine);
+    }).before("bind");
 
-    Alpine.magic('combobox', el => {
-        let data = Alpine.$data(el)
+    Alpine.magic("combobox", (el) => {
+        let data = Alpine.$data(el);
 
         return {
             get value() {
-                return data.__value
+                return data.__value;
             },
             get isOpen() {
-                return data.__isOpen
+                return data.__isOpen;
             },
             get isDisabled() {
-                return data.__isDisabled
+                return data.__isDisabled;
             },
             get activeOption() {
-                let active = data.__context?.getActiveItem()
+                let active = data.__context?.getActiveItem();
 
-                return active && active.value
+                return active && active.value;
             },
             get activeIndex() {
-                let active = data.__context?.getActiveItem()
+                let active = data.__context?.getActiveItem();
 
                 if (active) {
-                    return Object.values(Alpine.raw(data.__context.items)).findIndex(i => Alpine.raw(active) == Alpine.raw(i))
+                    return Object.values(
+                        Alpine.raw(data.__context.items)
+                    ).findIndex((i) => Alpine.raw(active) == Alpine.raw(i));
                 }
 
-                return null
+                return null;
             },
-        }
-    })
+        };
+    });
 
-    Alpine.magic('comboboxOption', el => {
-        let data = Alpine.$data(el)
+    Alpine.magic("comboboxOption", (el) => {
+        let data = Alpine.$data(el);
 
-        let optionEl = Alpine.findClosest(el, i => i.__optionKey)
+        let optionEl = Alpine.findClosest(el, (i) => i.__optionKey);
 
-        if (! optionEl) throw 'No x-combobox:option directive found...'
+        if (!optionEl) throw "No x-combobox:option directive found...";
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(optionEl.__optionKey)
+                return data.__context.isActiveKey(optionEl.__optionKey);
             },
             get isSelected() {
-                return data.__isSelected(optionEl)
+                return data.__isSelected(optionEl);
             },
             get isDisabled() {
-                return data.__context.isDisabled(optionEl.__optionKey)
+                return data.__context.isDisabled(optionEl.__optionKey);
             },
-        }
-    })
+        };
+    });
 }
 
 function handleRoot(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-id'() { return ['alpine-combobox-button', 'alpine-combobox-options', 'alpine-combobox-label'] },
-        'x-modelable': '__value',
+        "x-id"() {
+            return [
+                "alpine-combobox-button",
+                "alpine-combobox-options",
+                "alpine-combobox-label",
+            ];
+        },
+        "x-modelable": "__value",
 
         // Initialize...
-        'x-data'() {
+        "x-data"() {
             return {
                 /**
                  * Combobox state...
@@ -90,17 +99,34 @@ function handleRoot(el, Alpine) {
                  * Combobox initialization...
                  */
                 init() {
-                    this.__isMultiple = Alpine.extractProp(el, 'multiple', false)
-                    this.__isDisabled = Alpine.extractProp(el, 'disabled', false)
-                    this.__inputName = Alpine.extractProp(el, 'name', null)
-                    this.__nullable = Alpine.extractProp(el, 'nullable', false)
-                    this.__compareBy = Alpine.extractProp(el, 'by')
+                    this.__isMultiple = Alpine.extractProp(
+                        el,
+                        "multiple",
+                        false
+                    );
+                    this.__isDisabled = Alpine.extractProp(
+                        el,
+                        "disabled",
+                        false
+                    );
+                    this.__inputName = Alpine.extractProp(el, "name", null);
+                    this.__nullable = Alpine.extractProp(el, "nullable", false);
+                    this.__compareBy = Alpine.extractProp(el, "by");
 
-                    this.__context = generateContext(Alpine, this.__isMultiple, 'vertical', () => this.__activateSelectedOrFirst())
+                    this.__context = generateContext(
+                        Alpine,
+                        this.__isMultiple,
+                        "vertical",
+                        () => this.__activateSelectedOrFirst()
+                    );
 
-                    let defaultValue = Alpine.extractProp(el, 'default-value', this.__isMultiple ? [] : null)
+                    let defaultValue = Alpine.extractProp(
+                        el,
+                        "default-value",
+                        this.__isMultiple ? [] : null
+                    );
 
-                    this.__value = defaultValue
+                    this.__value = defaultValue;
 
                     // We have to wait again until after the "ready" processes are finished
                     // to settle up currently selected Values (this prevents this next bit
@@ -109,37 +135,44 @@ function handleRoot(el, Alpine) {
                         Alpine.effect(() => {
                             // Everytime the value changes, we need to re-render the hidden inputs,
                             // if a user passed the "name" prop...
-                            this.__inputName && renderHiddenInputs(Alpine, this.$el, this.__inputName, this.__value)
-                        })
-                    })
+                            this.__inputName &&
+                                renderHiddenInputs(
+                                    Alpine,
+                                    this.$el,
+                                    this.__inputName,
+                                    this.__value
+                                );
+                        });
+                    });
                 },
                 __startTyping() {
-                    this.__isTyping = true
+                    this.__isTyping = true;
                 },
                 __stopTyping() {
-                    this.__isTyping = false
+                    this.__isTyping = false;
                 },
                 __resetInput() {
-                    let input = this.$refs.__input
+                    let input = this.$refs.__input;
 
-                    if (! input) return
+                    if (!input) return;
 
-                    let value = this.__getCurrentValue()
+                    let value = this.__getCurrentValue();
 
-                    input.value = value
+                    input.value = value;
                 },
                 __getCurrentValue() {
-                    if (! this.$refs.__input) return ''
-                    if (! this.__value) return ''
-                    if (this.__displayValue) return this.__displayValue(this.__value)
-                    if (typeof this.__value === 'string') return this.__value
-                    return ''
+                    if (!this.$refs.__input) return "";
+                    if (!this.__value) return "";
+                    if (this.__displayValue)
+                        return this.__displayValue(this.__value);
+                    if (typeof this.__value === "string") return this.__value;
+                    return "";
                 },
                 __open() {
-                    if (this.__isOpen) return
-                    this.__isOpen = true
+                    if (this.__isOpen) return;
+                    this.__isOpen = true;
 
-                    let input = this.$refs.__input
+                    let input = this.$refs.__input;
 
                     // Make sure we always notify the parent component
                     // that the starting value is the empty string
@@ -149,354 +182,468 @@ function handleRoot(el, Alpine) {
                     // also helps VoiceOver to annunce the content properly
                     // See https://github.com/tailwindlabs/headlessui/pull/2153
                     if (input) {
-                        let value = input.value
-                        let { selectionStart, selectionEnd, selectionDirection } = input
-                        input.value = ''
-                        input.dispatchEvent(new Event('change'))
-                        input.value = value
+                        let value = input.value;
+                        let {
+                            selectionStart,
+                            selectionEnd,
+                            selectionDirection,
+                        } = input;
+                        input.value = "";
+                        input.dispatchEvent(new Event("change"));
+                        input.value = value;
                         if (selectionDirection !== null) {
-                            input.setSelectionRange(selectionStart, selectionEnd, selectionDirection)
+                            input.setSelectionRange(
+                                selectionStart,
+                                selectionEnd,
+                                selectionDirection
+                            );
                         } else {
-                            input.setSelectionRange(selectionStart, selectionEnd)
+                            input.setSelectionRange(
+                                selectionStart,
+                                selectionEnd
+                            );
                         }
                     }
 
                     // Safari needs more of a "tick" for focusing after x-show for some reason.
                     // Probably because Alpine adds an extra tick when x-showing for @click.outside
-                    let nextTick = callback => requestAnimationFrame(() => requestAnimationFrame(callback))
+                    let nextTick = (callback) =>
+                        requestAnimationFrame(() =>
+                            requestAnimationFrame(callback)
+                        );
 
                     nextTick(() => {
-                        this.$refs.__input.focus({ preventScroll: true })
-                        this.__activateSelectedOrFirst()
-                    })
+                        this.$refs.__input.focus({ preventScroll: true });
+                        this.__activateSelectedOrFirst();
+                    });
                 },
                 __close() {
-                    this.__isOpen = false
+                    this.__isOpen = false;
 
-                    this.__context.deactivate()
+                    this.__context.deactivate();
                 },
                 __activateSelectedOrFirst(activateSelected = true) {
-                    if (! this.__isOpen) return
+                    if (!this.__isOpen) return;
 
-                    if (this.__context.hasActive() && this.__context.wasActivatedByKeyPress()) return
+                    if (
+                        this.__context.hasActive() &&
+                        this.__context.wasActivatedByKeyPress()
+                    )
+                        return;
 
-                    let firstSelectedValue
+                    let firstSelectedValue;
 
                     if (this.__isMultiple) {
-                        let selectedItem = this.__context.getItemsByValues(this.__value)
+                        let selectedItem = this.__context.getItemsByValues(
+                            this.__value
+                        );
 
-                        firstSelectedValue = selectedItem.length ? selectedItem[0].value : null
+                        firstSelectedValue = selectedItem.length
+                            ? selectedItem[0].value
+                            : null;
                     } else {
-                        firstSelectedValue = this.__value
+                        firstSelectedValue = this.__value;
                     }
 
-                    let firstSelected = null
+                    let firstSelected = null;
                     if (activateSelected && firstSelectedValue) {
-                        firstSelected = this.__context.getItemByValue(firstSelectedValue)
+                        firstSelected =
+                            this.__context.getItemByValue(firstSelectedValue);
                     }
 
                     if (firstSelected) {
-                        this.__context.activateAndScrollToKey(firstSelected.key)
-                        return
+                        this.__context.activateAndScrollToKey(
+                            firstSelected.key
+                        );
+                        return;
                     }
 
-                    this.__context.activateAndScrollToKey(this.__context.firstKey())
+                    this.__context.activateAndScrollToKey(
+                        this.__context.firstKey()
+                    );
                 },
                 __selectActive() {
-                    let active = this.__context.getActiveItem()
-                    if (active) this.__toggleSelected(active.value)
+                    let active = this.__context.getActiveItem();
+                    if (active) this.__toggleSelected(active.value);
                 },
                 __selectOption(el) {
-                    let item = this.__context.getItemByEl(el)
+                    let item = this.__context.getItemByEl(el);
 
-                    if (item) this.__toggleSelected(item.value)
+                    if (item) this.__toggleSelected(item.value);
                 },
                 __isSelected(el) {
-                    let item = this.__context.getItemByEl(el)
+                    let item = this.__context.getItemByEl(el);
 
-                    if (! item) return false
-                    if (! item.value) return false
+                    if (!item) return false;
+                    if (!item.value) return false;
 
-                    return this.__hasSelected(item.value)
+                    return this.__hasSelected(item.value);
                 },
                 __toggleSelected(value) {
-                    if (! this.__isMultiple) {
-                        this.__value = value
+                    if (!this.__isMultiple) {
+                        this.__value = value;
 
-                        return
+                        return;
                     }
 
-                    let index = this.__value.findIndex(j => this.__compare(j, value))
+                    let index = this.__value.findIndex((j) =>
+                        this.__compare(j, value)
+                    );
 
                     if (index === -1) {
-                        this.__value.push(value)
+                        this.__value.push(value);
                     } else {
-                        this.__value.splice(index, 1)
+                        this.__value.splice(index, 1);
                     }
                 },
                 __hasSelected(value) {
-                    if (! this.__isMultiple) return this.__compare(this.__value, value)
+                    if (!this.__isMultiple)
+                        return this.__compare(this.__value, value);
 
-                    return this.__value.some(i => this.__compare(i, value))
+                    return this.__value.some((i) => this.__compare(i, value));
                 },
                 __compare(a, b) {
-                    let by = this.__compareBy
+                    let by = this.__compareBy;
 
-                    if (! by) by = (a, b) => Alpine.raw(a) === Alpine.raw(b)
+                    if (!by) by = (a, b) => Alpine.raw(a) === Alpine.raw(b);
 
-                    if (typeof by === 'string') {
-                        let property = by
+                    if (typeof by === "string") {
+                        let property = by;
                         by = (a, b) => {
                             // Handle null values
-                            if ((! a || typeof a !== 'object') || (! b || typeof b !== 'object')) {
-                                return Alpine.raw(a) === Alpine.raw(b)
+                            if (
+                                !a ||
+                                typeof a !== "object" ||
+                                !b ||
+                                typeof b !== "object"
+                            ) {
+                                return Alpine.raw(a) === Alpine.raw(b);
                             }
 
-
                             return a[property] === b[property];
-                        }
+                        };
                     }
 
-                    return by(a, b)
+                    return by(a, b);
                 },
-            }
+            };
         },
         // Register event listeners..
-        '@mousedown.window'(e) {
+        "@mousedown.window"(e) {
             if (
-                !! ! this.$refs.__input.contains(e.target)
-                && ! this.$refs.__button.contains(e.target)
-                && ! this.$refs.__options.contains(e.target)
+                !!!this.$refs.__input.contains(e.target) &&
+                !this.$refs.__button.contains(e.target) &&
+                !this.$refs.__options.contains(e.target)
             ) {
-                this.__close()
-                this.__resetInput()
+                this.__close();
+                this.__resetInput();
             }
-        }
-    })
+        },
+    });
 }
 
 function handleInput(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-ref': '__input',
-        ':id'() { return this.$id('alpine-combobox-input') },
+        "x-ref": "__input",
+        ":id"() {
+            return this.$id("alpine-combobox-input");
+        },
 
         // Accessibility attributes...
-        'role': 'combobox',
-        'tabindex': '0',
-        'aria-autocomplete': 'list',
+        role: "combobox",
+        tabindex: "0",
+        "aria-autocomplete": "list",
 
         // We need to defer this evaluation a bit because $refs that get declared later
         // in the DOM aren't available yet when x-ref is the result of an Alpine.bind object.
-        async ':aria-controls'() { return await microtask(() => this.$refs.__options && this.$refs.__options.id) },
-        ':aria-expanded'() { return this.$data.__isDisabled ? undefined : this.$data.__isOpen },
-        ':aria-multiselectable'() { return this.$data.__isMultiple ? true : undefined },
-        ':aria-activedescendant'() {
-            if (! this.$data.__context.hasActive()) return
-
-            let active = this.$data.__context.getActiveItem()
-
-            return active ? active.el.id : null
+        async ":aria-controls"() {
+            return await microtask(
+                () => this.$refs.__options && this.$refs.__options.id
+            );
         },
-        ':aria-labelledby'() { return this.$refs.__label ? this.$refs.__label.id : (this.$refs.__button ? this.$refs.__button.id : null) },
+        ":aria-expanded"() {
+            return this.$data.__isDisabled ? undefined : this.$data.__isOpen;
+        },
+        ":aria-multiselectable"() {
+            return this.$data.__isMultiple ? true : undefined;
+        },
+        ":aria-activedescendant"() {
+            if (!this.$data.__context.hasActive()) return;
+
+            let active = this.$data.__context.getActiveItem();
+
+            return active ? active.el.id : null;
+        },
+        ":aria-labelledby"() {
+            return this.$refs.__label
+                ? this.$refs.__label.id
+                : this.$refs.__button
+                ? this.$refs.__button.id
+                : null;
+        },
 
         // Initialize...
-        'x-init'() {
-            let displayValueFn = Alpine.extractProp(this.$el, 'display-value')
-            if (displayValueFn) this.$data.__displayValue = displayValueFn
+        "x-init"() {
+            let displayValueFn = Alpine.extractProp(this.$el, "display-value");
+            if (displayValueFn) this.$data.__displayValue = displayValueFn;
+            this.$data.__resetInput();
         },
 
         // Register listeners...
-        '@input.stop'(e) {
-            if(this.$data.__isTyping) {
+        "@input.stop"(e) {
+            if (this.$data.__isTyping) {
                 this.$data.__open();
-                this.$dispatch('change')
+                this.$dispatch("change");
             }
         },
-        '@blur'() { this.$data.__stopTyping(false) },
-        '@keydown'(e) {
-            queueMicrotask(() => this.$data.__context.activateByKeyEvent(e, false, () => this.$data.__isOpen, () => this.$data.__open(), (state) => this.$data.__isTyping = state))
+        "@blur"() {
+            this.$data.__stopTyping(false);
         },
-        '@keydown.enter.prevent.stop'() {
-            this.$data.__selectActive()
+        "@keydown"(e) {
+            queueMicrotask(() =>
+                this.$data.__context.activateByKeyEvent(
+                    e,
+                    false,
+                    () => this.$data.__isOpen,
+                    () => this.$data.__open(),
+                    (state) => (this.$data.__isTyping = state)
+                )
+            );
+        },
+        "@keydown.enter.prevent.stop"() {
+            this.$data.__selectActive();
 
-            this.$data.__stopTyping()
+            this.$data.__stopTyping();
 
-            if (! this.$data.__isMultiple) {
-                this.$data.__close()
-                this.$data.__resetInput()
+            if (!this.$data.__isMultiple) {
+                this.$data.__close();
+                this.$data.__resetInput();
             }
         },
-        '@keydown.escape.prevent'(e) {
-            if (! this.$data.__static) e.stopPropagation()
+        "@keydown.escape.prevent"(e) {
+            if (!this.$data.__static) e.stopPropagation();
 
-            this.$data.__stopTyping()
-            this.$data.__close()
-            this.$data.__resetInput()
-
+            this.$data.__stopTyping();
+            this.$data.__close();
+            this.$data.__resetInput();
         },
-        '@keydown.tab'() {
-            this.$data.__stopTyping()
-            if (this.$data.__isOpen) { this.$data.__close() }
-            this.$data.__resetInput()
+        "@keydown.tab"() {
+            this.$data.__stopTyping();
+            if (this.$data.__isOpen) {
+                this.$data.__close();
+            }
+            this.$data.__resetInput();
         },
-        '@keydown.backspace'(e) {
-            if (this.$data.__isMultiple) return
-            if (! this.$data.__nullable) return
+        "@keydown.backspace"(e) {
+            if (this.$data.__isMultiple) return;
+            if (!this.$data.__nullable) return;
 
-            let input = e.target
+            let input = e.target;
 
             requestAnimationFrame(() => {
-                if (input.value === '') {
-                    this.$data.__value = null
+                if (input.value === "") {
+                    this.$data.__value = null;
 
-                    let options = this.$refs.__options
+                    let options = this.$refs.__options;
                     if (options) {
-                        options.scrollTop = 0
+                        options.scrollTop = 0;
                     }
 
-                    this.$data.__context.deactivate()
+                    this.$data.__context.deactivate();
                 }
-            })
+            });
         },
-    })
+    });
 }
 
 function handleButton(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-ref': '__button',
-        ':id'() { return this.$id('alpine-combobox-button') },
+        "x-ref": "__button",
+        ":id"() {
+            return this.$id("alpine-combobox-button");
+        },
 
         // Accessibility attributes...
-        'aria-haspopup': 'true',
+        "aria-haspopup": "true",
         // We need to defer this evaluation a bit because $refs that get declared later
         // in the DOM aren't available yet when x-ref is the result of an Alpine.bind object.
-        async ':aria-controls'() { return await microtask(() => this.$refs.__options && this.$refs.__options.id) },
-        ':aria-labelledby'() { return this.$refs.__label ? [this.$refs.__label.id, this.$el.id].join(' ') : null },
-        ':aria-expanded'() { return this.$data.__isDisabled ? null : this.$data.__isOpen },
-        ':disabled'() { return this.$data.__isDisabled },
-        'tabindex': '-1',
+        async ":aria-controls"() {
+            return await microtask(
+                () => this.$refs.__options && this.$refs.__options.id
+            );
+        },
+        ":aria-labelledby"() {
+            return this.$refs.__label
+                ? [this.$refs.__label.id, this.$el.id].join(" ")
+                : null;
+        },
+        ":aria-expanded"() {
+            return this.$data.__isDisabled ? null : this.$data.__isOpen;
+        },
+        ":disabled"() {
+            return this.$data.__isDisabled;
+        },
+        tabindex: "-1",
 
         // Initialize....
-        'x-init'() { if (this.$el.tagName.toLowerCase() === 'button' && ! this.$el.hasAttribute('type')) this.$el.type = 'button' },
+        "x-init"() {
+            if (
+                this.$el.tagName.toLowerCase() === "button" &&
+                !this.$el.hasAttribute("type")
+            )
+                this.$el.type = "button";
+        },
 
         // Register listeners...
-        '@click'(e) {
-            if (this.$data.__isDisabled) return
+        "@click"(e) {
+            if (this.$data.__isDisabled) return;
             if (this.$data.__isOpen) {
-                this.$data.__close()
-                this.$data.__resetInput()
+                this.$data.__close();
+                this.$data.__resetInput();
             } else {
-                e.preventDefault()
-                this.$data.__open()
+                e.preventDefault();
+                this.$data.__open();
             }
 
-            this.$nextTick(() => this.$refs.__input.focus({ preventScroll: true }))
+            this.$nextTick(() =>
+                this.$refs.__input.focus({ preventScroll: true })
+            );
         },
-    })
+    });
 }
 
 function handleLabel(el, Alpine) {
     Alpine.bind(el, {
-        'x-ref': '__label',
-        ':id'() { return this.$id('alpine-combobox-label') },
-        '@click'() { this.$refs.__input.focus({ preventScroll: true }) },
-    })
+        "x-ref": "__label",
+        ":id"() {
+            return this.$id("alpine-combobox-label");
+        },
+        "@click"() {
+            this.$refs.__input.focus({ preventScroll: true });
+        },
+    });
 }
 
 function handleOptions(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-ref': '__options',
-        ':id'() { return this.$id('alpine-combobox-options') },
+        "x-ref": "__options",
+        ":id"() {
+            return this.$id("alpine-combobox-options");
+        },
 
         // Accessibility attributes...
-        'role': 'listbox',
-        ':aria-labelledby'() { return this.$refs.__label ? this.$refs.__label.id : (this.$refs.__button ? this.$refs.__button.id : null) },
+        role: "listbox",
+        ":aria-labelledby"() {
+            return this.$refs.__label
+                ? this.$refs.__label.id
+                : this.$refs.__button
+                ? this.$refs.__button.id
+                : null;
+        },
 
         // Initialize...
-        'x-init'() {
-            this.$data.__isStatic = Alpine.bound(this.$el, 'static', false)
+        "x-init"() {
+            this.$data.__isStatic = Alpine.bound(this.$el, "static", false);
 
-            if (Alpine.bound(this.$el, 'hold')) {
+            if (Alpine.bound(this.$el, "hold")) {
                 this.$data.__hold = true;
             }
         },
 
-        'x-show'() { return this.$data.__isStatic ? true : this.$data.__isOpen },
-    })
+        "x-show"() {
+            return this.$data.__isStatic ? true : this.$data.__isOpen;
+        },
+    });
 }
 
 function handleOption(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-id'() { return ['alpine-combobox-option'] },
-        ':id'() { return this.$id('alpine-combobox-option') },
-
-        // Accessibility attributes...
-        'role': 'option',
-        ':tabindex'() { return this.$comboboxOption.isDisabled ? undefined : '-1' },
-
-        // Only the active element should have aria-selected="true"...
-        'x-effect'() {
-            this.$comboboxOption.isSelected
-                ? el.setAttribute('aria-selected', true)
-                : el.setAttribute('aria-selected', false)
+        "x-id"() {
+            return ["alpine-combobox-option"];
+        },
+        ":id"() {
+            return this.$id("alpine-combobox-option");
         },
 
-        ':aria-disabled'() { return this.$comboboxOption.isDisabled },
+        // Accessibility attributes...
+        role: "option",
+        ":tabindex"() {
+            return this.$comboboxOption.isDisabled ? undefined : "-1";
+        },
+
+        // Only the active element should have aria-selected="true"...
+        "x-effect"() {
+            this.$comboboxOption.isSelected
+                ? el.setAttribute("aria-selected", true)
+                : el.setAttribute("aria-selected", false);
+        },
+
+        ":aria-disabled"() {
+            return this.$comboboxOption.isDisabled;
+        },
 
         // Initialize...
-        'x-data'() {
+        "x-data"() {
             return {
                 init() {
-                    let key = this.$el.__optionKey = (Math.random() + 1).toString(36).substring(7)
+                    let key = (this.$el.__optionKey = (Math.random() + 1)
+                        .toString(36)
+                        .substring(7));
 
-                    let value = Alpine.extractProp(this.$el, 'value')
-                    let disabled = Alpine.extractProp(this.$el, 'disabled', false, false)
+                    let value = Alpine.extractProp(this.$el, "value");
+                    let disabled = Alpine.extractProp(
+                        this.$el,
+                        "disabled",
+                        false,
+                        false
+                    );
 
                     // memoize the context as it's not going to change
                     // and calling this.$data on mouse action is expensive
-                    this.__context.registerItem(key, this.$el, value, disabled)
+                    this.__context.registerItem(key, this.$el, value, disabled);
                 },
                 destroy() {
-                    this.__context.unregisterItem(this.$el.__optionKey)
-                }
-            }
+                    this.__context.unregisterItem(this.$el.__optionKey);
+                },
+            };
         },
 
         // Register listeners...
-        '@click'() {
+        "@click"() {
             if (this.$comboboxOption.isDisabled) return;
 
-            this.__selectOption(this.$el)
+            this.__selectOption(this.$el);
 
-            if (! this.__isMultiple) {
-                this.__close()
-                this.__resetInput()
+            if (!this.__isMultiple) {
+                this.__close();
+                this.__resetInput();
             }
 
-            this.$nextTick(() => this.$refs.__input.focus({ preventScroll: true }))
+            this.$nextTick(() =>
+                this.$refs.__input.focus({ preventScroll: true })
+            );
         },
-        '@mouseenter'(e) {
-            this.__context.activateEl(this.$el)
+        "@mouseenter"(e) {
+            this.__context.activateEl(this.$el);
         },
-        '@mousemove'(e) {
-            if (this.__context.isActiveEl(this.$el)) return
+        "@mousemove"(e) {
+            if (this.__context.isActiveEl(this.$el)) return;
 
-            this.__context.activateEl(this.$el)
+            this.__context.activateEl(this.$el);
         },
-        '@mouseleave'(e) {
-            if (this.__hold) return
+        "@mouseleave"(e) {
+            if (this.__hold) return;
 
-            this.__context.deactivate()
+            this.__context.deactivate();
         },
-    })
+    });
 }
-
 
 // Little utility to defer a callback into the microtask queue...
 function microtask(callback) {
-    return new Promise(resolve => queueMicrotask(() => resolve(callback())))
+    return new Promise((resolve) => queueMicrotask(() => resolve(callback())));
 }

--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -1,83 +1,83 @@
-import { generateContext, renderHiddenInputs } from "./list-context";
+import { generateContext, renderHiddenInputs } from './list-context'
 
 export default function (Alpine) {
-    Alpine.directive("combobox", (el, directive, { evaluate }) => {
-        if (directive.value === "input") handleInput(el, Alpine);
-        else if (directive.value === "button") handleButton(el, Alpine);
-        else if (directive.value === "label") handleLabel(el, Alpine);
-        else if (directive.value === "options") handleOptions(el, Alpine);
-        else if (directive.value === "option")
-            handleOption(el, Alpine, directive, evaluate);
-        else handleRoot(el, Alpine);
-    }).before("bind");
+    Alpine.directive('combobox', (el, directive, { evaluate }) => {
+        if (directive.value === 'input') handleInput(el, Alpine)
+        else if (directive.value === 'button') handleButton(el, Alpine)
+        else if (directive.value === 'label') handleLabel(el, Alpine)
+        else if (directive.value === 'options') handleOptions(el, Alpine)
+        else if (directive.value === 'option')
+            handleOption(el, Alpine, directive, evaluate)
+        else handleRoot(el, Alpine)
+    }).before('bind')
 
-    Alpine.magic("combobox", (el) => {
-        let data = Alpine.$data(el);
+    Alpine.magic('combobox', (el) => {
+        let data = Alpine.$data(el)
 
         return {
             get value() {
-                return data.__value;
+                return data.__value
             },
             get isOpen() {
-                return data.__isOpen;
+                return data.__isOpen
             },
             get isDisabled() {
-                return data.__isDisabled;
+                return data.__isDisabled
             },
             get activeOption() {
-                let active = data.__context?.getActiveItem();
+                let active = data.__context?.getActiveItem()
 
-                return active && active.value;
+                return active && active.value
             },
             get activeIndex() {
-                let active = data.__context?.getActiveItem();
+                let active = data.__context?.getActiveItem()
 
                 if (active) {
                     return Object.values(
                         Alpine.raw(data.__context.items)
-                    ).findIndex((i) => Alpine.raw(active) == Alpine.raw(i));
+                    ).findIndex((i) => Alpine.raw(active) == Alpine.raw(i))
                 }
 
-                return null;
+                return null
             },
-        };
-    });
+        }
+    })
 
-    Alpine.magic("comboboxOption", (el) => {
-        let data = Alpine.$data(el);
+    Alpine.magic('comboboxOption', (el) => {
+        let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, (i) => i.__optionKey);
+        let optionEl = Alpine.findClosest(el, (i) => i.__optionKey)
 
-        if (!optionEl) throw "No x-combobox:option directive found...";
+        if (!optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(optionEl.__optionKey);
+                return data.__context.isActiveKey(optionEl.__optionKey)
             },
             get isSelected() {
-                return data.__isSelected(optionEl);
+                return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(optionEl.__optionKey);
+                return data.__context.isDisabled(optionEl.__optionKey)
             },
-        };
-    });
+        }
+    })
 }
 
 function handleRoot(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        "x-id"() {
+        'x-id'() {
             return [
-                "alpine-combobox-button",
-                "alpine-combobox-options",
-                "alpine-combobox-label",
-            ];
+                'alpine-combobox-button',
+                'alpine-combobox-options',
+                'alpine-combobox-label',
+            ]
         },
-        "x-modelable": "__value",
+        'x-modelable': '__value',
 
         // Initialize...
-        "x-data"() {
+        'x-data'() {
             return {
                 /**
                  * Combobox state...
@@ -101,32 +101,32 @@ function handleRoot(el, Alpine) {
                 init() {
                     this.__isMultiple = Alpine.extractProp(
                         el,
-                        "multiple",
+                        'multiple',
                         false
-                    );
+                    )
                     this.__isDisabled = Alpine.extractProp(
                         el,
-                        "disabled",
+                        'disabled',
                         false
-                    );
-                    this.__inputName = Alpine.extractProp(el, "name", null);
-                    this.__nullable = Alpine.extractProp(el, "nullable", false);
-                    this.__compareBy = Alpine.extractProp(el, "by");
+                    )
+                    this.__inputName = Alpine.extractProp(el, 'name', null)
+                    this.__nullable = Alpine.extractProp(el, 'nullable', false)
+                    this.__compareBy = Alpine.extractProp(el, 'by')
 
                     this.__context = generateContext(
                         Alpine,
                         this.__isMultiple,
-                        "vertical",
+                        'vertical',
                         () => this.__activateSelectedOrFirst()
-                    );
+                    )
 
                     let defaultValue = Alpine.extractProp(
                         el,
-                        "default-value",
+                        'default-value',
                         this.__isMultiple ? [] : null
-                    );
+                    )
 
-                    this.__value = defaultValue;
+                    this.__value = defaultValue
 
                     // We have to wait again until after the "ready" processes are finished
                     // to settle up currently selected Values (this prevents this next bit
@@ -141,38 +141,38 @@ function handleRoot(el, Alpine) {
                                     this.$el,
                                     this.__inputName,
                                     this.__value
-                                );
-                        });
-                    });
+                                )
+                        })
+                    })
                 },
                 __startTyping() {
-                    this.__isTyping = true;
+                    this.__isTyping = true
                 },
                 __stopTyping() {
-                    this.__isTyping = false;
+                    this.__isTyping = false
                 },
                 __resetInput() {
-                    let input = this.$refs.__input;
+                    let input = this.$refs.__input
 
-                    if (!input) return;
+                    if (!input) return
 
-                    let value = this.__getCurrentValue();
+                    let value = this.__getCurrentValue()
 
-                    input.value = value;
+                    input.value = value
                 },
                 __getCurrentValue() {
-                    if (!this.$refs.__input) return "";
-                    if (!this.__value) return "";
+                    if (!this.$refs.__input) return ''
+                    if (!this.__value) return ''
                     if (this.__displayValue)
-                        return this.__displayValue(this.__value);
-                    if (typeof this.__value === "string") return this.__value;
-                    return "";
+                        return this.__displayValue(this.__value)
+                    if (typeof this.__value === 'string') return this.__value
+                    return ''
                 },
                 __open() {
-                    if (this.__isOpen) return;
-                    this.__isOpen = true;
+                    if (this.__isOpen) return
+                    this.__isOpen = true
 
-                    let input = this.$refs.__input;
+                    let input = this.$refs.__input
 
                     // Make sure we always notify the parent component
                     // that the starting value is the empty string
@@ -182,26 +182,26 @@ function handleRoot(el, Alpine) {
                     // also helps VoiceOver to annunce the content properly
                     // See https://github.com/tailwindlabs/headlessui/pull/2153
                     if (input) {
-                        let value = input.value;
+                        let value = input.value
                         let {
                             selectionStart,
                             selectionEnd,
                             selectionDirection,
-                        } = input;
-                        input.value = "";
-                        input.dispatchEvent(new Event("change"));
-                        input.value = value;
+                        } = input
+                        input.value = ''
+                        input.dispatchEvent(new Event('change'))
+                        input.value = value
                         if (selectionDirection !== null) {
                             input.setSelectionRange(
                                 selectionStart,
                                 selectionEnd,
                                 selectionDirection
-                            );
+                            )
                         } else {
                             input.setSelectionRange(
                                 selectionStart,
                                 selectionEnd
-                            );
+                            )
                         }
                     }
 
@@ -210,197 +210,195 @@ function handleRoot(el, Alpine) {
                     let nextTick = (callback) =>
                         requestAnimationFrame(() =>
                             requestAnimationFrame(callback)
-                        );
+                        )
 
                     nextTick(() => {
-                        this.$refs.__input.focus({ preventScroll: true });
-                        this.__activateSelectedOrFirst();
-                    });
+                        this.$refs.__input.focus({ preventScroll: true })
+                        this.__activateSelectedOrFirst()
+                    })
                 },
                 __close() {
-                    this.__isOpen = false;
+                    this.__isOpen = false
 
-                    this.__context.deactivate();
+                    this.__context.deactivate()
                 },
                 __activateSelectedOrFirst(activateSelected = true) {
-                    if (!this.__isOpen) return;
+                    if (!this.__isOpen) return
 
                     if (
                         this.__context.hasActive() &&
                         this.__context.wasActivatedByKeyPress()
                     )
-                        return;
+                        return
 
-                    let firstSelectedValue;
+                    let firstSelectedValue
 
                     if (this.__isMultiple) {
                         let selectedItem = this.__context.getItemsByValues(
                             this.__value
-                        );
+                        )
 
                         firstSelectedValue = selectedItem.length
                             ? selectedItem[0].value
-                            : null;
+                            : null
                     } else {
-                        firstSelectedValue = this.__value;
+                        firstSelectedValue = this.__value
                     }
 
-                    let firstSelected = null;
+                    let firstSelected = null
                     if (activateSelected && firstSelectedValue) {
                         firstSelected =
-                            this.__context.getItemByValue(firstSelectedValue);
+                            this.__context.getItemByValue(firstSelectedValue)
                     }
 
                     if (firstSelected) {
-                        this.__context.activateAndScrollToKey(
-                            firstSelected.key
-                        );
-                        return;
+                        this.__context.activateAndScrollToKey(firstSelected.key)
+                        return
                     }
 
                     this.__context.activateAndScrollToKey(
                         this.__context.firstKey()
-                    );
+                    )
                 },
                 __selectActive() {
-                    let active = this.__context.getActiveItem();
-                    if (active) this.__toggleSelected(active.value);
+                    let active = this.__context.getActiveItem()
+                    if (active) this.__toggleSelected(active.value)
                 },
                 __selectOption(el) {
-                    let item = this.__context.getItemByEl(el);
+                    let item = this.__context.getItemByEl(el)
 
-                    if (item) this.__toggleSelected(item.value);
+                    if (item) this.__toggleSelected(item.value)
                 },
                 __isSelected(el) {
-                    let item = this.__context.getItemByEl(el);
+                    let item = this.__context.getItemByEl(el)
 
-                    if (!item) return false;
-                    if (!item.value) return false;
+                    if (!item) return false
+                    if (!item.value) return false
 
-                    return this.__hasSelected(item.value);
+                    return this.__hasSelected(item.value)
                 },
                 __toggleSelected(value) {
                     if (!this.__isMultiple) {
-                        this.__value = value;
+                        this.__value = value
 
-                        return;
+                        return
                     }
 
                     let index = this.__value.findIndex((j) =>
                         this.__compare(j, value)
-                    );
+                    )
 
                     if (index === -1) {
-                        this.__value.push(value);
+                        this.__value.push(value)
                     } else {
-                        this.__value.splice(index, 1);
+                        this.__value.splice(index, 1)
                     }
                 },
                 __hasSelected(value) {
                     if (!this.__isMultiple)
-                        return this.__compare(this.__value, value);
+                        return this.__compare(this.__value, value)
 
-                    return this.__value.some((i) => this.__compare(i, value));
+                    return this.__value.some((i) => this.__compare(i, value))
                 },
                 __compare(a, b) {
-                    let by = this.__compareBy;
+                    let by = this.__compareBy
 
-                    if (!by) by = (a, b) => Alpine.raw(a) === Alpine.raw(b);
+                    if (!by) by = (a, b) => Alpine.raw(a) === Alpine.raw(b)
 
-                    if (typeof by === "string") {
-                        let property = by;
+                    if (typeof by === 'string') {
+                        let property = by
                         by = (a, b) => {
                             // Handle null values
                             if (
                                 !a ||
-                                typeof a !== "object" ||
+                                typeof a !== 'object' ||
                                 !b ||
-                                typeof b !== "object"
+                                typeof b !== 'object'
                             ) {
-                                return Alpine.raw(a) === Alpine.raw(b);
+                                return Alpine.raw(a) === Alpine.raw(b)
                             }
 
-                            return a[property] === b[property];
-                        };
+                            return a[property] === b[property]
+                        }
                     }
 
-                    return by(a, b);
+                    return by(a, b)
                 },
-            };
+            }
         },
         // Register event listeners..
-        "@mousedown.window"(e) {
+        '@mousedown.window'(e) {
             if (
                 !!!this.$refs.__input.contains(e.target) &&
                 !this.$refs.__button.contains(e.target) &&
                 !this.$refs.__options.contains(e.target)
             ) {
-                this.__close();
-                this.__resetInput();
+                this.__close()
+                this.__resetInput()
             }
         },
-    });
+    })
 }
 
 function handleInput(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        "x-ref": "__input",
-        ":id"() {
-            return this.$id("alpine-combobox-input");
+        'x-ref': '__input',
+        ':id'() {
+            return this.$id('alpine-combobox-input')
         },
 
         // Accessibility attributes...
-        role: "combobox",
-        tabindex: "0",
-        "aria-autocomplete": "list",
+        role: 'combobox',
+        tabindex: '0',
+        'aria-autocomplete': 'list',
 
         // We need to defer this evaluation a bit because $refs that get declared later
         // in the DOM aren't available yet when x-ref is the result of an Alpine.bind object.
-        async ":aria-controls"() {
+        async ':aria-controls'() {
             return await microtask(
                 () => this.$refs.__options && this.$refs.__options.id
-            );
+            )
         },
-        ":aria-expanded"() {
-            return this.$data.__isDisabled ? undefined : this.$data.__isOpen;
+        ':aria-expanded'() {
+            return this.$data.__isDisabled ? undefined : this.$data.__isOpen
         },
-        ":aria-multiselectable"() {
-            return this.$data.__isMultiple ? true : undefined;
+        ':aria-multiselectable'() {
+            return this.$data.__isMultiple ? true : undefined
         },
-        ":aria-activedescendant"() {
-            if (!this.$data.__context.hasActive()) return;
+        ':aria-activedescendant'() {
+            if (!this.$data.__context.hasActive()) return
 
-            let active = this.$data.__context.getActiveItem();
+            let active = this.$data.__context.getActiveItem()
 
-            return active ? active.el.id : null;
+            return active ? active.el.id : null
         },
-        ":aria-labelledby"() {
+        ':aria-labelledby'() {
             return this.$refs.__label
                 ? this.$refs.__label.id
                 : this.$refs.__button
                 ? this.$refs.__button.id
-                : null;
+                : null
         },
 
         // Initialize...
-        "x-init"() {
-            let displayValueFn = Alpine.extractProp(this.$el, "display-value");
-            if (displayValueFn) this.$data.__displayValue = displayValueFn;
-            this.$data.__resetInput();
+        'x-init'() {
+            let displayValueFn = Alpine.extractProp(this.$el, 'display-value')
+            if (displayValueFn) this.$data.__displayValue = displayValueFn
+            this.$data.__resetInput()
         },
 
         // Register listeners...
-        "@input.stop"(e) {
+        '@input.stop'(e) {
             if (this.$data.__isTyping) {
-                this.$data.__open();
-                this.$dispatch("change");
+                this.$data.__open()
+                this.$dispatch('change')
             }
         },
-        "@blur"() {
-            this.$data.__stopTyping(false);
+        '@blur'() {
+            this.$data.__stopTyping(false)
         },
-        "@keydown"(e) {
+        '@keydown'(e) {
             queueMicrotask(() =>
                 this.$data.__context.activateByKeyEvent(
                     e,
@@ -409,241 +407,241 @@ function handleInput(el, Alpine) {
                     () => this.$data.__open(),
                     (state) => (this.$data.__isTyping = state)
                 )
-            );
+            )
         },
-        "@keydown.enter.prevent.stop"() {
-            this.$data.__selectActive();
+        '@keydown.enter.prevent.stop'() {
+            this.$data.__selectActive()
 
-            this.$data.__stopTyping();
+            this.$data.__stopTyping()
 
             if (!this.$data.__isMultiple) {
-                this.$data.__close();
-                this.$data.__resetInput();
+                this.$data.__close()
+                this.$data.__resetInput()
             }
         },
-        "@keydown.escape.prevent"(e) {
-            if (!this.$data.__static) e.stopPropagation();
+        '@keydown.escape.prevent'(e) {
+            if (!this.$data.__static) e.stopPropagation()
 
-            this.$data.__stopTyping();
-            this.$data.__close();
-            this.$data.__resetInput();
+            this.$data.__stopTyping()
+            this.$data.__close()
+            this.$data.__resetInput()
         },
-        "@keydown.tab"() {
-            this.$data.__stopTyping();
+        '@keydown.tab'() {
+            this.$data.__stopTyping()
             if (this.$data.__isOpen) {
-                this.$data.__close();
+                this.$data.__close()
             }
-            this.$data.__resetInput();
+            this.$data.__resetInput()
         },
-        "@keydown.backspace"(e) {
-            if (this.$data.__isMultiple) return;
-            if (!this.$data.__nullable) return;
+        '@keydown.backspace'(e) {
+            if (this.$data.__isMultiple) return
+            if (!this.$data.__nullable) return
 
-            let input = e.target;
+            let input = e.target
 
             requestAnimationFrame(() => {
-                if (input.value === "") {
-                    this.$data.__value = null;
+                if (input.value === '') {
+                    this.$data.__value = null
 
-                    let options = this.$refs.__options;
+                    let options = this.$refs.__options
                     if (options) {
-                        options.scrollTop = 0;
+                        options.scrollTop = 0
                     }
 
-                    this.$data.__context.deactivate();
+                    this.$data.__context.deactivate()
                 }
-            });
+            })
         },
-    });
+    })
 }
 
 function handleButton(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        "x-ref": "__button",
-        ":id"() {
-            return this.$id("alpine-combobox-button");
+        'x-ref': '__button',
+        ':id'() {
+            return this.$id('alpine-combobox-button')
         },
 
         // Accessibility attributes...
-        "aria-haspopup": "true",
+        'aria-haspopup': 'true',
         // We need to defer this evaluation a bit because $refs that get declared later
         // in the DOM aren't available yet when x-ref is the result of an Alpine.bind object.
-        async ":aria-controls"() {
+        async ':aria-controls'() {
             return await microtask(
                 () => this.$refs.__options && this.$refs.__options.id
-            );
+            )
         },
-        ":aria-labelledby"() {
+        ':aria-labelledby'() {
             return this.$refs.__label
-                ? [this.$refs.__label.id, this.$el.id].join(" ")
-                : null;
+                ? [this.$refs.__label.id, this.$el.id].join(' ')
+                : null
         },
-        ":aria-expanded"() {
-            return this.$data.__isDisabled ? null : this.$data.__isOpen;
+        ':aria-expanded'() {
+            return this.$data.__isDisabled ? null : this.$data.__isOpen
         },
-        ":disabled"() {
-            return this.$data.__isDisabled;
+        ':disabled'() {
+            return this.$data.__isDisabled
         },
-        tabindex: "-1",
+        tabindex: '-1',
 
         // Initialize....
-        "x-init"() {
+        'x-init'() {
             if (
-                this.$el.tagName.toLowerCase() === "button" &&
-                !this.$el.hasAttribute("type")
+                this.$el.tagName.toLowerCase() === 'button' &&
+                !this.$el.hasAttribute('type')
             )
-                this.$el.type = "button";
+                this.$el.type = 'button'
         },
 
         // Register listeners...
-        "@click"(e) {
-            if (this.$data.__isDisabled) return;
+        '@click'(e) {
+            if (this.$data.__isDisabled) return
             if (this.$data.__isOpen) {
-                this.$data.__close();
-                this.$data.__resetInput();
+                this.$data.__close()
+                this.$data.__resetInput()
             } else {
-                e.preventDefault();
-                this.$data.__open();
+                e.preventDefault()
+                this.$data.__open()
             }
 
             this.$nextTick(() =>
                 this.$refs.__input.focus({ preventScroll: true })
-            );
+            )
         },
-    });
+    })
 }
 
 function handleLabel(el, Alpine) {
     Alpine.bind(el, {
-        "x-ref": "__label",
-        ":id"() {
-            return this.$id("alpine-combobox-label");
+        'x-ref': '__label',
+        ':id'() {
+            return this.$id('alpine-combobox-label')
         },
-        "@click"() {
-            this.$refs.__input.focus({ preventScroll: true });
+        '@click'() {
+            this.$refs.__input.focus({ preventScroll: true })
         },
-    });
+    })
 }
 
 function handleOptions(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        "x-ref": "__options",
-        ":id"() {
-            return this.$id("alpine-combobox-options");
+        'x-ref': '__options',
+        ':id'() {
+            return this.$id('alpine-combobox-options')
         },
 
         // Accessibility attributes...
-        role: "listbox",
-        ":aria-labelledby"() {
+        role: 'listbox',
+        ':aria-labelledby'() {
             return this.$refs.__label
                 ? this.$refs.__label.id
                 : this.$refs.__button
                 ? this.$refs.__button.id
-                : null;
+                : null
         },
 
         // Initialize...
-        "x-init"() {
-            this.$data.__isStatic = Alpine.bound(this.$el, "static", false);
+        'x-init'() {
+            this.$data.__isStatic = Alpine.bound(this.$el, 'static', false)
 
-            if (Alpine.bound(this.$el, "hold")) {
-                this.$data.__hold = true;
+            if (Alpine.bound(this.$el, 'hold')) {
+                this.$data.__hold = true
             }
         },
 
-        "x-show"() {
-            return this.$data.__isStatic ? true : this.$data.__isOpen;
+        'x-show'() {
+            return this.$data.__isStatic ? true : this.$data.__isOpen
         },
-    });
+    })
 }
 
 function handleOption(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        "x-id"() {
-            return ["alpine-combobox-option"];
+        'x-id'() {
+            return ['alpine-combobox-option']
         },
-        ":id"() {
-            return this.$id("alpine-combobox-option");
+        ':id'() {
+            return this.$id('alpine-combobox-option')
         },
 
         // Accessibility attributes...
-        role: "option",
-        ":tabindex"() {
-            return this.$comboboxOption.isDisabled ? undefined : "-1";
+        role: 'option',
+        ':tabindex'() {
+            return this.$comboboxOption.isDisabled ? undefined : '-1'
         },
 
         // Only the active element should have aria-selected="true"...
-        "x-effect"() {
+        'x-effect'() {
             this.$comboboxOption.isSelected
-                ? el.setAttribute("aria-selected", true)
-                : el.setAttribute("aria-selected", false);
+                ? el.setAttribute('aria-selected', true)
+                : el.setAttribute('aria-selected', false)
         },
 
-        ":aria-disabled"() {
-            return this.$comboboxOption.isDisabled;
+        ':aria-disabled'() {
+            return this.$comboboxOption.isDisabled
         },
 
         // Initialize...
-        "x-data"() {
+        'x-data'() {
             return {
                 init() {
                     let key = (this.$el.__optionKey = (Math.random() + 1)
                         .toString(36)
-                        .substring(7));
+                        .substring(7))
 
-                    let value = Alpine.extractProp(this.$el, "value");
+                    let value = Alpine.extractProp(this.$el, 'value')
                     let disabled = Alpine.extractProp(
                         this.$el,
-                        "disabled",
+                        'disabled',
                         false,
                         false
-                    );
+                    )
 
                     // memoize the context as it's not going to change
                     // and calling this.$data on mouse action is expensive
-                    this.__context.registerItem(key, this.$el, value, disabled);
+                    this.__context.registerItem(key, this.$el, value, disabled)
                 },
                 destroy() {
-                    this.__context.unregisterItem(this.$el.__optionKey);
+                    this.__context.unregisterItem(this.$el.__optionKey)
                 },
-            };
+            }
         },
 
         // Register listeners...
-        "@click"() {
-            if (this.$comboboxOption.isDisabled) return;
+        '@click'() {
+            if (this.$comboboxOption.isDisabled) return
 
-            this.__selectOption(this.$el);
+            this.__selectOption(this.$el)
 
             if (!this.__isMultiple) {
-                this.__close();
-                this.__resetInput();
+                this.__close()
+                this.__resetInput()
             }
 
             this.$nextTick(() =>
                 this.$refs.__input.focus({ preventScroll: true })
-            );
+            )
         },
-        "@mouseenter"(e) {
-            this.__context.activateEl(this.$el);
+        '@mouseenter'(e) {
+            this.__context.activateEl(this.$el)
         },
-        "@mousemove"(e) {
-            if (this.__context.isActiveEl(this.$el)) return;
+        '@mousemove'(e) {
+            if (this.__context.isActiveEl(this.$el)) return
 
-            this.__context.activateEl(this.$el);
+            this.__context.activateEl(this.$el)
         },
-        "@mouseleave"(e) {
-            if (this.__hold) return;
+        '@mouseleave'(e) {
+            if (this.__hold) return
 
-            this.__context.deactivate();
+            this.__context.deactivate()
         },
-    });
+    })
 }
 
 // Little utility to defer a callback into the microtask queue...
 function microtask(callback) {
-    return new Promise((resolve) => queueMicrotask(() => resolve(callback())));
+    return new Promise((resolve) => queueMicrotask(() => resolve(callback())))
 }

--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -106,6 +106,9 @@ function handleRoot(el, Alpine) {
                     // to settle up currently selected Values (this prevents this next bit
                     // of code from running multiple times on startup...)
                     queueMicrotask(() => {
+                        // Set initial combobox values in the input...
+                        queueMicrotask(() => this.__resetInput())
+
                         Alpine.effect(() => {
                             // Everytime the value changes, we need to re-render the hidden inputs,
                             // if a user passed the "name" prop...
@@ -304,7 +307,6 @@ function handleInput(el, Alpine) {
         'x-init'() {
             let displayValueFn = Alpine.extractProp(this.$el, 'display-value')
             if (displayValueFn) this.$data.__displayValue = displayValueFn
-            this.$data.__resetInput()
         },
 
         // Register listeners...

--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -2,16 +2,15 @@ import { generateContext, renderHiddenInputs } from './list-context'
 
 export default function (Alpine) {
     Alpine.directive('combobox', (el, directive, { evaluate }) => {
-        if (directive.value === 'input') handleInput(el, Alpine)
-        else if (directive.value === 'button') handleButton(el, Alpine)
-        else if (directive.value === 'label') handleLabel(el, Alpine)
-        else if (directive.value === 'options') handleOptions(el, Alpine)
-        else if (directive.value === 'option')
-            handleOption(el, Alpine, directive, evaluate)
-        else handleRoot(el, Alpine)
+        if      (directive.value === 'input')        handleInput(el, Alpine)
+        else if (directive.value === 'button')       handleButton(el, Alpine)
+        else if (directive.value === 'label')        handleLabel(el, Alpine)
+        else if (directive.value === 'options')      handleOptions(el, Alpine)
+        else if (directive.value === 'option')       handleOption(el, Alpine, directive, evaluate)
+        else                                         handleRoot(el, Alpine)
     }).before('bind')
 
-    Alpine.magic('combobox', (el) => {
+    Alpine.magic('combobox', el => {
         let data = Alpine.$data(el)
 
         return {
@@ -33,9 +32,7 @@ export default function (Alpine) {
                 let active = data.__context?.getActiveItem()
 
                 if (active) {
-                    return Object.values(
-                        Alpine.raw(data.__context.items)
-                    ).findIndex((i) => Alpine.raw(active) == Alpine.raw(i))
+                    return Object.values(Alpine.raw(data.__context.items)).findIndex(i => Alpine.raw(active) == Alpine.raw(i))
                 }
 
                 return null
@@ -43,12 +40,12 @@ export default function (Alpine) {
         }
     })
 
-    Alpine.magic('comboboxOption', (el) => {
+    Alpine.magic('comboboxOption', el => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, (i) => i.__optionKey)
+        let optionEl = Alpine.findClosest(el, i => i.__optionKey)
 
-        if (!optionEl) throw 'No x-combobox:option directive found...'
+        if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
@@ -67,13 +64,7 @@ export default function (Alpine) {
 function handleRoot(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-id'() {
-            return [
-                'alpine-combobox-button',
-                'alpine-combobox-options',
-                'alpine-combobox-label',
-            ]
-        },
+        'x-id'() { return ['alpine-combobox-button', 'alpine-combobox-options', 'alpine-combobox-label'] },
         'x-modelable': '__value',
 
         // Initialize...
@@ -99,32 +90,15 @@ function handleRoot(el, Alpine) {
                  * Combobox initialization...
                  */
                 init() {
-                    this.__isMultiple = Alpine.extractProp(
-                        el,
-                        'multiple',
-                        false
-                    )
-                    this.__isDisabled = Alpine.extractProp(
-                        el,
-                        'disabled',
-                        false
-                    )
+                    this.__isMultiple = Alpine.extractProp(el, 'multiple', false)
+                    this.__isDisabled = Alpine.extractProp(el, 'disabled', false)
                     this.__inputName = Alpine.extractProp(el, 'name', null)
                     this.__nullable = Alpine.extractProp(el, 'nullable', false)
                     this.__compareBy = Alpine.extractProp(el, 'by')
 
-                    this.__context = generateContext(
-                        Alpine,
-                        this.__isMultiple,
-                        'vertical',
-                        () => this.__activateSelectedOrFirst()
-                    )
+                    this.__context = generateContext(Alpine, this.__isMultiple, 'vertical', () => this.__activateSelectedOrFirst())
 
-                    let defaultValue = Alpine.extractProp(
-                        el,
-                        'default-value',
-                        this.__isMultiple ? [] : null
-                    )
+                    let defaultValue = Alpine.extractProp(el, 'default-value', this.__isMultiple ? [] : null)
 
                     this.__value = defaultValue
 
@@ -135,13 +109,7 @@ function handleRoot(el, Alpine) {
                         Alpine.effect(() => {
                             // Everytime the value changes, we need to re-render the hidden inputs,
                             // if a user passed the "name" prop...
-                            this.__inputName &&
-                                renderHiddenInputs(
-                                    Alpine,
-                                    this.$el,
-                                    this.__inputName,
-                                    this.__value
-                                )
+                            this.__inputName && renderHiddenInputs(Alpine, this.$el, this.__inputName, this.__value)
                         })
                     })
                 },
@@ -154,17 +122,16 @@ function handleRoot(el, Alpine) {
                 __resetInput() {
                     let input = this.$refs.__input
 
-                    if (!input) return
+                    if (! input) return
 
                     let value = this.__getCurrentValue()
 
                     input.value = value
                 },
                 __getCurrentValue() {
-                    if (!this.$refs.__input) return ''
-                    if (!this.__value) return ''
-                    if (this.__displayValue)
-                        return this.__displayValue(this.__value)
+                    if (! this.$refs.__input) return ''
+                    if (! this.__value) return ''
+                    if (this.__displayValue) return this.__displayValue(this.__value)
                     if (typeof this.__value === 'string') return this.__value
                     return ''
                 },
@@ -183,34 +150,20 @@ function handleRoot(el, Alpine) {
                     // See https://github.com/tailwindlabs/headlessui/pull/2153
                     if (input) {
                         let value = input.value
-                        let {
-                            selectionStart,
-                            selectionEnd,
-                            selectionDirection,
-                        } = input
+                        let { selectionStart, selectionEnd, selectionDirection } = input
                         input.value = ''
                         input.dispatchEvent(new Event('change'))
                         input.value = value
                         if (selectionDirection !== null) {
-                            input.setSelectionRange(
-                                selectionStart,
-                                selectionEnd,
-                                selectionDirection
-                            )
+                            input.setSelectionRange(selectionStart, selectionEnd, selectionDirection)
                         } else {
-                            input.setSelectionRange(
-                                selectionStart,
-                                selectionEnd
-                            )
+                            input.setSelectionRange(selectionStart, selectionEnd)
                         }
                     }
 
                     // Safari needs more of a "tick" for focusing after x-show for some reason.
                     // Probably because Alpine adds an extra tick when x-showing for @click.outside
-                    let nextTick = (callback) =>
-                        requestAnimationFrame(() =>
-                            requestAnimationFrame(callback)
-                        )
+                    let nextTick = callback => requestAnimationFrame(() => requestAnimationFrame(callback))
 
                     nextTick(() => {
                         this.$refs.__input.focus({ preventScroll: true })
@@ -223,32 +176,23 @@ function handleRoot(el, Alpine) {
                     this.__context.deactivate()
                 },
                 __activateSelectedOrFirst(activateSelected = true) {
-                    if (!this.__isOpen) return
+                    if (! this.__isOpen) return
 
-                    if (
-                        this.__context.hasActive() &&
-                        this.__context.wasActivatedByKeyPress()
-                    )
-                        return
+                    if (this.__context.hasActive() && this.__context.wasActivatedByKeyPress()) return
 
                     let firstSelectedValue
 
                     if (this.__isMultiple) {
-                        let selectedItem = this.__context.getItemsByValues(
-                            this.__value
-                        )
+                        let selectedItem = this.__context.getItemsByValues(this.__value)
 
-                        firstSelectedValue = selectedItem.length
-                            ? selectedItem[0].value
-                            : null
+                        firstSelectedValue = selectedItem.length ? selectedItem[0].value : null
                     } else {
                         firstSelectedValue = this.__value
                     }
 
                     let firstSelected = null
                     if (activateSelected && firstSelectedValue) {
-                        firstSelected =
-                            this.__context.getItemByValue(firstSelectedValue)
+                        firstSelected = this.__context.getItemByValue(firstSelectedValue)
                     }
 
                     if (firstSelected) {
@@ -256,9 +200,7 @@ function handleRoot(el, Alpine) {
                         return
                     }
 
-                    this.__context.activateAndScrollToKey(
-                        this.__context.firstKey()
-                    )
+                    this.__context.activateAndScrollToKey(this.__context.firstKey())
                 },
                 __selectActive() {
                     let active = this.__context.getActiveItem()
@@ -272,21 +214,19 @@ function handleRoot(el, Alpine) {
                 __isSelected(el) {
                     let item = this.__context.getItemByEl(el)
 
-                    if (!item) return false
-                    if (!item.value) return false
+                    if (! item) return false
+                    if (! item.value) return false
 
                     return this.__hasSelected(item.value)
                 },
                 __toggleSelected(value) {
-                    if (!this.__isMultiple) {
+                    if (! this.__isMultiple) {
                         this.__value = value
 
                         return
                     }
 
-                    let index = this.__value.findIndex((j) =>
-                        this.__compare(j, value)
-                    )
+                    let index = this.__value.findIndex(j => this.__compare(j, value))
 
                     if (index === -1) {
                         this.__value.push(value)
@@ -295,30 +235,25 @@ function handleRoot(el, Alpine) {
                     }
                 },
                 __hasSelected(value) {
-                    if (!this.__isMultiple)
-                        return this.__compare(this.__value, value)
+                    if (! this.__isMultiple) return this.__compare(this.__value, value)
 
-                    return this.__value.some((i) => this.__compare(i, value))
+                    return this.__value.some(i => this.__compare(i, value))
                 },
                 __compare(a, b) {
                     let by = this.__compareBy
 
-                    if (!by) by = (a, b) => Alpine.raw(a) === Alpine.raw(b)
+                    if (! by) by = (a, b) => Alpine.raw(a) === Alpine.raw(b)
 
                     if (typeof by === 'string') {
                         let property = by
                         by = (a, b) => {
                             // Handle null values
-                            if (
-                                !a ||
-                                typeof a !== 'object' ||
-                                !b ||
-                                typeof b !== 'object'
-                            ) {
+                            if ((! a || typeof a !== 'object') || (! b || typeof b !== 'object')) {
                                 return Alpine.raw(a) === Alpine.raw(b)
                             }
 
-                            return a[property] === b[property]
+
+                            return a[property] === b[property];
                         }
                     }
 
@@ -329,14 +264,14 @@ function handleRoot(el, Alpine) {
         // Register event listeners..
         '@mousedown.window'(e) {
             if (
-                !!!this.$refs.__input.contains(e.target) &&
-                !this.$refs.__button.contains(e.target) &&
-                !this.$refs.__options.contains(e.target)
+                !! ! this.$refs.__input.contains(e.target)
+                && ! this.$refs.__button.contains(e.target)
+                && ! this.$refs.__options.contains(e.target)
             ) {
                 this.__close()
                 this.__resetInput()
             }
-        },
+        }
     })
 }
 
@@ -344,42 +279,26 @@ function handleInput(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
         'x-ref': '__input',
-        ':id'() {
-            return this.$id('alpine-combobox-input')
-        },
+        ':id'() { return this.$id('alpine-combobox-input') },
 
         // Accessibility attributes...
-        role: 'combobox',
-        tabindex: '0',
+        'role': 'combobox',
+        'tabindex': '0',
         'aria-autocomplete': 'list',
 
         // We need to defer this evaluation a bit because $refs that get declared later
         // in the DOM aren't available yet when x-ref is the result of an Alpine.bind object.
-        async ':aria-controls'() {
-            return await microtask(
-                () => this.$refs.__options && this.$refs.__options.id
-            )
-        },
-        ':aria-expanded'() {
-            return this.$data.__isDisabled ? undefined : this.$data.__isOpen
-        },
-        ':aria-multiselectable'() {
-            return this.$data.__isMultiple ? true : undefined
-        },
+        async ':aria-controls'() { return await microtask(() => this.$refs.__options && this.$refs.__options.id) },
+        ':aria-expanded'() { return this.$data.__isDisabled ? undefined : this.$data.__isOpen },
+        ':aria-multiselectable'() { return this.$data.__isMultiple ? true : undefined },
         ':aria-activedescendant'() {
-            if (!this.$data.__context.hasActive()) return
+            if (! this.$data.__context.hasActive()) return
 
             let active = this.$data.__context.getActiveItem()
 
             return active ? active.el.id : null
         },
-        ':aria-labelledby'() {
-            return this.$refs.__label
-                ? this.$refs.__label.id
-                : this.$refs.__button
-                ? this.$refs.__button.id
-                : null
-        },
+        ':aria-labelledby'() { return this.$refs.__label ? this.$refs.__label.id : (this.$refs.__button ? this.$refs.__button.id : null) },
 
         // Initialize...
         'x-init'() {
@@ -390,52 +309,41 @@ function handleInput(el, Alpine) {
 
         // Register listeners...
         '@input.stop'(e) {
-            if (this.$data.__isTyping) {
-                this.$data.__open()
+            if(this.$data.__isTyping) {
+                this.$data.__open();
                 this.$dispatch('change')
             }
         },
-        '@blur'() {
-            this.$data.__stopTyping(false)
-        },
+        '@blur'() { this.$data.__stopTyping(false) },
         '@keydown'(e) {
-            queueMicrotask(() =>
-                this.$data.__context.activateByKeyEvent(
-                    e,
-                    false,
-                    () => this.$data.__isOpen,
-                    () => this.$data.__open(),
-                    (state) => (this.$data.__isTyping = state)
-                )
-            )
+            queueMicrotask(() => this.$data.__context.activateByKeyEvent(e, false, () => this.$data.__isOpen, () => this.$data.__open(), (state) => this.$data.__isTyping = state))
         },
         '@keydown.enter.prevent.stop'() {
             this.$data.__selectActive()
 
             this.$data.__stopTyping()
 
-            if (!this.$data.__isMultiple) {
+            if (! this.$data.__isMultiple) {
                 this.$data.__close()
                 this.$data.__resetInput()
             }
         },
         '@keydown.escape.prevent'(e) {
-            if (!this.$data.__static) e.stopPropagation()
+            if (! this.$data.__static) e.stopPropagation()
 
             this.$data.__stopTyping()
             this.$data.__close()
             this.$data.__resetInput()
+
         },
         '@keydown.tab'() {
             this.$data.__stopTyping()
-            if (this.$data.__isOpen) {
-                this.$data.__close()
-            }
+            if (this.$data.__isOpen) { this.$data.__close() }
             this.$data.__resetInput()
         },
         '@keydown.backspace'(e) {
             if (this.$data.__isMultiple) return
-            if (!this.$data.__nullable) return
+            if (! this.$data.__nullable) return
 
             let input = e.target
 
@@ -459,40 +367,20 @@ function handleButton(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
         'x-ref': '__button',
-        ':id'() {
-            return this.$id('alpine-combobox-button')
-        },
+        ':id'() { return this.$id('alpine-combobox-button') },
 
         // Accessibility attributes...
         'aria-haspopup': 'true',
         // We need to defer this evaluation a bit because $refs that get declared later
         // in the DOM aren't available yet when x-ref is the result of an Alpine.bind object.
-        async ':aria-controls'() {
-            return await microtask(
-                () => this.$refs.__options && this.$refs.__options.id
-            )
-        },
-        ':aria-labelledby'() {
-            return this.$refs.__label
-                ? [this.$refs.__label.id, this.$el.id].join(' ')
-                : null
-        },
-        ':aria-expanded'() {
-            return this.$data.__isDisabled ? null : this.$data.__isOpen
-        },
-        ':disabled'() {
-            return this.$data.__isDisabled
-        },
-        tabindex: '-1',
+        async ':aria-controls'() { return await microtask(() => this.$refs.__options && this.$refs.__options.id) },
+        ':aria-labelledby'() { return this.$refs.__label ? [this.$refs.__label.id, this.$el.id].join(' ') : null },
+        ':aria-expanded'() { return this.$data.__isDisabled ? null : this.$data.__isOpen },
+        ':disabled'() { return this.$data.__isDisabled },
+        'tabindex': '-1',
 
         // Initialize....
-        'x-init'() {
-            if (
-                this.$el.tagName.toLowerCase() === 'button' &&
-                !this.$el.hasAttribute('type')
-            )
-                this.$el.type = 'button'
-        },
+        'x-init'() { if (this.$el.tagName.toLowerCase() === 'button' && ! this.$el.hasAttribute('type')) this.$el.type = 'button' },
 
         // Register listeners...
         '@click'(e) {
@@ -505,9 +393,7 @@ function handleButton(el, Alpine) {
                 this.$data.__open()
             }
 
-            this.$nextTick(() =>
-                this.$refs.__input.focus({ preventScroll: true })
-            )
+            this.$nextTick(() => this.$refs.__input.focus({ preventScroll: true }))
         },
     })
 }
@@ -515,12 +401,8 @@ function handleButton(el, Alpine) {
 function handleLabel(el, Alpine) {
     Alpine.bind(el, {
         'x-ref': '__label',
-        ':id'() {
-            return this.$id('alpine-combobox-label')
-        },
-        '@click'() {
-            this.$refs.__input.focus({ preventScroll: true })
-        },
+        ':id'() { return this.$id('alpine-combobox-label') },
+        '@click'() { this.$refs.__input.focus({ preventScroll: true }) },
     })
 }
 
@@ -528,50 +410,34 @@ function handleOptions(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
         'x-ref': '__options',
-        ':id'() {
-            return this.$id('alpine-combobox-options')
-        },
+        ':id'() { return this.$id('alpine-combobox-options') },
 
         // Accessibility attributes...
-        role: 'listbox',
-        ':aria-labelledby'() {
-            return this.$refs.__label
-                ? this.$refs.__label.id
-                : this.$refs.__button
-                ? this.$refs.__button.id
-                : null
-        },
+        'role': 'listbox',
+        ':aria-labelledby'() { return this.$refs.__label ? this.$refs.__label.id : (this.$refs.__button ? this.$refs.__button.id : null) },
 
         // Initialize...
         'x-init'() {
             this.$data.__isStatic = Alpine.bound(this.$el, 'static', false)
 
             if (Alpine.bound(this.$el, 'hold')) {
-                this.$data.__hold = true
+                this.$data.__hold = true;
             }
         },
 
-        'x-show'() {
-            return this.$data.__isStatic ? true : this.$data.__isOpen
-        },
+        'x-show'() { return this.$data.__isStatic ? true : this.$data.__isOpen },
     })
 }
 
 function handleOption(el, Alpine) {
     Alpine.bind(el, {
         // Setup...
-        'x-id'() {
-            return ['alpine-combobox-option']
-        },
-        ':id'() {
-            return this.$id('alpine-combobox-option')
-        },
+        'x-id'() { return ['alpine-combobox-option'] },
+        ':id'() { return this.$id('alpine-combobox-option') },
 
         // Accessibility attributes...
-        role: 'option',
-        ':tabindex'() {
-            return this.$comboboxOption.isDisabled ? undefined : '-1'
-        },
+        'role': 'option',
+        ':tabindex'() { return this.$comboboxOption.isDisabled ? undefined : '-1' },
 
         // Only the active element should have aria-selected="true"...
         'x-effect'() {
@@ -580,25 +446,16 @@ function handleOption(el, Alpine) {
                 : el.setAttribute('aria-selected', false)
         },
 
-        ':aria-disabled'() {
-            return this.$comboboxOption.isDisabled
-        },
+        ':aria-disabled'() { return this.$comboboxOption.isDisabled },
 
         // Initialize...
         'x-data'() {
             return {
                 init() {
-                    let key = (this.$el.__optionKey = (Math.random() + 1)
-                        .toString(36)
-                        .substring(7))
+                    let key = this.$el.__optionKey = (Math.random() + 1).toString(36).substring(7)
 
                     let value = Alpine.extractProp(this.$el, 'value')
-                    let disabled = Alpine.extractProp(
-                        this.$el,
-                        'disabled',
-                        false,
-                        false
-                    )
+                    let disabled = Alpine.extractProp(this.$el, 'disabled', false, false)
 
                     // memoize the context as it's not going to change
                     // and calling this.$data on mouse action is expensive
@@ -606,24 +463,22 @@ function handleOption(el, Alpine) {
                 },
                 destroy() {
                     this.__context.unregisterItem(this.$el.__optionKey)
-                },
+                }
             }
         },
 
         // Register listeners...
         '@click'() {
-            if (this.$comboboxOption.isDisabled) return
+            if (this.$comboboxOption.isDisabled) return;
 
             this.__selectOption(this.$el)
 
-            if (!this.__isMultiple) {
+            if (! this.__isMultiple) {
                 this.__close()
                 this.__resetInput()
             }
 
-            this.$nextTick(() =>
-                this.$refs.__input.focus({ preventScroll: true })
-            )
+            this.$nextTick(() => this.$refs.__input.focus({ preventScroll: true }))
         },
         '@mouseenter'(e) {
             this.__context.activateEl(this.$el)
@@ -641,7 +496,8 @@ function handleOption(el, Alpine) {
     })
 }
 
+
 // Little utility to defer a callback into the microtask queue...
 function microtask(callback) {
-    return new Promise((resolve) => queueMicrotask(() => resolve(callback())))
+    return new Promise(resolve => queueMicrotask(() => resolve(callback())))
 }

--- a/tests/cypress/integration/plugins/ui/combobox.spec.js
+++ b/tests/cypress/integration/plugins/ui/combobox.spec.js
@@ -98,6 +98,68 @@ test('it works with x-model',
     },
 )
 
+test('initial value is set from x-model',
+    [html`
+        <div
+            x-data="{
+                query: '',
+                selected: { id: 1, name: 'Wade Cooper' },
+                people: [
+                    { id: 1, name: 'Wade Cooper' },
+                ],
+                get filteredPeople() {
+                    return this.query === ''
+                        ? this.people
+                        : this.people.filter((person) => {
+                            return person.name.toLowerCase().includes(this.query.toLowerCase())
+                        })
+                },
+            }"
+        >
+            <div x-combobox x-model="selected">
+                <label x-combobox:label>Select person</label>
+
+                <div>
+                    <div>
+                        <input
+                            x-combobox:input
+                            :display-value="person => person.name"
+                            @change="query = $event.target.value"
+                            placeholder="Search..."
+                        />
+
+                        <button x-combobox:button>Toggle</button>
+                    </div>
+
+                    <div x-combobox:options>
+                        <ul>
+                            <template
+                                x-for="person in filteredPeople"
+                                :key="person.id"
+                                hidden
+                            >
+                                <li
+                                    x-combobox:option
+                                    :option="person.id"
+                                    :value="person"
+                                    :disabled="person.disabled"
+                                    x-text="person.name"
+                                >
+                                </li>
+                            </template>
+                        </ul>
+                    </div>
+                </div>
+
+                <article x-text="selected?.name"></article>
+            </div>
+        </div>
+    `],
+    ({ get }) => {
+        get('input').should(haveValue('Wade Cooper'))
+    },
+)
+
 test('it works with internal state',
     [html`
         <div
@@ -581,7 +643,7 @@ test('"multiple" prop',
         >
             <label x-combobox:label>Assigned to</label>
 
-            <input x-combobox:input :display-value="(person) => person.name" type="text">
+            <input x-combobox:input type="text">
             <button x-combobox:button x-text="$combobox.value ? $combobox.value.join(',') : 'Select People'"></button>
 
             <ul x-combobox:options>


### PR DESCRIPTION
Currently when setting a default value for the combobox it isn't displayed right away. You would have to open and close it before the display value would be visible. This will reset the input as part of the init so the value is displayed right away.