### PR TITLE
Magics: Introduce new `$mixin` magic helper

### DIFF
--- a/packages/alpinejs/src/magics/$mixin.js
+++ b/packages/alpinejs/src/magics/$mixin.js
@@ -3,11 +3,14 @@ import { magic } from "../magics";
 magic('mixin', () => (...datas) => {
     let inits = []
     let destroys = []
+    const mixed = {}
 
-    const mixed = datas.reduce((acc, data) => {
+    for (let data of datas) {
         if (typeof data === 'function') {
             data = data()
         }
+
+        if (typeof data !== 'object') continue
 
         if (typeof data.init === 'function') {
             inits.push(data.init)
@@ -17,20 +20,15 @@ magic('mixin', () => (...datas) => {
             destroys.push(data.destroy)
         }
 
-        if (typeof data === 'object') {
-            return { ...acc, ...data }
-        }
+        Object.defineProperties(mixed, Object.getOwnPropertyDescriptors(data));
+    }
 
-        return acc
-    }, {})
-
-    return {
-        ...mixed,
+    return Object.defineProperties(mixed, Object.getOwnPropertyDescriptors({
         init() {
-            inits.forEach(init => init.call(this))
+            inits.forEach((init) => init.call(this));
         },
         destroy() {
-            destroys.forEach(destroy => destroy.call(this))
-        }
-    }
+            destroys.forEach((destroy) => destroy.call(this));
+        },
+    }));
 })

--- a/packages/alpinejs/src/magics/$mixin.js
+++ b/packages/alpinejs/src/magics/$mixin.js
@@ -1,0 +1,36 @@
+import { magic } from "../magics";
+
+magic('mixin', () => (...datas) => {
+    let inits = []
+    let destroys = []
+
+    const mixed = datas.reduce((acc, data) => {
+        if (typeof data === 'function') {
+            data = data()
+        }
+
+        if (typeof data.init === 'function') {
+            inits.push(data.init)
+        }
+
+        if (typeof data.destroy === 'function') {
+            destroys.push(data.destroy)
+        }
+
+        if (typeof data === 'object') {
+            return { ...acc, ...data }
+        }
+
+        return acc
+    }, {})
+
+    return {
+        ...mixed,
+        init() {
+            inits.forEach(init => init.call(this))
+        },
+        destroy() {
+            destroys.forEach(destroy => destroy.call(this))
+        }
+    }
+})

--- a/packages/alpinejs/src/magics/index.js
+++ b/packages/alpinejs/src/magics/index.js
@@ -10,6 +10,7 @@ import './$root'
 import './$refs'
 import './$id'
 import './$el'
+import './$mixin'
 
 // Register warnings for people using plugin syntaxes and not loading the plugin itself:
 warnMissingPluginMagic('Focus', 'focus', 'focus')

--- a/tests/cypress/integration/magics/$mixin.spec.js
+++ b/tests/cypress/integration/magics/$mixin.spec.js
@@ -110,3 +110,40 @@ test(
         get("#2").should(haveText("bar"));
     }
 );
+
+test(
+    '$mixin maintains getters and setters',
+    html`
+        <div x-data="$mixin(
+            {
+                _foo: 'bar',
+                get foo() {
+                    return this._foo + '!'
+                },
+                set foo(value) {
+                    this._foo = value
+                }
+            },
+            {
+                _baz: 'qux',
+                get baz() {
+                    return this._baz + '!'
+                },
+                set baz(value) {
+                    this._baz = value
+                }
+            }
+        )">
+            <button id="1" x-on:click="foo = 'BAR'"></button>
+            <span id="2" x-text="foo"></span>
+            <button id="3" x-on:click="baz = 'QUX'"></button>
+            <span id="4" x-text="baz"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#1').click()
+        get('#2').should(haveText('BAR!'))
+        get('#3').click()
+        get('#4').should(haveText('QUX!'))
+    },
+)

--- a/tests/cypress/integration/magics/$mixin.spec.js
+++ b/tests/cypress/integration/magics/$mixin.spec.js
@@ -1,0 +1,112 @@
+import { haveText, html, test } from "../../utils";
+
+test(
+    '$mixin merges multiple data objects',
+    html`
+        <div
+            x-data="$mixin(
+                {
+                    foo: 'bar',
+                },
+                {
+                    baz: 'qux',
+                }
+            )"
+        >
+            <span id="1" x-text="foo"></span>
+            <span id="2" x-text="baz"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#1').should(haveText('bar'))
+        get('#2').should(haveText('qux'))
+    },
+)
+
+test(
+    '$mixin merges plain objects with data providers',
+    html`
+        <script>
+            document.addEventListener("alpine:init", () => {
+                Alpine.data("test", () => ({
+                    foo: "bar",
+                }));
+            });
+        </script>
+
+        <div
+            x-data="$mixin(
+                test,
+                {
+                    baz: 'qux',
+                }
+            )"
+        >
+            <span id="1" x-text="foo"></span>
+            <span id="2" x-text="baz"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#1').should(haveText('bar'))
+        get('#2').should(haveText('qux'))
+    },
+);
+
+test(
+    '$mixin merges init functions',
+    html`
+        <div
+            x-data="$mixin(
+                {
+                    foo: '',
+                    init() {
+                        this.foo = 'bar'
+                    }
+                },
+                {
+                    baz: '',
+                    init() {
+                        this.baz = 'qux'
+                    }
+                }
+            )"
+        >
+            <span id="1" x-text="foo"></span>
+            <span id="2" x-text="baz"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#1').should(haveText('bar'))
+        get('#2').should(haveText('qux'))
+    },
+)
+
+test(
+    "$mixin merges destroy functions",
+    html`
+        <div
+            x-data="$mixin(
+                {
+                    destroy() {
+                        document.getElementById('1').textContent = 'foo';
+                    },
+                },
+                {
+                    destroy() {
+                        document.getElementById('2').textContent = 'bar';
+                    },
+                }
+            )"
+        >
+            <button x-on:click="$root.remove()"></button>
+        </div>
+
+        <span id="1"></span>
+        <span id="2"></span>
+    `,
+    ({ get }) => {
+        get("button").click();
+        get("#1").should(haveText("foo"));
+        get("#2").should(haveText("bar"));
+    }
+);


### PR DESCRIPTION
This pull request introduces a new `$mixin` magic helper that aims to make components more easily composable.

At the minute, if you want to use multiple data providers for a component, you have to do something like this:

```html
<div x-data="{
    ...foo(),
    ...bar(),
}">
```

This doesn't feel very nice – plus it has some downsides such as `init()` and `destroy()` functions being overwritten by the final item in the spread.

The goals of the `$mixin` helper are:
1. Make the API feel a little nicer to write.
2. Handle the `init()` and `destroy()` functions correctly.

The above code would become something like this:

```html
<div x-data="$mixin(foo, bar)">
</div>
```

If both `foo()` and `bar()` have an `init()`, `$mixin()` is smart enough to call both of those functions in the correct order (whichever order they're being mixed in). The same goes for `destroy()` methods.

Of course, conflicting properties in each function are still an issue but that's not really avoidable without some weird object nesting stuff and I'd say that's not very intuitive.

Either way, I think this is a nice API for core and something I'd find myself using a lot, especially given the nicer syntax!

Let me know what you think 🤞 