### PR TITLE
Add fix to ensure Alpine's started property is global

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -4,12 +4,10 @@ import { dispatch } from './utils/dispatch'
 import { walk } from "./utils/walk"
 import { warn } from './utils/warn'
 
-let started = false
-
 export function start() {
-    if (started) warn('Alpine has already been initialized on this page. Calling Alpine.start() more than once can cause problems.')
+    if (window.AlpineStarted) warn('Alpine has already been initialized on this page. Calling Alpine.start() more than once can cause problems.')
 
-    started = true
+    window.AlpineStarted = true
 
     if (! document.body) warn('Unable to initialize. Trying to load Alpine before `<body>` is available. Did you forget to add `defer` in Alpine\'s `<script>` tag?')
 


### PR DESCRIPTION
With some of Laravel's started kits, AlpineJS is included by default in the `app.js` bundle.

The problem is if Livewire v3 is then installed - which has a bundled version of Alpine - then Livewire won't function correctly.

This is due to the conflict between the two Alpine versions.

So the recommended action is to remove AlpineJS from the `app.js` bundle and use the one bundled with Livewire. But developers that a new to using Livewire/Alpine don't necessarily know this and it can be hard to debug when just nothing works. https://github.com/livewire/livewire/discussions/8025#discussioncomment-8620466 https://github.com/livewire/livewire/discussions/6672#discussioncomment-8706642

Alpine has a check to see if Alpine is already running, which works fine if it is two standard instances of Alpine are loaded on the page, but for some reason the check does not work when using the Livewire bundled version of Alpine.

<img width="1135" alt="Screenshot 2024-03-18 at 4 36 36 pm" src="https://github.com/alpinejs/alpine/assets/882837/cfb74ab9-246b-40f0-8734-fe3180db830c">

So to fix this, I've changed the Alpine `started` property to be a property on the window `window.AlpineStarted`.

This ensures that Alpine check runs properly no matter where Alpine is started from.

<img width="1133" alt="Screenshot 2024-03-18 at 4 37 20 pm" src="https://github.com/alpinejs/alpine/assets/882837/6f42c06c-9abf-4145-9782-0c9de7912617">

Hopefully this will make it easier for developers to find the problem.

We could add a warning on the Livewire side too just before `Alpine.start()` is called with a more descriptive warning like check your `app.js` if we feel it is necessarly.