### PR TITLE
Fix x-on with both self and once

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -37,7 +37,6 @@ export default function on (el, event, modifiers, callback) {
 
     if (modifiers.includes('prevent')) handler = wrapHandler(handler, (next, e) => { e.preventDefault(); next(e) })
     if (modifiers.includes('stop')) handler = wrapHandler(handler, (next, e) => { e.stopPropagation(); next(e) })
-    if (modifiers.includes('self')) handler = wrapHandler(handler, (next, e) => { e.target === el && next(e) })
 
     if (modifiers.includes('away') || modifiers.includes('outside')) {
         listenerTarget = document
@@ -64,6 +63,8 @@ export default function on (el, event, modifiers, callback) {
             listenerTarget.removeEventListener(event, handler, options)
         })
     }
+
+    if (modifiers.includes('self')) handler = wrapHandler(handler, (next, e) => { e.target === el && next(e) })
 
     // Handle :keydown and :keyup listeners.
     handler = wrapHandler(handler, (next, e) => {

--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -38,6 +38,14 @@ export default function on (el, event, modifiers, callback) {
     if (modifiers.includes('prevent')) handler = wrapHandler(handler, (next, e) => { e.preventDefault(); next(e) })
     if (modifiers.includes('stop')) handler = wrapHandler(handler, (next, e) => { e.stopPropagation(); next(e) })
 
+    if (modifiers.includes("once")) {
+        handler = wrapHandler(handler, (next, e) => {
+            next(e);
+
+            listenerTarget.removeEventListener(event, handler, options);
+        });
+    }
+
     if (modifiers.includes('away') || modifiers.includes('outside')) {
         listenerTarget = document
 
@@ -53,14 +61,6 @@ export default function on (el, event, modifiers, callback) {
             if (el._x_isShown === false) return
 
             next(e)
-        })
-    }
-
-    if (modifiers.includes('once')) {
-        handler = wrapHandler(handler, (next, e) => {
-            next(e)
-
-            listenerTarget.removeEventListener(event, handler, options)
         })
     }
 

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -186,6 +186,27 @@ test('.self modifier',
     }
 )
 
+test(
+    ".self.once modifiers",
+    html`
+        <div x-data="{ foo: 'bar' }">
+            <h1 x-on:click.self.once="foo = 'baz'" id="selfTarget">
+                content
+                <button>click</button>
+                content
+            </h1>
+            <span x-text="foo"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get("span").should(haveText("bar"));
+        get("button").click();
+        get("span").should(haveText("bar"));
+        get("h1").click();
+        get("span").should(haveText("baz"));
+    }
+);
+
 test('.prevent modifier',
     html`
         <div x-data="{}">

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -513,6 +513,25 @@ test('@click.away',
     }
 )
 
+test('@click.away.once works after clicking inside',
+    html`
+        <div x-data="{ foo: 'bar' }">
+            <h1 @click.away.once="foo = 'baz'">h1</h1>
+
+            <h2>h2</h2>
+
+            <span x-text="foo"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('h1').click()
+        get('span').should(haveText('bar'))
+        get('h2').click()
+        get('span').should(haveText('baz'))
+    }
+)
+
 test('@click.away with x-show (prevent race condition)',
     html`
         <div x-data="{ show: false }">


### PR DESCRIPTION
I want to use the `once` and `self` modifiers together, like `@something.self.once`, but the handler never runs if the first event is not from self. I think the reason is that once is evaluated before self. 

This PR fixes the order of evaluating the modifiers so the two work together.

I think the failing test is unrelated.