### PR TITLE
Fix fill modifier for radio buttons

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -168,14 +168,16 @@ function getInputValue(el, modifiers, event, currentValue) {
                 return option.value || option.text
             })
         } else {
+            const newValue = event.target.value
+
             if (modifiers.includes('number')) {
-                return safeParseNumber(event.target.value)
+                return safeParseNumber(newValue)
             } else if (modifiers.includes('boolean')) {
-                return safeParseBoolean(event.target.value)
+                return safeParseBoolean(newValue)
             } else if (modifiers.includes('trim')) {
-                return event.target.value.trim()
+                return newValue.trim()
             } else {
-                return event.target.value
+                return newValue
             }
         }
     })

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -172,9 +172,11 @@ function getInputValue(el, modifiers, event, currentValue) {
                 return safeParseNumber(event.target.value)
             } else if (modifiers.includes('boolean')) {
                 return safeParseBoolean(event.target.value)
+            } else if (modifiers.includes('trim')) {
+                return event.target.value.trim()
+            } else {
+                return event.target.value
             }
-
-            return modifiers.includes('trim') ? event.target.value.trim() : event.target.value
         }
     })
 }

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -168,7 +168,17 @@ function getInputValue(el, modifiers, event, currentValue) {
                 return option.value || option.text
             })
         } else {
-            const newValue = event.target.value
+            let newValue
+
+            if (el.type === 'radio') {
+                if (event.target.checked) {
+                    newValue = event.target.value
+                } else {
+                    newValue = currentValue
+                }
+            } else {
+                newValue = event.target.value
+            }
 
             if (modifiers.includes('number')) {
                 return safeParseNumber(newValue)

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -234,7 +234,7 @@ test('x-model with fill modifier takes input value on null, empty string or unde
     }
 )
 
-test('x-model with fill modifier works with select/radio elements',
+test('x-model with fill modifier works with select elements',
     html`
         <div x-data="{ a: null, b: null, c: null, d: null }">
             <select x-model.fill="a">
@@ -250,6 +250,35 @@ test('x-model with fill modifier works with select/radio elements',
     ({ get }) => {
         get('[x-data]').should(haveData('a', '456'));
         get('[x-data]').should(haveData('b', ['123', '456']));
+    }
+);
+
+test('x-model with fill modifier works with radio elements',
+    html`
+        <div x-data="{ a: null, b: null, c: '101112', d: null }">
+            <input x-model.fill="a" type="radio" value="123" />
+            <input x-model.fill="a" type="radio" value="456" checked />
+            <input x-model.fill="a" type="radio" value="789" />
+            <input x-model.fill="a" type="radio" value="101112" />
+            <input x-model.fill="a" type="radio" value="131415" />
+
+            <input x-model.fill="b" name="b" type="radio" value="123" />
+            <input x-model.fill="b" name="b" type="radio" value="456" />
+            <input x-model.fill="b" name="b" type="radio" value="789" checked />
+            <input x-model.fill="b" name="b" type="radio" value="101112" />
+            <input x-model.fill="b" name="b" type="radio" value="131415" />
+
+            <input x-model.fill="c" type="radio" value="123" />
+            <input x-model.fill="c" type="radio" value="456" />
+            <input x-model.fill="c" type="radio" value="789" />
+            <input x-model.fill="c" type="radio" value="101112" />
+            <input x-model.fill="c" type="radio" value="131415" />
+        </div>
+    `,
+    ({ get }) => {
+        get('[x-data]').should(haveData('a', '456'));
+        get('[x-data]').should(haveData('b', '789'));
+        get('[x-data]').should(haveData('c', '101112'));
     }
 );
 


### PR DESCRIPTION
This fixes filling model data based on which radio button is checked when the page loads. A very simple example can be found [here](https://codepen.io/willrowe/pen/BaEpRyJ) and this PR also includes a test.

In the Codepen, I expected that `type` in the Alpine data would be set to 'second' after page load and that the 'Second' radio button would be checked. However, `type` is set to 'first' and the 'First' radio button is checked instead.

I did a little bit of debugging and figured out that a `change` event is being triggered when the `.fill` modifier is present. Removing it from the first radio button (second example in the Codepen) makes it work as expected, but it should still work when the modifier is present by filling based on which radio button is currently checked.

The `getInputValue` function has been updated to take into account whether a radio button is checked, if not it will return the `currentValue`. I loosely based the changes on how checkboxes are handled.

I tested it with checkboxes (third example in the Codepen) and that appears to be working correctly.