### PR TITLE
:bug: Removes value attribute when bound value is null

### DIFF
--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -74,7 +74,7 @@ function bindInputValue(el, value) {
         updateSelect(el, value)
     } else {
         if (el.value === value) return
-
+        if (value === null) return el.removeAttribute('value')
         el.value = value === undefined ? '' : value
     }
 }


### PR DESCRIPTION
Better handles Progress elements #4153 

Not entirely positive if this is the best way to approach this, but it seems more likely to handle cases for other elements with `value` attributes than the main inputs, where `null` is unlikely to be a legitimate value anyway.

Passes all current tests (aside from the flaky ones that seem to change every run), will add new test for this specific case soon.