### PR TITLE
Fix context of listbox to prevent error when using wire:navigate

### DIFF
--- a/packages/ui/src/listbox.js
+++ b/packages/ui/src/listbox.js
@@ -104,7 +104,7 @@ function handleRoot(el, Alpine) {
                     this.__compareBy = Alpine.extractProp(el, 'by')
                     this.__orientation = Alpine.extractProp(el, 'horizontal', false) ? 'horizontal' : 'vertical'
 
-                    this.__context = generateContext(Alpine, this.__isMultiple, this.__orientation, () => this.$data.__activateSelectedOrFirst())
+                    this.__context = generateContext(Alpine, this.__isMultiple, this.__orientation, () => this.__activateSelectedOrFirst())
 
                     let defaultValue = Alpine.extractProp(el, 'default-value', this.__isMultiple ? [] : null)
 


### PR DESCRIPTION
When I combine Livewire's `wire:navigate` and listbox components, I get the following error when navigating:

<img width="809" alt="Screenshot 2024-01-30 at 14 15 03" src="https://github.com/alpinejs/alpine/assets/22586858/449c76e9-871c-4652-ae0d-10f0d8fd5e90">

The combobox component does not have that issue. When looking at the source code of the combobox, I saw that the `__activateSelectedOrFirst` method is directly accessed on `this` instead of `this.$data`. This PR changes that in the listbox component in the same way, as that fixes the error.