### PR TITLE
Allows access to methods when class instance used for x-data

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -48,7 +48,7 @@ let mergeProxyTrap = {
         if (name == Symbol.unscopables) return false;
 
         return objects.some((obj) =>
-            Object.prototype.hasOwnProperty.call(obj, name)
+            Reflect.has(obj, name)
         );
     },
 
@@ -57,7 +57,7 @@ let mergeProxyTrap = {
 
         return Reflect.get(
             objects.find((obj) =>
-                Object.prototype.hasOwnProperty.call(obj, name)
+                Reflect.has(obj, name)
             ) || {},
             name,
             thisProxy
@@ -66,7 +66,7 @@ let mergeProxyTrap = {
 
     set({ objects }, name, value, thisProxy) {
         const target = objects.find((obj) =>
-                Object.prototype.hasOwnProperty.call(obj, name)
+               Reflect.has(obj, name)
             ) || objects[objects.length - 1];
         const descriptor = Object.getOwnPropertyDescriptor(target, name);
         if (descriptor?.set && descriptor?.get)

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -56,3 +56,32 @@ test(
         get("span#two").should(haveText("foobar"));
     }
 );
+
+test(
+    "allows accessing class methods",
+    [
+        html`
+            <script>
+                class Counter {
+                    value = 0;
+                    constructor() {}
+                    increment() {
+                        this.value++;
+                    }
+                }
+                document.addEventListener("alpine:init", () => 
+                    Alpine.data("counter", () => new Counter())
+                )
+            </script>
+            <div x-data="counter">
+                <button type="button" @click="increment" x-text=value></button>
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("button").should(haveText("0"));
+        get("button").click();
+        get("button").should(haveText("1"));
+    }
+);
+


### PR DESCRIPTION
Currently, if a class instance is used as the data scope, instance methods (and inherited properties *shudders*) are not accessible in expressions.

This is due to only checking for own properties in `mergeProxies`.

This changes this to use `Reflect.has` to better *reflect* the actual operation being performed, and uses that same behavior in other places doing this check for consistency. (Of note, I found in some testing that using `Reflect.ownKeys` in the `ownKeys` trap caused some very strange call stack issues).

(Note on using Class instances in general: actually private instance properties/methods will not be accessible from other methods on that class instance due to how the proxy reflection actually works).