### PR TITLE
Remove extra destroyTree call

### DIFF
--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -1,5 +1,3 @@
-import { destroyTree } from "./lifecycle"
-
 let onAttributeAddeds = []
 let onElRemoveds = []
 let onElAddeds = []
@@ -177,8 +175,6 @@ function onMutate(mutations) {
         if (addedNodes.has(node)) continue
 
         onElRemoveds.forEach(i => i(node))
-
-        destroyTree(node)
     }
 
     // Mutations are bundled together by the browser but sometimes


### PR DESCRIPTION
`destroyTree` is hooked into `mutation.js` by [lifecycle.js#L22](https://github.com/alpinejs/alpine/blob/main/packages/alpinejs/src/lifecycle.js#L22), and will be called [when an element is removed](https://github.com/alpinejs/alpine/blob/cd171328bffdfc805256d1ada84522898ef5b107/packages/alpinejs/src/mutation.js#L179).

If we [call it again](https://github.com/alpinejs/alpine/blob/cd171328bffdfc805256d1ada84522898ef5b107/packages/alpinejs/src/mutation.js#L181), then we call it twice.

This PR removes the extra call, and it also eliminates the dependency-cycle between `lifecycle.js` and `mutation.js`.