### PR TITLE
collapse: remove overflow hidden even if height does not match perfect

### DIFF
--- a/packages/collapse/src/index.js
+++ b/packages/collapse/src/index.js
@@ -56,7 +56,7 @@ export default function (Alpine) {
                     start: { height: current+'px' },
                     end: { height: full+'px' },
                 }, () => el._x_isShown = true, () => {
-                    if (el.getBoundingClientRect().height == full) {
+                    if (Math.abs(el.getBoundingClientRect().height - full) < 1) {
                         el.style.overflow = null
                     }
                 })


### PR DESCRIPTION
Sometimes it happens, that the `overflow: hidden` style remains on the element after it has expanded.

The reason is, that there is a condition checking that the element height as reached the full height, but sometimes the values do not match perfectly. For example, `full` is `100.5` but `el.getBoundingClientRect().height` returns `100.4765625`.

This PR changes the condition to allow a difference up to 1px.

To be honest, I am not sure, if the condition is necessary at all.