### PR TITLE
Add minified ESM distribution for browsers

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -55,8 +55,8 @@ function bundleFile(package, file) {
             })
 
         },
-        // This file outputs two files: an esm module and a cjs module.
-        // The ESM one is meant for "import" statements (bundlers and new browsers)
+        // This file outputs three files: an esm module (+ a minified version) and a cjs module.
+        // The ESM ones are meant for "import" statements (bundlers and new browsers)
         // and the cjs one is meant for "require" statements (node).
         'module.js': () => {
             build({
@@ -65,6 +65,18 @@ function bundleFile(package, file) {
                 bundle: true,
                 platform: 'neutral',
                 mainFields: ['module', 'main'],
+            })
+
+            // Build a minified version.
+            build({
+                entryPoints: [`packages/${package}/builds/${file}`],
+                outfile: `packages/${package}/dist/${file.replace('.js', '.esm.min.js')}`,
+                bundle: true,
+                minify: true,
+                platform: 'neutral',
+                mainFields: ['module', 'main'],
+            }).then(() => {
+                outputSize(package, `packages/${package}/dist/${file.replace('.js', '.esm.min.js')}`)
             })
 
             build({


### PR DESCRIPTION
Adds a minified version of the ESM distribution that can be included directly in browsers. See #4181 for a background on this topic.