### PR TITLE
Fix mask plugin with data directive (CSP)

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -18,7 +18,7 @@ export default function (Alpine) {
                         // x-on expressions do so that we can use them as mask functions.
                         Alpine.dontAutoEvaluateFunctions(() => {
                             evaluator(value => {
-                                result = typeof value === 'function' ? value(input) : value
+                                result = typeof value === 'function' ? value(input, formatMoney.bind({ el }) : value
                             }, { scope: {
                                 // These are "magics" we'll make available to the x-mask:function:
                                 '$input': input,


### PR DESCRIPTION
## Before:

Data directive:
```
Alpine.data('form', function() {
  return {
    amountMask: function (inputValue) {
      return this.moneyMaskFormat(inputValue) // ❌ How to access the $money formatter?
    }
  }
})
```

HTML:
```
<form x-data="form">
  <input x-mask:dynamic="amountMask($input, $money)" /> // ❌ 
</form>
```

![image](https://github.com/alpinejs/alpine/assets/48229166/969d89a2-f6ca-42cf-a408-17d531f93490)


## After

Data directive:
```
Alpine.data('form', function() {
  return {
    amountMask: function (inputValue, moneyMaskFormat) { // ✅ We get access to the formatter
      return moneyMaskFormat(inputValue)
    }
  }
})
```

HTML:
```
<form x-data="form">
  <input x-mask:dynamic="amountMask" /> // ✅ Valid CSP expression
</form>
```

Let me know if I'm missing something, or if it would break something else?