### PR TITLE
Documentation issue: Event name in code snippet and description doesn't match in dispatch.md

### DIFF
--- a/packages/docs/src/en/magics/dispatch.md
+++ b/packages/docs/src/en/magics/dispatch.md
@@ -66,7 +66,7 @@ Notice that, because of [event bubbling](https://en.wikipedia.org/wiki/Event_bub
 </div>
 ```
 
-> The first example won't work because when `custom-event` is dispatched, it'll propagate to its common ancestor, the `div`, not its sibling, the `<span>`. The second example will work because the sibling is listening for `notify` at the `window` level, which the custom event will eventually bubble up to.
+> The first example won't work because when `notify` is dispatched, it'll propagate to its common ancestor, the `div`, not its sibling, the `<span>`. The second example will work because the sibling is listening for `notify` at the `window` level, which the custom event will eventually bubble up to.
 
 <a name="dispatching-to-components"></a>
 ## Dispatching to other components


### PR DESCRIPTION
In the documentation about dispatch there is a typo. The text says:

> The first example won't work because when **`custom-event`** is dispatched, it'll propagate to its common ancestor, the `div`, not its sibling, the `<span>`. The second example will work because the sibling is listening for `notify` at the `window` level, which the custom event will eventually bubble up to.

But the code snippet doesn't dispatch `custom-event`, it dispatches a `notify` event: `@click="$dispatch('notify')"`