### PR TITLE
Add failing test for keyboard controls with `x-teleport`

### DIFF
--- a/tests/cypress/integration/plugins/ui/menu.spec.js
+++ b/tests/cypress/integration/plugins/ui/menu.spec.js
@@ -219,6 +219,54 @@ test('keyboard controls',
     },
 )
 
+test('keyboard controls with x-teleport',
+    [html`
+        <div x-data x-menu>
+            <span>
+                <button x-menu:button trigger>
+                    <span>Options</span>
+                </button>
+            </span>
+
+            <template x-teleport="body">
+                <div x-menu:items items>
+                    <a x-menu:item href="#account-settings" :class="$menuItem.isActive && 'active'">
+                        Account settings
+                    </a>
+                    <a x-menu:item href="#support" :class="$menuItem.isActive && 'active'">
+                        Support
+                    </a>
+                </div>
+            </template>
+        </div>`],
+    ({ get }) => {
+        get('.active').should(notExist())
+        get('[trigger]').type(' ')
+        get('[items]')
+            .should(beVisible())
+            .should(haveFocus())
+            .type('{downarrow}')
+        get('[href="#account-settings"]')
+            .should(haveClasses(['active']))
+        get('[items]')
+            .type('{downarrow}')
+        get('[href="#support"]')
+            .should(haveClasses(['active']))
+            .type('{uparrow}')
+        get('[href="#account-settings"]')
+            .should(haveClasses(['active']))
+        get('[items]')
+            .tab()
+            .should(haveFocus())
+            .should(beVisible())
+            .tab({ shift: true})
+            .should(haveFocus())
+            .should(beVisible())
+            .type('{esc}')
+            .should(notBeVisible())
+    },
+)
+
 test('search',
     [html`
         <div x-data x-menu>


### PR DESCRIPTION
Adds failing test for #4030 

If the `this.$refs.__items` are replaced with `this.$el` in the following section then the test passes, so it seems to be related to teleported refs.

https://github.com/alpinejs/alpine/blob/84fd08d62c1041ed73358a4a0d337656d8d488cd/packages/ui/src/menu.js#L98-L110