### PR TITLE
Handles Object Prototype Methods in Proxy

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -46,10 +46,12 @@ let mergeProxyTrap = {
 
     has({ objects }, name) {
         if (name == Symbol.unscopables) return false;
-        if (name in Object.prototype) return false;
+        const isPrototypeMethod = name in Object.prototype;
 
         return objects.some((obj) =>
-            Object.prototype.hasOwnProperty.call(obj, name)
+            isPrototypeMethod
+                ? Object.prototype.hasOwnProperty.call(obj, name)
+                : Reflect.has(obj, name)
         );
     },
 
@@ -66,7 +68,8 @@ let mergeProxyTrap = {
     },
 
     set({ objects }, name, value, thisProxy) {
-        const target = objects.find((obj) =>
+        const target =
+            objects.find((obj) =>
                 Object.prototype.hasOwnProperty.call(obj, name)
             ) || objects[objects.length - 1];
         const descriptor = Object.getOwnPropertyDescriptor(target, name);

--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -46,6 +46,7 @@ let mergeProxyTrap = {
 
     has({ objects }, name) {
         if (name == Symbol.unscopables) return false;
+        if (name in Object.prototype) return false;
 
         return objects.some((obj) =>
             Object.prototype.hasOwnProperty.call(obj, name)

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -56,3 +56,48 @@ test(
         get("span#two").should(haveText("foobar"));
     }
 );
+
+test(
+    "allows accessing class methods",
+    [
+        html`
+            <script>
+                class Counter {
+                    value = 0;
+                    constructor() {}
+                    increment() {
+                        this.value++;
+                    }
+                }
+                document.addEventListener("alpine:init", () =>
+                    Alpine.data("counter", () => new Counter())
+                );
+            </script>
+            <div x-data="counter">
+                <button
+                    type="button"
+                    @click="increment"
+                    x-text="value"
+                ></button>
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("button").should(haveText("0"));
+        get("button").click();
+        get("button").should(haveText("1"));
+    }
+);
+test(
+    "does not expose Object.prototype methods",
+    [
+        html`
+            <div x-data="{ foo: 'bar' }">
+                <span x-text="Reflect.has($data, 'valueOf')">
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("span").should(haveText("false"));
+    }
+);

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -101,3 +101,16 @@ test(
         get("span").should(haveText("false"));
     }
 );
+test(
+    "does expose data methods that match name of Object.prototype methods",
+    [
+        html`
+            <div x-data="{ valueOf: 'bar' }">
+                <span x-text="Reflect.has($data, 'valueOf')">
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("span").should(haveText("true"));
+    }
+);


### PR DESCRIPTION
Continuation of #4038 

This addresses a potential issue that may arise (and then another issue that fix may lead to).

These "fixes" are more for posterities sake, as these becoming issues hinges on #4038 being merged, but also the likelihood of them being issues is quite small.

This can just be in draft (or even closed) for history sake if those issues do come to fruition.

Basically, #4038 would expose prototype methods to the Proxy used for expressions, so expressions like `valueOf` would point to the data object method `valueOf` while the previous behavior would be the `window.valueOf`.

This checks if the things being accessed is an Object.prototype method and skips it, but to allow someones own object to use those same names, we check if the object has that name itself.

These seem like low likelihood/low impact issues, but are logical results of #4038