### PR TITLE
Add missing plugin warnings

### DIFF
--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -30,6 +30,10 @@ export function directive(name, callback) {
     }
 }
 
+export function directiveExists(name) {
+    return Object.keys(directiveHandlers).includes(name)
+}
+
 export function directives(el, attributes, originalAttributeOverride) {
     attributes = Array.from(attributes)
 


### PR DESCRIPTION
A common issue is encountered where someone tries to use a plugin, receives a mysterious error, and fails to realize that the Plugin wasn't included on the page in the first place.

This happens most often with the headless UI plugin as well as the anchor plugin (because these plugins aren't bundled with Livewire).

For now, we're only warning about the ones not bundled with Livewire because this addition disproportionately increases the core bundle size because of the string literals.

We can add more as needed/requested. 

![CleanShot 2024-04-18 at 15 07 31@2x](https://github.com/alpinejs/alpine/assets/3670578/57792c1a-7ebd-4a59-ac72-70b27056bf5b)
