### PR TITLE
Bug Fix in Docs: Update mask plugin docs to include 'x-data' attribute

### DIFF
--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -69,12 +69,12 @@ The primary API for using this plugin is the `x-mask` directive.
 Let's start by looking at the following simple example of a date field:
 
 ```alpine
-<input x-mask="99/99/9999" placeholder="MM/DD/YYYY">
+<input type="text" x-data x-mask="99/99/9999" placeholder="MM/DD/YYYY">
 ```
 
 <!-- START_VERBATIM -->
 <div class="demo">
-    <input x-data x-mask="99/99/9999" placeholder="MM/DD/YYYY">
+    <input type="text" x-data x-mask="99/99/9999" placeholder="MM/DD/YYYY">
 </div>
 <!-- END_VERBATIM -->
 
@@ -97,7 +97,7 @@ Sometimes simple mask literals (i.e. `(999) 999-9999`) are not sufficient. In th
 Here's an example of a credit card input that needs to change it's mask based on if the number starts with the numbers "34" or "37" (which means it's an Amex card and therefore has a different format).
 
 ```alpine
-<input x-mask:dynamic="
+<input type="text" x-data x-mask:dynamic="
     $input.startsWith('34') || $input.startsWith('37')
         ? '9999 999999 99999' : '9999 9999 9999 9999'
 ">
@@ -109,7 +109,7 @@ Try it for yourself by typing a number that starts with "34" and one that doesn'
 
 <!-- START_VERBATIM -->
 <div class="demo">
-    <input x-data x-mask:dynamic="
+    <input type="text" x-data x-mask:dynamic="
         $input.startsWith('34') || $input.startsWith('37')
             ? '9999 999999 99999' : '9999 9999 9999 9999'
     ">
@@ -139,36 +139,36 @@ Because writing your own dynamic mask expression for money inputs is fairly comp
 Here is a fully functioning money input mask:
 
 ```alpine
-<input x-mask:dynamic="$money($input)">
+<input type="text" x-data x-mask:dynamic="$money($input)" placeholder="0.00">
 ```
 
 <!-- START_VERBATIM -->
-<div class="demo" x-data>
-    <input type="text" x-mask:dynamic="$money($input)" placeholder="0.00">
+<div class="demo">
+    <input type="text" x-data x-mask:dynamic="$money($input)" placeholder="0.00">
 </div>
 <!-- END_VERBATIM -->
 
 If you wish to swap the periods for commas and vice versa (as is required in certain currencies), you can do so using the second optional parameter:
 
 ```alpine
-<input x-mask:dynamic="$money($input, ',')">
+<input type="text" x-data x-mask:dynamic="$money($input, ',')"  placeholder="0,00">
 ```
 
 <!-- START_VERBATIM -->
-<div class="demo" x-data>
-    <input type="text" x-mask:dynamic="$money($input, ',')"  placeholder="0,00">
+<div class="demo">
+    <input type="text" x-data x-mask:dynamic="$money($input, ',')"  placeholder="0,00">
 </div>
 <!-- END_VERBATIM -->
 
 You may also choose to override the thousands separator by supplying a third optional argument:
 
 ```alpine
-<input x-mask:dynamic="$money($input, '.', ' ')">
+<input type="text" x-data x-mask:dynamic="$money($input, '.', ' ')"  placeholder="3 000.00">
 ```
 
 <!-- START_VERBATIM -->
-<div class="demo" x-data>
-    <input type="text" x-mask:dynamic="$money($input, '.', ' ')"  placeholder="3 000.00">
+<div class="demo">
+    <input type="text" x-data x-mask:dynamic="$money($input, '.', ' ')"  placeholder="3 000.00">
 </div>
 <!-- END_VERBATIM -->
 
@@ -176,11 +176,11 @@ You may also choose to override the thousands separator by supplying a third opt
 You can also override the default precision of 2 digits by using any desired number of digits as the fourth optional argument:
 
 ```alpine
-<input x-mask:dynamic="$money($input, '.', ',', 4)">
+<input type="text" x-data x-mask:dynamic="$money($input, '.', ',', 4)"  placeholder="0.0001">
 ```
 
 <!-- START_VERBATIM -->
-<div class="demo" x-data>
-    <input type="text" x-mask:dynamic="$money($input, '.', ',', 4)"  placeholder="0.0001">
+<div class="demo">
+    <input type="text" x-data x-mask:dynamic="$money($input, '.', ',', 4)"  placeholder="0.0001">
 </div>
 <!-- END_VERBATIM -->


### PR DESCRIPTION
The 'x-data' attribute has been now included in the input fields of the examples given in the mask plugin documentation. This helps to demonstrate its usage correctly; plus, placeholders added to match the demo fields.

Without x-data Mask doesn't work. 
Reproducable [JSFidle demo](https://jsfiddle.net/hLd24ey7/)