### PR TITLE
:bug: Prevents Setting from registering a dependency

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -48,6 +48,7 @@ let mergeProxyTrap = {
         if (name == Symbol.unscopables) return false;
 
         return objects.some((obj) =>
+            Object.prototype.hasOwnProperty.call(obj, name) ||
             Reflect.has(obj, name)
         );
     },
@@ -65,8 +66,9 @@ let mergeProxyTrap = {
     },
 
     set({ objects }, name, value, thisProxy) {
-        const target = objects.find((obj) =>
-               Reflect.has(obj, name)
+        const target =
+            objects.find((obj) =>
+                Object.prototype.hasOwnProperty.call(obj, name)
             ) || objects[objects.length - 1];
         const descriptor = Object.getOwnPropertyDescriptor(target, name);
         if (descriptor?.set && descriptor?.get)

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -69,12 +69,16 @@ test(
                         this.value++;
                     }
                 }
-                document.addEventListener("alpine:init", () => 
+                document.addEventListener("alpine:init", () =>
                     Alpine.data("counter", () => new Counter())
-                )
+                );
             </script>
             <div x-data="counter">
-                <button type="button" @click="increment" x-text=value></button>
+                <button
+                    type="button"
+                    @click="increment"
+                    x-text="value"
+                ></button>
             </div>
         `,
     ],
@@ -85,3 +89,23 @@ test(
     }
 );
 
+test(
+    "setting value doesn't register a dependency",
+    [
+        html`
+            <div x-data="{ message: 'original' }">
+                <button
+                    x-effect="message = 'effected'"
+                    @click="message = 'clicked'"
+                    x-text="message"
+                ></button>
+            </div>
+            ;
+        `,
+    ],
+    ({ get }) => {
+        get("button").should(haveText("effected"));
+        get("button").click();
+        get("button").should(haveText("clicked"));
+    }
+);


### PR DESCRIPTION
Apprently, internally Vue reacitivity would register a tracking on the key if the key was checked using Reflect.has, while `getOwnProperty` would not.

This using `getOwnProperty` first to prevent tracking on own properties, then uses Reflect.get to check for class methods.

That's a bit unexpected. 😢 

but now at least there is a test for this case.

After this is pushed and released (as this is a pretty critical bug) 3.13.6 should probably be yanked/deprecated on npm.

Playground for reference of :

[3.13.5](https://awesomealpine.com/play?coreplugins=0&html=PGRpdiB4LWRhdGE9InsgbWVzc2FnZTogJ29yaWdpbmFsJyB9Ij4KICA8YnV0dG9uCiAgICB4LWVmZmVjdD0ibWVzc2FnZSA9ICdlZmZlY3RlZCciCiAgICBAY2xpY2s9Im1lc3NhZ2UgPSAnY2xpY2tlZCciCiAgICB4LXRleHQ9Im1lc3NhZ2UiCiAgPjwvYnV0dG9uPgo8L2Rpdj4K&tw=1&ts=1&script=QWxwaW5lLmRhdGEoJ3Rlc3QnLCAoKSA9PiAoewogIHdvcmtpbmc6IGZhbHNlLAogIGRvc3R1ZmYoKSB7CiAgICBpZiAodGhpcy50aW1lcysrID4gNSkgcmV0dXJuOwogICAgZGVidWdnZXI7CiAgICB0aGlzLndvcmtpbmcgPSB0cnVlOwogICAgY29uc29sZS5sb2coJ1dvcmtpbmcgbm93JywgdGhpcy50aW1lcyk7CiAgICBzZXRUaW1lb3V0KCgpID0-ICh0aGlzLndvcmtpbmcgPSBmYWxzZSksIDEwMDApOwogIH0sCiAgdGltZXM6IDAsCn0pKTsK&v=3.13.5)

[3.13.6](https://awesomealpine.com/play?coreplugins=0&html=PGRpdiB4LWRhdGE9InsgbWVzc2FnZTogJ29yaWdpbmFsJyB9Ij4KICA8YnV0dG9uCiAgICB4LWVmZmVjdD0ibWVzc2FnZSA9ICdlZmZlY3RlZCciCiAgICBAY2xpY2s9Im1lc3NhZ2UgPSAnY2xpY2tlZCciCiAgICB4LXRleHQ9Im1lc3NhZ2UiCiAgPjwvYnV0dG9uPgo8L2Rpdj4K&tw=1&ts=1&script=QWxwaW5lLmRhdGEoJ3Rlc3QnLCAoKSA9PiAoewogIHdvcmtpbmc6IGZhbHNlLAogIGRvc3R1ZmYoKSB7CiAgICBpZiAodGhpcy50aW1lcysrID4gNSkgcmV0dXJuOwogICAgZGVidWdnZXI7CiAgICB0aGlzLndvcmtpbmcgPSB0cnVlOwogICAgY29uc29sZS5sb2coJ1dvcmtpbmcgbm93JywgdGhpcy50aW1lcyk7CiAgICBzZXRUaW1lb3V0KCgpID0-ICh0aGlzLndvcmtpbmcgPSBmYWxzZSksIDEwMDApOwogIH0sCiAgdGltZXM6IDAsCn0pKTsK&v=3.13.6)

In the first you can see that clicking the button changes the button to clicked, while the second, the effect will run again and overwrite the change from clicked.