### PR TITLE
Bug: Fixes x-model.fill when used with debounce

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -72,7 +72,9 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
     if (modifiers.includes('fill'))
         if ([undefined, null, ''].includes(getValue())
             || (el.type === 'checkbox' && Array.isArray(getValue()))) {
-            el.dispatchEvent(new Event(event, {}));
+        setValue(
+            getInputValue(el, modifiers, { target: el }, getValue())
+        );
     }
     // Register the listener removal callback on the element, so that
     // in addition to the cleanup function, x-modelable may call it.

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -282,3 +282,15 @@ test(
     }
 );
 
+test(
+    'x-model with fill and debounce still fills value',
+    html`
+        <div x-data="{ a: '' }">
+            <input type="text" x-model.fill.debounce="a" value="hello" />
+        </div>
+    `,
+    ({ get }) => {
+        get('[x-data]').should(haveData('a', 'hello'));
+    }
+);
+


### PR DESCRIPTION
Fixes #4102 

due to how debounce influenced the handling of the fill event, the model would clear out the input value before the event would be handled.

[demo here](https://awesomealpine.com/play/?coreplugins=0&tw=1&html=PGRpdgogIHgtZGF0YT0ieyB2YWx1ZTogbnVsbCwgb3RoZXI6ICcnIH0iCiAgY2xhc3M9ImZsZXggZmxleC1jb2wgZ2FwLTIgcC04Igo-CiAgPGlucHV0CiAgICB4LW1vZGVsLmZpbGw9InZhbHVlIgogICAgdmFsdWU9ImhlbGxvIgogICAgdHlwZT0idGV4dCIKICAvPgogIDxpbnB1dAogICAgeC1tb2RlbC5kZWJvdW5jZS5maWxsPSJvdGhlciIKICAgIHR5cGU9InRleHQiCiAgICB2YWx1ZT0id29ybGQiCiAgLz4KICA8c3BhbiB4LXRleHQ9ImAke3ZhbHVlfSwgJHtvdGhlcn1gIj48L3NwYW4-CjwvZGl2Pgo&script=Y29uc29sZS5sb2coJ0hpIGN1dGllJyk7Cg)

This instead just directly uses the same methods to update the value. These methods hadn't existed before, which is why the event was used before.

This isn't amazing, since it does not use any real Events, since it's impossible to make a real Event with a target value, and I was aiming for a minimal impact change.

Test is included.