### PR TITLE
Combobox and listbox: Save optionKey in x-data to fix usage in Livewire

### DIFF
--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -43,19 +43,19 @@ export default function (Alpine) {
     Alpine.magic('comboboxOption', el => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => i.__optionKey)
+        let optionEl = Alpine.findClosest(el, i => Alpine.$data(i).optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(optionEl.__optionKey)
+                return data.__context.isActiveKey(Alpine.$data(optionEl).optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(optionEl.__optionKey)
+                return data.__context.isDisabled(Alpine.$data(optionEl).optionKey)
             },
         }
     })
@@ -450,18 +450,20 @@ function handleOption(el, Alpine) {
         // Initialize...
         'x-data'() {
             return {
+                'optionKey': null,
+
                 init() {
-                    let key = this.$el.__optionKey = (Math.random() + 1).toString(36).substring(7)
+                    this.optionKey = (Math.random() + 1).toString(36).substring(7)
 
                     let value = Alpine.extractProp(this.$el, 'value')
                     let disabled = Alpine.extractProp(this.$el, 'disabled', false, false)
 
                     // memoize the context as it's not going to change
                     // and calling this.$data on mouse action is expensive
-                    this.__context.registerItem(key, this.$el, value, disabled)
+                    this.__context.registerItem(this.optionKey, this.$el, value, disabled)
                 },
                 destroy() {
-                    this.__context.unregisterItem(this.$el.__optionKey)
+                    this.__context.unregisterItem(this.optionKey)
                 }
             }
         },

--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -48,19 +48,19 @@ export default function (Alpine) {
     Alpine.magic('listboxOption', (el) => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => Alpine.$date(i).optionKey)
+        let optionEl = Alpine.findClosest(el, i => Alpine.$data(i).optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(Alpine.$date(optionEl).optionKey)
+                return data.__context.isActiveKey(Alpine.$data(optionEl).optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(Alpine.$date(optionEl).optionKey)
+                return data.__context.isDisabled(Alpine.$data(optionEl).optionKey)
             },
         }
     })

--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -48,19 +48,19 @@ export default function (Alpine) {
     Alpine.magic('listboxOption', (el) => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => i.__optionKey)
+        let optionEl = Alpine.findClosest(el, i => Alpine.$date(i).optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(optionEl.__optionKey)
+                return data.__context.isActiveKey(Alpine.$date(optionEl).optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(optionEl.__optionKey)
+                return data.__context.isDisabled(Alpine.$date(optionEl).optionKey)
             },
         }
     })
@@ -339,16 +339,18 @@ function handleOption(el, Alpine) {
             // Initialize...
             'x-data'() {
                 return {
+                    'optionKey': null,
+
                     init() {
-                        let key = el.__optionKey = (Math.random() + 1).toString(36).substring(7)
+                        this.optionKey = (Math.random() + 1).toString(36).substring(7)
 
                         let value = Alpine.extractProp(el, 'value')
                         let disabled = Alpine.extractProp(el, 'disabled', false, false)
 
-                        this.$data.__context.registerItem(key, el, value, disabled)
+                        this.$data.__context.registerItem(this.optionKey, el, value, disabled)
                     },
                     destroy() {
-                        this.$data.__context.unregisterItem(this.$el.__optionKey)
+                        this.$data.__context.unregisterItem(this.optionKey)
                     },
                 }
             },


### PR DESCRIPTION
When optionKey is not saved in x-data, the value is lost after a Livewire update. That causes the optionElement of the $listboxOption magic to not be found and that results in the combobox/listbox not working completely anymore.
```js
Alpine.magic('listboxOption', (el) => {
	let data = Alpine.$data(el)
	
	let optionEl = Alpine.findClosest(el, i => i.__optionKey)
	
	// This error will be thrown after a Livewire update (same in comboxOption-magic)
	if (! optionEl) throw 'No x-combobox:option directive found...'
	
	// ...
});
```

This PR fixes that by saving the optionKey in x-data.