### PR TITLE
Higher visibility in docs about needing x-data for things to work

### DIFF
--- a/packages/docs/src/en/essentials/installation.md
+++ b/packages/docs/src/en/essentials/installation.md
@@ -38,6 +38,8 @@ Notice the `@3.x.x` in the provided CDN link. This will pull the latest version 
 
 That's it! Alpine is now available for use inside your page.
 
+Note that you will still need to define a component with `x-data` in order for any Alpine.js attributes to work. See <https://github.com/alpinejs/alpine/discussions/3805> for more information.
+
 <a name="as-a-module"></a>
 ## As a module
 


### PR DESCRIPTION
The fact that `x-data` is needed in order to enable any Alpine.js behavior is pretty hidden in the docs. It'd be nice to make it more visible via the getting started guide.