### PR TITLE
Bug in code example of documentation for x-anchor to an ID

### DIFF
--- a/packages/docs/src/en/plugins/anchor.md
+++ b/packages/docs/src/en/plugins/anchor.md
@@ -192,7 +192,7 @@ Because `x-anchor` accepts a reference to any DOM element, you can use utilities
 <div x-data="{ open: false }">
     <button id="trigger" @click="open = ! open">Toggle</button>
 
-    <div x-show="open" x-anchor="document.getElementById('#trigger')">
+    <div x-show="open" x-anchor="document.getElementById('trigger')">
         Dropdown content
     </div>
 </div>


### PR DESCRIPTION
The code example uses `#` in the `getElementById` function, which breaks the code

```js
// Wrong
document.getElementById('#trigger')

// Right
document.getElementById('trigger')
```

Full code example

```html
<div x-data="{ open: false }">
    <button id="trigger" @click="open = ! open">Toggle</button>

    <div x-show="open" x-anchor="document.getElementById('trigger')">
        Dropdown content
    </div>
</div>
```