### PR TITLE
Prevent unwanted persistence of 'undefined' in storage

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -73,5 +73,7 @@ function storageGet(key, storage) {
 }
 
 function storageSet(key, value, storage) {
+    if (value === undefined) value = null
+    
     storage.setItem(key, JSON.stringify(value))
 }


### PR DESCRIPTION
I noticed [an issue](https://github.com/filamentphp/filament/pull/12191) in Filament which caused Alpine to crash due to a component inadvertently setting `undefined` as a value with `$persist`. Whilst debugging I found a recent PR #4091, which attempts to prevent a similar issue when retrieving an `undefined` value from storage.

However it seems users can still unintentionally persist an `undefined` value, which confusingly [gets stringified to remain `undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description) before then [being saved as a string regardless](https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem#examples) by localStorage `setItem`.

This PR prevents committing `undefined` to storage by swapping it out with `null`, which is valid JSON and can therefore be stringified. Future checks with `storageHas` will return false (as expected), falling back to the initial value. It might be worth raising a warning but I'll take any feedback on this approach first. Thanks! 