### PR TITLE
Throw error when passing anything other than a function to `Alpine.plugin`

### DIFF
--- a/packages/alpinejs/src/plugin.js
+++ b/packages/alpinejs/src/plugin.js
@@ -3,5 +3,9 @@ import Alpine from "./alpine";
 export function plugin(callback) {
     let callbacks = Array.isArray(callback) ? callback : [callback]
 
-    callbacks.forEach(i => i(Alpine))
+    callbacks.forEach(i => {
+      if (typeof i === undefined) { throw new Error(`Alpine.plugin(...) expects a callback function but got undefined. Did you misspell your plugin import?`)}
+      if (typeof i !== 'function') { throw new Error(`Alpine.plugin(...) expects a callback function but got ${i}`)}
+      i(Alpine)
+    })
 }

--- a/packages/alpinejs/src/plugin.js
+++ b/packages/alpinejs/src/plugin.js
@@ -4,7 +4,6 @@ export function plugin(callback) {
     let callbacks = Array.isArray(callback) ? callback : [callback]
 
     callbacks.forEach(i => {
-      if (typeof i === undefined) { throw new Error(`Alpine.plugin(...) expects a callback function but got undefined. Did you misspell your plugin import?`)}
       if (typeof i !== 'function') { throw new Error(`Alpine.plugin(...) expects a callback function but got ${i}`)}
       i(Alpine)
     })

--- a/tests/cypress/integration/custom-plugins.spec.js
+++ b/tests/cypress/integration/custom-plugins.spec.js
@@ -1,0 +1,48 @@
+import { haveText, haveAttribute, html, test } from '../utils'
+
+test('can register custom directive from plugin',
+    [html`
+        <div x-data>
+            <span x-foo:bar.baz="bob"></span>
+        </div>
+    `,
+    `
+        Alpine.plugin((PluginAlpine) => {
+          PluginAlpine.directive('foo', (el, { value, modifiers, expression }) => {
+              el.textContent = value+modifiers+expression
+          })
+        })
+    `],
+    ({ get }) => get('span').should(haveText('barbazbob'))
+)
+
+test('can register custom magic properties from plugin',
+    [html`
+        <div x-data>
+            <span x-text="$foo.bar"></span>
+        </div>
+    `,
+    `
+        Alpine.plugin((PluginAlpine) => {
+          PluginAlpine.magic('foo', (el) => {
+            return { bar: 'baz' }
+          })
+        })
+    `],
+    ({ get }) => get('span').should(haveText('baz'))
+)
+
+test('throws error when plugin is not a callback function',
+    [html`
+        <div x-data>
+            <span x-foo:bar.baz="bob"></span>
+        </div>
+    `,
+    `
+        Alpine.plugin(undefined)
+    `],
+  () => {}, (err) => {
+    expect(err.message).to.include('Alpine.plugin(...) expects a callback function but got');
+    return false;
+  },
+)

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -42,14 +42,19 @@ test.csp = (name, template, callback, handleExpectedErrors = false) => {
     })
 }
 
-function injectHtmlAndBootAlpine(cy, templateAndPotentiallyScripts, callback, page, handleExpectedErrors = false) {
+function injectHtmlAndBootAlpine(cy, templateAndPotentiallyScripts, callback, page, errorHandler = false) {
     let [template, scripts] = Array.isArray(templateAndPotentiallyScripts)
         ? templateAndPotentiallyScripts
         : [templateAndPotentiallyScripts]
 
     cy.visit(page || __dirname+'/spec.html')
 
-    if( handleExpectedErrors ) {
+    if( errorHandler ) {
+      if (typeof errorHandler == 'function') {
+        cy.on( 'uncaught:exception', ( error ) => {
+          return errorHandler(error)
+      } );
+      } else {
         cy.on( 'uncaught:exception', ( error ) => {
             if( error.el === undefined && error.expression === undefined ) {
                 console.warn( 'Expected all errors originating from Alpine to have el and expression.  Letting cypress fail the test.', error )
@@ -57,6 +62,7 @@ function injectHtmlAndBootAlpine(cy, templateAndPotentiallyScripts, callback, pa
             }
             return false
         } );
+      }
     }
 
     cy.get('#root').then(([el]) => {


### PR DESCRIPTION
Currently if you accidentally pass anything other than a function to `Alpine.plugin` you get this cryptic error:

<img width="566" alt="image" src="https://github.com/alpinejs/alpine/assets/64985/c8aa3c04-71d0-408d-a44b-d7f9629d7f24">

This has happened to me a few times when I misspell my import e.g.

```
import myPlugin from './wrong-name'

Alpine.plugin(myPlugin)
```

This PR changes the plugin function so that it throws nice errors when this happens:

<img width="569" alt="image" src="https://github.com/alpinejs/alpine/assets/64985/500935be-dab9-491c-b091-4a782785d9f1">

I also added integration tests for plugins and modified the test suite setup so it's possible to assert a specific error is thrown.