### PR TITLE
add explanation of passing an object to `x-for`

### DIFF
--- a/packages/docs/src/en/directives/for.md
+++ b/packages/docs/src/en/directives/for.md
@@ -25,6 +25,30 @@ Alpine's `x-for` directive allows you to create DOM elements by iterating throug
 </div>
 <!-- END_VERBATIM -->
 
+You may also pass objects to `x-for`.
+
+```alpine
+<ul x-data="{ car: { make: 'Jeep', model: 'Grand Cherokee', color: 'Black' } }">
+    <template x-for="(value, index) in car">
+        <li>
+            <span x-text="index"></span>: <span x-text="value"></span>
+        </li>
+    </template>
+</ul>
+```
+
+<!-- START_VERBATIM -->
+<div class="demo">
+    <ul x-data="{ car: { make: 'Jeep', model: 'Grand Cherokee', color: 'Black' } }">
+        <template x-for="(value, index) in car">
+            <li>
+                <span x-text="index"></span>: <span x-text="value"></span>
+            </li>
+        </template>
+    </ul>
+</div>
+<!-- END_VERBATIM -->
+
 There are two rules worth noting about `x-for`:
 
 >`x-for` MUST be declared on a `<template>` element


### PR DESCRIPTION
`x-for` also accepts objects in addition to arrays. the docs currently only mention arrays, so users might not be sure if objects are allowed. this explicitly states they are and gives an example how to use them.

I was trying to find the relevant PR for when this functionality was added, but was unable to. I found some PRs from Ryan Chandler that were trying to add this feature but were closed.