### PR TITLE
Add missing border to fill example

### DIFF
--- a/packages/docs/src/en/directives/model.md
+++ b/packages/docs/src/en/directives/model.md
@@ -379,7 +379,7 @@ By default, if an input has a value attribute, it is ignored by Alpine and inste
 But if a bound property is empty, then you can use an input's value attribute to populate the property by adding the `.fill` modifier.
 
 <div x-data="{ message: null }">
-  <input x-model.fill="message" value="This is the default message.">
+  <input type="text" x-model.fill="message" value="This is the default message.">
 </div>
 
 <a name="programmatic access"></a>


### PR DESCRIPTION
Example input for `.fill` is missing a border:
![CleanShot 2024-03-20 at 15 28 47@2x](https://github.com/alpinejs/alpine/assets/4932/566461dd-e4ab-4342-9b65-ca4d75947141)

This PR adds the border and makes it look like throttle above.