### PR TITLE
Fix morphing root level state

### DIFF
--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -49,7 +49,7 @@ directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
     mutateDom(() => {
         placeInDom(clone, target, modifiers)
 
-        initTree(clone)
+        skipDuringClone(() => initTree(clone))()
 
         clone._x_ignore = true
     })

--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -49,9 +49,11 @@ directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
     mutateDom(() => {
         placeInDom(clone, target, modifiers)
 
-        skipDuringClone(() => initTree(clone))()
+        skipDuringClone(() => {
+            initTree(clone)
 
-        clone._x_ignore = true
+            clone._x_ignore = true
+        })()
     })
 
     el._x_teleportPutBack = () => {

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -353,7 +353,7 @@ export function morph(from, toHtml, options) {
     toEl = typeof toHtml === 'string' ? createElement(toHtml) : toHtml
 
     if (window.Alpine && window.Alpine.closestDataStack && ! from._x_dataStack) {
-        // Just in case a part of this {template} uses Alpine scope from somewhere
+        // Just in case a part of this template uses Alpine scope from somewhere
         // higher in the DOM tree, we'll find that state and replace it on the root
         // element so everything is synced up accurately.
         toEl._x_dataStack = window.Alpine.closestDataStack(from)

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -40,6 +40,10 @@ export function morph(from, toHtml, options) {
         // Initialize the server-side HTML element with Alpine...
         if (from.nodeType === 1 && window.Alpine) {
             window.Alpine.cloneNode(from, to)
+
+            if (from._x_teleport && to._x_teleport) {
+                patch(from._x_teleport, to._x_teleport)
+            }
         }
 
         if (textOrComment(to)) {
@@ -120,11 +124,6 @@ export function morph(from, toHtml, options) {
     }
 
     function patchChildren(from, to) {
-        // If we hit a <template x-teleport="body">,
-        // let's use the teleported nodes for this patch...
-        if (from._x_teleport) from = from._x_teleport
-        if (to._x_teleport) to = to._x_teleport
-
         let fromKeys = keyToMap(from.children)
         let fromKeyHoldovers = {}
 
@@ -354,7 +353,7 @@ export function morph(from, toHtml, options) {
     toEl = typeof toHtml === 'string' ? createElement(toHtml) : toHtml
 
     if (window.Alpine && window.Alpine.closestDataStack && ! from._x_dataStack) {
-        // Just in case a part of this template uses Alpine scope from somewhere
+        // Just in case a part of this {template} uses Alpine scope from somewhere
         // higher in the DOM tree, we'll find that state and replace it on the root
         // element so everything is synced up accurately.
         toEl._x_dataStack = window.Alpine.closestDataStack(from)

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -134,6 +134,51 @@ test('can morph teleports',
     },
 )
 
+test('can morph teleports in different places with IDs',
+    [html`
+        <div x-data="{ count: 1 }" id="a">
+            <button @click="count++">Inc</button>
+
+            <template x-teleport="#b" id="template">
+                <div>
+                    <h1 x-text="count"></h1>
+                    <h2>hey</h2>
+                </div>
+            </template>
+
+            <div>moving placeholder</div>
+        </div>
+
+        <div id="b"></div>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+        <div x-data="{ count: 1 }" id="a">
+            <button @click="count++">Inc</button>
+
+            <div>moving placeholder</div>
+
+            <template x-teleport="#b" id="template">
+                <div>
+                    <h1 x-text="count"></h1>
+                    <h2>there</h2>
+                </div>
+            </template>
+        </div>
+        `
+        get('h1').should(haveText('1'))
+        get('h2').should(haveText('hey'))
+        get('button').click()
+        get('h1').should(haveText('2'))
+        get('h2').should(haveText('hey'))
+
+        get('div#a').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('h1').should(haveText('2'))
+        get('h2').should(haveText('there'))
+    },
+)
+
 test('can morph',
     [html`
         <ul>
@@ -576,5 +621,34 @@ test('can morph teleports with x-for',
         get('button').should(haveText('2'));
         get('button').click()
         get('button').should(haveText('3'));
+    },
+)
+
+test('can morph teleports with root-level state',
+    [html`
+    <main x-data>
+        <template x-teleport="body">
+            <div x-data="{ foo: 'bar' }">
+                <h1 x-text="foo"></h1>
+            </div>
+        </template>
+    </main>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+        <main x-data>
+            <template x-teleport="body">
+                <div x-data="{ foo: 'bar' }">
+                    <h1 x-text="foo"></h1>
+                </div>
+            </template>
+        </main>
+        `
+
+        get('h1').should(haveText('bar'));
+
+        get('main').then(([el]) => window.Alpine.morph(el, toHtml));
+
+        get('h1').should(haveText('bar'));
     },
 )

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -537,3 +537,44 @@ test('can morph menu',
         get('input').should(haveValue('foo'))
     },
 )
+
+test('can morph teleports with x-for',
+    [html`
+    <main x-data>
+        <template x-teleport="body">
+            <article>
+                <template x-for="item in 3" :key="item">
+                    <span x-text="item"></span>
+                </template>
+            </article>
+        </template>
+
+        <button x-data="{ count: 1 }" x-text="count" x-on:click="count++" type="button"></button>
+    </main>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = html`
+        <main x-data>
+            <template x-teleport="body">
+                <article>
+                    <template x-for="item in 3" :key="item">
+                        <span x-text="item"></span>
+                    </template>
+                </article>
+            </template>
+
+            <button x-data="{ count: 1 }" x-text="count" x-on:click="count++" type="button"></button>
+        </main>
+        `
+
+        get('button').should(haveText('1'));
+        get('button').click()
+        get('button').should(haveText('2'));
+
+        get('main').then(([el]) => window.Alpine.morph(el, toHtml));
+
+        get('button').should(haveText('2'));
+        get('button').click()
+        get('button').should(haveText('3'));
+    },
+)


### PR DESCRIPTION
## The Problem
The following HTML, when morphed to itself (like in the case of a Livewire component refreshing), will throw an error:

```html
<div>
    <template x-teleport="body">
        <div x-data="{ foo: false }">
            <div x-text="'foo value: ' + foo"></div>
        </div>
    </template>
</div>
```

The error: `Uncaught ReferenceError: foo is not defined`

Interestingly, the problem does NOT occur when wrapping the `x-data` element in a plain `<div>` like so:

```html
<div>
    <template x-teleport="body">
        <div>
            <div x-data="{ foo: false }">
                <div x-text="'foo value: ' + foo"></div>
            </div>
        </div>
    </template>
</div>
```

## The explanation

Clearly during the morph/clone phase, the live tree's `x-data` data is not being brought over to the reference `<div>` during clone.

Alpine's morph algorithm will walk both the live and reference tree, element by element. As it walks, it will "clone" (initialize) the reference element based on information from the live tree (such as existing `x-data` state), then compare the two, and make any "mutations" to the live tree it needs.

So, in a normal, non-teleport scenario, when `<div x-data>` is encountered in the tree walk, Alpine will recognize live "state" in the live tree and graft it onto the reference tree before initializing the reference element (cloning).

However, for some reason Alpine isn't carrying over the "live" state from the live tree to the reference tree when `x-data` is the first child of `x-teleport`.

Here's the reason this is happening:

As Alpine walks both trees during morph, when it encounters an element using `x-teleport`, it will internally do it's own "teleport" in the DOM from the `<template>` element to the live, teleported element.

To understand the problem, you have to understand two key processes in "morph": `patch` and `patchChildren`

**`patch(from, to)` operation**
* Compare nodes for "swapping" (early return if so)
* Clone "to" (reference) node based on "from" (live) node
* Run `patchChildren(from, to)` (recursively patch each child)

**`patchChildren(from, to)` operation**
* Check the "from" and "to" for "teleports" and gather an array of the teleported element children, instead of the `<template>` tag's children.
* Go through the two arrays of children, compare and `patch()`, remove, and add elements

As you can see from above, the combination of `patch()` and `patchChildren`, is how morph crawls a both DOM trees in parallel.

The problem is that the `teleported` elements are substituted until AFTER the `<template>` elements are cloned. This means that the `<div x-data>` elements never have an opportunity to be "cloned", and the state is never grafted over, resulting in state-based scope errors downstream.

## The solution

### Solution A: Re-clone template targets
We could call "clone" once more inside `patchChilren()` when the "from" and "to" are about to be substituted with their actual teleported elements.

**Pros:**
* Simple
* Non-invasive

**Cons:**
* Not "pure" or "deep"
    * Like if the root element changes it won't be "swapped" and the lifecycle hook won't run

### Solution B: Re-run `patch()` on targets
From inside `patchChildren()`, we could pass the template target elements back through `patch()` and return early.

**Pros:**
* Comprehensive, deep

**Cons:**
* Potentially too invasive?
* Might cause other unintended issues

### Solution C: Swap teleport targets earlier
We could also move the conditional for swapping teleport targets earlier in the process (out of `patch()` and into `patchChildren`).

**Pros**
* Comprehensive, deep

**Cons**
* We then need to decide which operations apply to the `<template>` element and which apply to the `<div>` elements (swapping, cloning, lifecycle hooks, etc...)
* We also need both `<template>` AND `<div>`to be cloned so there would need to be duplication somewhere

### Solution D: Just graft state
Instead of full on "patching" the teleport targets, we could just move state if it exists over to the "to" tree.

**Pros:**
* Super simple

**Cons:**
* "diffing" wouldn't work on the root element of a template teleport element

---

Based on the above, I think solution "B" is worth trying, as it's the most comprehensive. It is also the scariest to me (risk of causing other complicated bugs), but we should at least try it.