### PR TITLE
Combobox and listbox: Save optionKey in x-data to fix usage in Livewire

### DIFF
--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -43,19 +43,19 @@ export default function (Alpine) {
     Alpine.magic('comboboxOption', el => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => i.__optionKey)
+        let optionEl = Alpine.findClosest(el, i => Alpine.$data(i).optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(optionEl.__optionKey)
+                return data.__context.isActiveKey(Alpine.$data(optionEl).optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(optionEl.__optionKey)
+                return data.__context.isDisabled(Alpine.$data(optionEl).optionKey)
             },
         }
     })
@@ -450,18 +450,20 @@ function handleOption(el, Alpine) {
         // Initialize...
         'x-data'() {
             return {
+                'optionKey': null,
+
                 init() {
-                    let key = this.$el.__optionKey = (Math.random() + 1).toString(36).substring(7)
+                    this.optionKey = (Math.random() + 1).toString(36).substring(7)
 
                     let value = Alpine.extractProp(this.$el, 'value')
                     let disabled = Alpine.extractProp(this.$el, 'disabled', false, false)
 
                     // memoize the context as it's not going to change
                     // and calling this.$data on mouse action is expensive
-                    this.__context.registerItem(key, this.$el, value, disabled)
+                    this.__context.registerItem(this.optionKey, this.$el, value, disabled)
                 },
                 destroy() {
-                    this.__context.unregisterItem(this.$el.__optionKey)
+                    this.__context.unregisterItem(this.optionKey)
                 }
             }
         },

--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -43,19 +43,19 @@ export default function (Alpine) {
     Alpine.magic('comboboxOption', el => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => Alpine.$data(i).optionKey)
+        let optionEl = Alpine.findClosest(el, i => data.__optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(Alpine.$data(optionEl).optionKey)
+                return data.__context.isActiveKey(Alpine.$data(optionEl).__optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(Alpine.$data(optionEl).optionKey)
+                return data.__context.isDisabled(Alpine.$data(optionEl).__optionKey)
             },
         }
     })
@@ -450,20 +450,20 @@ function handleOption(el, Alpine) {
         // Initialize...
         'x-data'() {
             return {
-                'optionKey': null,
+                '__optionKey': null,
 
                 init() {
-                    this.optionKey = (Math.random() + 1).toString(36).substring(7)
+                    this.__optionKey = (Math.random() + 1).toString(36).substring(7)
 
                     let value = Alpine.extractProp(this.$el, 'value')
                     let disabled = Alpine.extractProp(this.$el, 'disabled', false, false)
 
                     // memoize the context as it's not going to change
                     // and calling this.$data on mouse action is expensive
-                    this.__context.registerItem(this.optionKey, this.$el, value, disabled)
+                    this.__context.registerItem(this.__optionKey, this.$el, value, disabled)
                 },
                 destroy() {
-                    this.__context.unregisterItem(this.optionKey)
+                    this.__context.unregisterItem(this.__optionKey)
                 }
             }
         },
@@ -496,7 +496,6 @@ function handleOption(el, Alpine) {
         },
     })
 }
-
 
 // Little utility to defer a callback into the microtask queue...
 function microtask(callback) {

--- a/packages/ui/src/combobox.js
+++ b/packages/ui/src/combobox.js
@@ -43,7 +43,11 @@ export default function (Alpine) {
     Alpine.magic('comboboxOption', el => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => data.__optionKey)
+        // It's not great depending on the existance of the attribute in the DOM
+        // but it's probably the fastest and most reliable at this point...
+        let optionEl = Alpine.findClosest(el, i => {
+            return i.hasAttribute('x-combobox:option')
+        })
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 

--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -48,19 +48,19 @@ export default function (Alpine) {
     Alpine.magic('listboxOption', (el) => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => Alpine.$date(i).optionKey)
+        let optionEl = Alpine.findClosest(el, i => Alpine.$data(i).optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(Alpine.$date(optionEl).optionKey)
+                return data.__context.isActiveKey(Alpine.$data(optionEl).optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(Alpine.$date(optionEl).optionKey)
+                return data.__context.isDisabled(Alpine.$data(optionEl).optionKey)
             },
         }
     })

--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -48,19 +48,19 @@ export default function (Alpine) {
     Alpine.magic('listboxOption', (el) => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => i.__optionKey)
+        let optionEl = Alpine.findClosest(el, i => Alpine.$date(i).optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(optionEl.__optionKey)
+                return data.__context.isActiveKey(Alpine.$date(optionEl).optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(optionEl.__optionKey)
+                return data.__context.isDisabled(Alpine.$date(optionEl).optionKey)
             },
         }
     })
@@ -339,16 +339,18 @@ function handleOption(el, Alpine) {
             // Initialize...
             'x-data'() {
                 return {
+                    'optionKey': null,
+
                     init() {
-                        let key = el.__optionKey = (Math.random() + 1).toString(36).substring(7)
+                        this.optionKey = (Math.random() + 1).toString(36).substring(7)
 
                         let value = Alpine.extractProp(el, 'value')
                         let disabled = Alpine.extractProp(el, 'disabled', false, false)
 
-                        this.$data.__context.registerItem(key, el, value, disabled)
+                        this.$data.__context.registerItem(this.optionKey, el, value, disabled)
                     },
                     destroy() {
-                        this.$data.__context.unregisterItem(this.$el.__optionKey)
+                        this.$data.__context.unregisterItem(this.optionKey)
                     },
                 }
             },

--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -48,19 +48,19 @@ export default function (Alpine) {
     Alpine.magic('listboxOption', (el) => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => Alpine.$data(i).optionKey)
+        let optionEl = Alpine.findClosest(el, i => data.__optionKey)
 
         if (! optionEl) throw 'No x-combobox:option directive found...'
 
         return {
             get isActive() {
-                return data.__context.isActiveKey(Alpine.$data(optionEl).optionKey)
+                return data.__context.isActiveKey(Alpine.$data(optionEl).__optionKey)
             },
             get isSelected() {
                 return data.__isSelected(optionEl)
             },
             get isDisabled() {
-                return data.__context.isDisabled(Alpine.$data(optionEl).optionKey)
+                return data.__context.isDisabled(Alpine.$data(optionEl).__optionKey)
             },
         }
     })
@@ -339,18 +339,18 @@ function handleOption(el, Alpine) {
             // Initialize...
             'x-data'() {
                 return {
-                    'optionKey': null,
+                    '__optionKey': null,
 
                     init() {
-                        this.optionKey = (Math.random() + 1).toString(36).substring(7)
+                        this.__optionKey = (Math.random() + 1).toString(36).substring(7)
 
                         let value = Alpine.extractProp(el, 'value')
                         let disabled = Alpine.extractProp(el, 'disabled', false, false)
 
-                        this.$data.__context.registerItem(this.optionKey, el, value, disabled)
+                        this.$data.__context.registerItem(this.__optionKey, el, value, disabled)
                     },
                     destroy() {
-                        this.$data.__context.unregisterItem(this.optionKey)
+                        this.$data.__context.unregisterItem(this.__optionKey)
                     },
                 }
             },

--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -48,9 +48,13 @@ export default function (Alpine) {
     Alpine.magic('listboxOption', (el) => {
         let data = Alpine.$data(el)
 
-        let optionEl = Alpine.findClosest(el, i => data.__optionKey)
+        // It's not great depending on the existance of the attribute in the DOM
+        // but it's probably the fastest and most reliable at this point...
+        let optionEl = Alpine.findClosest(el, i => {
+            return i.hasAttribute('x-listbox:option')
+        })
 
-        if (! optionEl) throw 'No x-combobox:option directive found...'
+        if (! optionEl) throw 'No x-listbox:option directive found...'
 
         return {
             get isActive() {

--- a/tests/cypress/integration/plugins/ui/combobox.spec.js
+++ b/tests/cypress/integration/plugins/ui/combobox.spec.js
@@ -1,4 +1,4 @@
-import { beVisible, beHidden, haveAttribute, haveClasses, notHaveClasses, haveText, contain, notContain, html, notBeVisible, notHaveAttribute, notExist, haveFocus, test, haveValue, haveLength} from '../../../utils'
+import { beVisible, beHidden, haveAttribute, haveClasses, notHaveClasses, haveText, contain, notContain, html, notBeVisible, notHaveAttribute, notExist, haveFocus, test, haveValue, haveLength, ensureNoConsoleWarns} from '../../../utils'
 
 test('it works with x-model',
     [html`
@@ -1558,3 +1558,39 @@ test('can remove an option without other options getting removed',
         get('[check="3"]').should(notBeVisible())
     },
 );
+
+test('works with morph',
+    [html`
+    <div x-data="{ value: null }">
+        <div x-combobox x-model="value">
+            <button x-combobox:button>Select Framework</button>
+
+            <ul x-combobox:options>
+                <li x-combobox:option value="laravel">Laravel</li>
+            </ul>
+        </div>
+
+        Selected: <span x-text="value"></span>
+    </div>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+        <div x-data="{ value: null }">
+            <div x-combobox x-model="value">
+                <button x-combobox:button>Select Framework (updated)</button>
+
+                <ul x-combobox:options>
+                    <li x-combobox:option value="laravel">Laravel</li>
+                </ul>
+            </div>
+
+            Selected: <span x-text="value"></span>
+        </div>
+        `
+        ensureNoConsoleWarns()
+
+        get('div').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('button').should(haveText('Select Framework (updated)'))
+    },
+)

--- a/tests/cypress/integration/plugins/ui/listbox.spec.js
+++ b/tests/cypress/integration/plugins/ui/listbox.spec.js
@@ -1,4 +1,4 @@
-import { beVisible, beHidden, haveAttribute, haveClasses, notHaveClasses, haveText, html, notBeVisible, notHaveAttribute, notExist, haveFocus, test} from '../../../utils'
+import { beVisible, beHidden, haveAttribute, haveClasses, notHaveClasses, haveText, html, notBeVisible, notHaveAttribute, notExist, haveFocus, test, ensureNoConsoleWarns} from '../../../utils'
 
 test('it works with x-model',
     [html`
@@ -862,6 +862,42 @@ test('"static" prop',
         get('[option="2"]').click()
         get('ul').should(beVisible())
         get('[normal-toggle]').should(haveText('Arlene Mccoy'))
+    },
+)
+
+test('works with morph',
+    [html`
+    <div x-data="{ value: null }">
+        <div x-listbox x-model="value">
+            <button x-listbox:button>Select Framework</button>
+
+            <ul x-listbox:options>
+                <li x-listbox:option value="laravel">Laravel</li>
+            </ul>
+        </div>
+
+        Selected: <span x-text="value"></span>
+    </div>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+        <div x-data="{ value: null }">
+            <div x-listbox x-model="value">
+                <button x-listbox:button>Select Framework (updated)</button>
+
+                <ul x-listbox:options>
+                    <li x-listbox:option value="laravel">Laravel</li>
+                </ul>
+            </div>
+
+            Selected: <span x-text="value"></span>
+        </div>
+        `
+        ensureNoConsoleWarns()
+
+        get('div').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('button').should(haveText('Select Framework (updated)'))
     },
 )
 

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -5,6 +5,18 @@ export function html(strings) {
     return strings.raw[0]
 }
 
+export function ensureNoConsoleWarns() {
+    cy.window().then((win) => {
+        let cache = win.console.warn
+
+        win.console.warn = () => { throw new Error('Console warn was triggered') }
+
+        cy.on('window:before:unload', () => {
+            win.console.warn = cache
+        });
+    });
+}
+
 export let test = function (name, template, callback, handleExpectedErrors = false) {
     it(name, () => {
         injectHtmlAndBootAlpine(cy, template, callback, undefined, handleExpectedErrors)


### PR DESCRIPTION
I created a listbox (or combobox) with options that are present in HTML and not generated by javascript.
```blade
<!-- in the blade file of a livewire component -->

<div>
    <button wire:click="$refresh" type="button">trigger livewire update</button>

    <div x-data="{ value: null }">
        <div x-listbox x-model="value">
            <button x-listbox:button>
                Select Framework
            </button>

            <ul x-listbox:options>
                <li :class="{
                    'text-blue-100': $listboxOption.isActive,
                    'text-yellow-100': !$listboxOption.isActive,
                    '!text-gray-60 opacity-50 cursor-not-allowed': $listboxOption.isDisabled,
                }" x-listbox:option value="laravel">
                    Laravel
                </li>

                <li :class="{
                    'text-blue-100': $listboxOption.isActive,
                    'text-yellow-100': !$listboxOption.isActive,
                    '!text-gray-60 opacity-50 cursor-not-allowed': $listboxOption.isDisabled,
                }" x-listbox:option value="rails">
                    Ruby on Rails
                </li>

                <li :class="{
                    'text-blue-100': $listboxOption.isActive,
                    'text-yellow-100': !$listboxOption.isActive,
                    '!text-gray-60 opacity-50 cursor-not-allowed': $listboxOption.isDisabled,
                }" x-listbox:option value="phoenix" :disabled="true">
                    Phoenix
                </li>
            </ul>
        </div>

        Selected: <span x-text="value"></span>
    </div>
</div>
```

When I use the listbox/combobox in a livewire component and a livewire update is triggered (by clicking the "trigger livewire update" button in the example above), then the following javascript warnings and errors occur:

<img width="1707" alt="Screenshot 2024-01-22 at 08 23 49" src="https://github.com/alpinejs/alpine/assets/22586858/5d0d5aa5-babd-4829-af4b-0975c3b55488">

When I debugged the issue, I discovered that the `__optionKey` on the option HTML element disappears after the Livewire update. To fix that, I updated the listbox/combobox code so that the "optionKey" is saved in the Alpinejs' x-data as that data will not be disappear after a Livewire update.

I did not add tests because I'm unsure how to test this as Livewire causes it.

_This issue and another Livewire-related issue (https://github.com/livewire/livewire/discussions/7566) are currently the only 2 bugs preventing me from using the listbox/combobox in Livewire. I have tried to debug the other issue, but after many hours of searching, I have still not found what is causing the infinite loop._