### PR TITLE
Add 'panelWithoutClose' to Dialogs

### DIFF
--- a/packages/ui/src/dialog.js
+++ b/packages/ui/src/dialog.js
@@ -3,6 +3,7 @@ export default function (Alpine) {
     Alpine.directive('dialog', (el, directive) => {
         if      (directive.value === 'overlay')     handleOverlay(el, Alpine)
         else if (directive.value === 'panel')       handlePanel(el, Alpine)
+        else if (directive.value === 'panelWithoutClose') handlePanelWithoutClose(el, Alpine)
         else if (directive.value === 'title')       handleTitle(el, Alpine)
         else if (directive.value === 'description') handleDescription(el, Alpine)
         else                                        handleRoot(el, Alpine)
@@ -77,6 +78,12 @@ function handleOverlay(el, Alpine) {
 function handlePanel(el, Alpine) {
     Alpine.bind(el, {
         '@click.outside'() { this.$data.__close() },
+        'x-show'() { return this.$data.__isOpen },
+    })
+}
+
+function handlePanelWithoutClose(el, Alpine) {
+    Alpine.bind(el, {
         'x-show'() { return this.$data.__isOpen },
     })
 }


### PR DESCRIPTION
The hope here is to keep a dialog/modal open when clicking outside of the panel. 

Not a default or breaking change, just another option.

I added an additional directive of panelWithoutClose, cloned the handlePanel function, and removed the @click.outside line from it.  

