### PR TITLE
Clear combobox bugfix

### DIFF
--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -111,6 +111,8 @@ function handleRoot(el, Alpine) {
                             // if a user passed the "name" prop...
                             this.__inputName && renderHiddenInputs(Alpine, this.$el, this.__inputName, this.__value)
                         })
+
+                        Alpine.effect(() => ! this.__isMultiple && this.__resetInput())
                     })
                 },
                 __startTyping() {

--- a/tests/cypress/integration/plugins/ui/combobox.spec.js
+++ b/tests/cypress/integration/plugins/ui/combobox.spec.js
@@ -66,6 +66,8 @@ test('it works with x-model',
 
                 <article x-text="selected?.name"></article>
             </div>
+
+            <a href="#" x-on:click.prevent="selected = { id: 7, name: 'Caroline Schultz' }">Set selected via code</a>
         </div>
     `],
     ({ get }) => {
@@ -95,6 +97,9 @@ test('it works with x-model',
         get('ul').should(notBeVisible())
         get('input').should(haveValue('Wade Cooper'))
         get('article').should(haveText('Wade Cooper'))
+        get('a').click()
+        get('input').should(haveValue('Caroline Schultz'))
+        get('article').should(haveText('Caroline Schultz'))
     },
 )
 
@@ -1209,6 +1214,7 @@ test('input reset',
             </div>
 
             <article>lorem ipsum</article>
+            <a x-on:click="selected = null">Clear</a>
         </div>
     `],
     ({ get }) => {
@@ -1265,6 +1271,10 @@ test('input reset',
         get('input').type('w')
         get('article').click()
         get('input').should(haveValue('Arlene Mccoy'))
+
+        // Test correct state after clearing selected via code
+        get('a').click()
+        get('input').should(haveValue(''))
     },
 )
 


### PR DESCRIPTION
Fixes https://github.com/alpinejs/alpine/discussions/3724

When you want to clear the selected value or you want to set the selected value via code, the search input is not immediately updated. You must click somewhere on the page to update the search input's value.

https://github.com/alpinejs/alpine/assets/22586858/69d491e9-e7b5-4e7c-a897-137876af613b

This PR fixes that. When the selected value changes, the search input's value immediately updates.


https://github.com/alpinejs/alpine/assets/22586858/5175a960-9e12-4952-b4ad-79184d968a29



