### PR TITLE
Allow forcing `$id` to always generate a fresh id

### DIFF
--- a/packages/alpinejs/src/magics/$id.js
+++ b/packages/alpinejs/src/magics/$id.js
@@ -4,8 +4,7 @@ import { interceptClone } from '../clone'
 
 magic('id', (el, { cleanup }) => (name, key = null) => {
     let cacheKey = `${name}${key ? `-${key}` : ''}`
-
-    return cacheIdByNameOnElement(el, cacheKey, cleanup, () => {
+    const getId = () => {
         let root = closestIdRoot(el, name)
 
         let id = root
@@ -15,7 +14,9 @@ magic('id', (el, { cleanup }) => (name, key = null) => {
         return key
             ? `${name}-${id}-${key}`
             : `${name}-${id}`
-    })
+    }
+
+    return cacheIdByNameOnElement(el, cacheKey, cleanup, getId)
 })
 
 interceptClone((from, to) => {

--- a/packages/alpinejs/src/magics/$id.js
+++ b/packages/alpinejs/src/magics/$id.js
@@ -2,8 +2,7 @@ import { magic } from '../magics'
 import { closestIdRoot, findAndIncrementId } from '../ids'
 import { interceptClone } from '../clone'
 
-magic('id', (el, { cleanup }) => (name, key = null) => {
-    let cacheKey = `${name}${key ? `-${key}` : ''}`
+magic('id', (el, { cleanup }) => (name, key = null, cache = true) => {
     const getId = () => {
         let root = closestIdRoot(el, name)
 
@@ -16,7 +15,13 @@ magic('id', (el, { cleanup }) => (name, key = null) => {
             : `${name}-${id}`
     }
 
-    return cacheIdByNameOnElement(el, cacheKey, cleanup, getId)
+    if (cache) {
+        let cacheKey = `${name}${key ? `-${key}` : ''}`
+
+        return cacheIdByNameOnElement(el, cacheKey, cleanup, getId)
+    } else {
+        return getId()
+    }
 })
 
 interceptClone((from, to) => {

--- a/tests/cypress/integration/magics/$id.spec.js
+++ b/tests/cypress/integration/magics/$id.spec.js
@@ -26,6 +26,47 @@ test('$id generates a unique id',
     }
 )
 
+test('$id can be forced to generate unique ids',
+    html`
+        <div x-data="{ heading: 'initial' }" id="1">
+            <h1 x-text="heading"></h1>
+
+            <button x-on:click="heading += ', ' + $id('cached')"></button>
+        </div>
+
+        <div x-data="{ heading: 'initial' }" id="2">
+            <h1 x-text="heading"></h1>
+
+            <button x-on:click="heading += ', ' + $id('not-cached', null, false)"></button>
+        </div>
+
+        <div x-data="{ heading: 'initial' }" id="3">
+            <h1 x-text="heading"></h1>
+
+            <button x-on:click="heading += ', ' + $id('not-cached-with-key', 'key', false)"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('#1 h1').should(haveText('initial'))
+        get('#1 button').click()
+        get('#1 h1').should(haveText('initial, cached-1'))
+        get('#1 button').click()
+        get('#1 h1').should(haveText('initial, cached-1, cached-1'))
+
+        get('#2 h1').should(haveText('initial'))
+        get('#2 button').click()
+        get('#2 h1').should(haveText('initial, not-cached-1'))
+        get('#2 button').click()
+        get('#2 h1').should(haveText('initial, not-cached-1, not-cached-2'))
+
+        get('#3 h1').should(haveText('initial'))
+        get('#3 button').click()
+        get('#3 h1').should(haveText('initial, not-cached-with-key-1-key'))
+        get('#3 button').click()
+        get('#3 h1').should(haveText('initial, not-cached-with-key-1-key, not-cached-with-key-2-key'))
+    }
+)
+
 test('$id works with keys and nested data scopes',
     html`
         <div x-data x-id="['foo']" id="1">


### PR DESCRIPTION
A couple of months ago I made [this demo](https://codepen.io/willrowe/pen/VwgEpaB) after I got an idea of a way to use `$id` to make a quick and easy form with a dynamic number of fieldsets using the same template.

I used v3.13.3 at the time and it worked great! However, recently I needed this functionality on a real world project, so I pulled up the demo and copied over the concept, it didn't work. After some debugging I found that the `$id` call on the button click was no longer creating new ids each time it was clicked.

At first I thought this was a bug due to [this recent update in Alpine](https://github.com/alpinejs/alpine/pull/3919), but then I realized that I was actually relying on a bug in v3.13.3 that just happened to make the demo to work as I wanted. Conceptually, it makes perfect sense that a call to `$id` on the same element would always return the same value, that's exactly what it's for.

After realizing my mistake, I added the 'Altered Version' to the demo with a secondary variable in the `x-data` that tracks how many times the button has been clicked. While this works just fine, I was left feeling like it was a shame there wasn't a more simple way to just use `$id` to generate a fresh value each time and not have to rely on an extra counter variable with no other purpose. I tried a couple of different variations and landed on adding a third argument to `$id` to allow caching to simply be disabled for a specific call. `$id` will still function exactly the same unless `false` is explicitly passed as the third argument, denoting that a new value should be returned each time it is run.