### PR TITLE
Allow debouncing/throttling x-model when using x-modelable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7866,7 +7866,7 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7874,17 +7874,17 @@
         },
         "packages/anchor": {
             "name": "@alpinejs/anchor",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/collapse": {
             "name": "@alpinejs/collapse",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/csp": {
             "name": "@alpinejs/csp",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7892,12 +7892,12 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.13.8-revision.1",
+            "version": "3.13.10-revision.2",
             "license": "MIT"
         },
         "packages/focus": {
             "name": "@alpinejs/focus",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.9.4",
@@ -7914,17 +7914,17 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/mask": {
             "name": "@alpinejs/mask",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/morph": {
             "name": "@alpinejs/morph",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/navigate": {
@@ -7937,17 +7937,17 @@
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/sort": {
             "name": "@alpinejs/sort",
-            "version": "3.13.8",
+            "version": "3.13.10",
             "license": "MIT"
         },
         "packages/ui": {
             "name": "@alpinejs/ui",
-            "version": "3.13.8-beta.0",
+            "version": "3.13.10-beta.0",
             "license": "MIT",
             "devDependencies": {}
         }

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -120,10 +120,10 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
     // Allow programmatic overriding of x-model.
     el._x_model = {
         get() {
-            return getValue();
+            return getValue()
         },
         set(value) {
-            setValue(value);
+            setValue(value)
         },
 
         setWithModifiers: setWithModifiers,

--- a/packages/alpinejs/src/directives/x-modelable.js
+++ b/packages/alpinejs/src/directives/x-modelable.js
@@ -21,7 +21,7 @@ directive('modelable', (el, { expression }, { effect, evaluateLater, cleanup }) 
         el._x_removeModelListeners['default']()
 
         let outerGet = el._x_model.get
-        let outerSet = el._x_model.set
+        let outerSet = el._x_model.setWithModifiers
 
         let releaseEntanglement = entangle(
             {

--- a/tests/cypress/integration/directives/x-modelable.spec.js
+++ b/tests/cypress/integration/directives/x-modelable.spec.js
@@ -68,3 +68,52 @@ test('x-modelable removes the event listener used by corresponding x-model',
         get('h2').should(haveText('foo'))
     }
 )
+
+
+test('x-modelable works with .debounce modifier',
+    html`
+        <div x-data="{ outer: 'foo' }">
+            <div x-data="{ inner: 'bar' }" x-modelable="inner" x-model.debounce="outer">
+                <h1 x-text="outer"></h1>
+                <h2 x-text="inner"></h2>
+
+                <button @click="inner = 'bob'" id="1">change inner</button>
+                <button @click="inner = 'lob'" id="2">change inner</button>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('h1').should(haveText('foo'))
+        get('h2').should(haveText('foo'))
+        get('#1').click()
+        get('h1').should(haveText('bob'))
+        get('h2').should(haveText('bob'))
+        get('#2').click()
+        get('h1').should(haveText('bob'))
+        get('h2').should(haveText('lob'))
+    }
+)
+
+test('x-modelable works with .throttle modifier',
+    html`
+        <div x-data="{ outer: 'foo' }">
+            <div x-data="{ inner: 'bar' }" x-modelable="inner" x-model.throttle="outer">
+                <h1 x-text="outer"></h1>
+                <h2 x-text="inner"></h2>
+
+                <button @click="inner = 'bob'" id="1">change inner</button>
+                <button @click="inner = 'lob'" id="2">change inner</button>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('h1').should(haveText('foo'))
+        get('h2').should(haveText('foo'))
+        get('#1').click()
+        get('h1').should(haveText('bob'))
+        get('h2').should(haveText('bob'))
+        get('#2').click()
+        get('h1').should(haveText('bob'))
+        get('h2').should(haveText('lob'))
+    }
+)


### PR DESCRIPTION
Solves
#2812 

# Problem

When using `x-model.debounce` with x-modelable the outer values will not be debounced. I belive this to be a bug as the documentation says the following about x-modelable:

> It's useful for abstracting away Alpine components into backend templates and exposing state to the outside through `x-model` as if it were a native input.

# Solution

I have not modified the `el._x_model.set` function as you would expect this to ignore the throttle/debounce (the same way it does for normal `x-models`). Instead I have added an extra method (`setWithModifiers`) which respects debounce and throttle modifiers. I have then changed the outerSet of x-modelable to use `setWithModifiers` (still allowing the inner value to update live).

# Tests
I have included one test for debounce and throttle respectively (as they are implemented slightly seperate from each other, I thought this reasonable).