### PR TITLE
fix: already init component

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -88,8 +88,11 @@ export function initTree(el, walker = walk, intercept = () => {}) {
 
             directives(el, el.attributes).forEach(handle => handle())
 
-            el._x_isInit = true
-            el._x_ignore && skip()
+            if (el._x_ignore) {
+              skip()
+            } else {
+              el._x_isInit = true
+            }
         })
     })
 }

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -88,6 +88,7 @@ export function initTree(el, walker = walk, intercept = () => {}) {
 
             directives(el, el.attributes).forEach(handle => handle())
 
+            el._x_isInit = true
             el._x_ignore && skip()
         })
     })

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -82,9 +82,6 @@ export function interceptInit(callback) { initInterceptors.push(callback) }
 export function initTree(el, walker = walk, intercept = () => {}) {
     deferHandlingDirectives(() => {
         walker(el, (el, skip) => {
-            if (el._x_isInit) return;
-            el._x_isInit = true
-
             intercept(el, skip)
 
             initInterceptors.forEach(i => i(el, skip))

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -82,16 +82,17 @@ export function interceptInit(callback) { initInterceptors.push(callback) }
 export function initTree(el, walker = walk, intercept = () => {}) {
     deferHandlingDirectives(() => {
         walker(el, (el, skip) => {
-            intercept(el, skip)
+            if (!el._x_isInit) {
+                intercept(el, skip)
 
-            initInterceptors.forEach(i => i(el, skip))
-
-            directives(el, el.attributes).forEach(handle => handle())
+                initInterceptors.forEach(i => i(el, skip))
+                directives(el, el.attributes).forEach(handle => handle())
+            }
 
             if (el._x_ignore) {
-              skip()
+                skip()
             } else {
-              el._x_isInit = true
+                el._x_isInit = true
             }
         })
     })
@@ -101,5 +102,6 @@ export function destroyTree(root) {
     walk(root, el => {
         cleanupAttributes(el)
         cleanupElement(el)
+        delete el._x_isInit
     })
 }

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -82,6 +82,9 @@ export function interceptInit(callback) { initInterceptors.push(callback) }
 export function initTree(el, walker = walk, intercept = () => {}) {
     deferHandlingDirectives(() => {
         walker(el, (el, skip) => {
+            if (el._x_isInit) return;
+            el._x_isInit = true
+
             intercept(el, skip)
 
             initInterceptors.forEach(i => i(el, skip))

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -194,10 +194,6 @@ function onMutate(mutations) {
         node._x_ignore = true
     })
     for (let node of addedNodes) {
-        // If an element gets moved on a page, it's registered
-        // as both an "add" and "remove", so we want to skip those.
-        if (removedNodes.includes(node)) continue
-
         // If the node was eventually removed as part of one of his
         // parent mutations, skip it
         if (! node.isConnected) continue

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -194,14 +194,9 @@ function onMutate(mutations) {
         node._x_ignore = true
     })
     for (let node of addedNodes) {
-        // If the node is already init, it means it's a move operation
-        if (node._x_isInit) continue
-
         // If the node was eventually removed as part of one of his
         // parent mutations, skip it
         if (! node.isConnected) continue
-
-        node._x_isInit = true
 
         delete node._x_ignoreSelf
         delete node._x_ignore

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -194,9 +194,14 @@ function onMutate(mutations) {
         node._x_ignore = true
     })
     for (let node of addedNodes) {
+        // If the node is already init, it means it's a move operation
+        if (node._x_isInit) continue
+
         // If the node was eventually removed as part of one of his
         // parent mutations, skip it
         if (! node.isConnected) continue
+
+        node._x_isInit = true
 
         delete node._x_ignoreSelf
         delete node._x_ignore


### PR DESCRIPTION
Currently we defined if a mutation is a move operation if the node is in the `addedNodes` and in the `removedNodes`. 

However in some case, an element is added, removed and added again. So it should considered as `add` + `move` operations. But alpine will ignore it, considering it as a move operation only (so nothing will be init).

The PR focus on introducing a new state `_x_isInit` that will be true for component that are initialized.

Also it may speed up a little bit the `onMutate` function. Previously we checked every deleted nodes before adding any new nodes. For big mutations, iterate over the `deletedNodes` several times could be CPU intensive.

> Conversation on : https://github.com/alpinejs/alpine/discussions/3947