### PR TITLE
Fix error: TypeError: i is not a function

### DIFF
--- a/packages/alpinejs/src/directives/x-transition.js
+++ b/packages/alpinejs/src/directives/x-transition.js
@@ -173,7 +173,7 @@ window.Element.prototype._x_toggleAndCascadeWithTransitions = function (el, valu
                     let carry = Promise.all([
                         el._x_hidePromise,
                         ...(el._x_hideChildren || []).map(hideAfterChildren),
-                    ]).then(([i]) => i && i())
+                    ]).then(([i]) => i?.())
 
                     delete el._x_hidePromise
                     delete el._x_hideChildren

--- a/packages/alpinejs/src/directives/x-transition.js
+++ b/packages/alpinejs/src/directives/x-transition.js
@@ -173,7 +173,7 @@ window.Element.prototype._x_toggleAndCascadeWithTransitions = function (el, valu
                     let carry = Promise.all([
                         el._x_hidePromise,
                         ...(el._x_hideChildren || []).map(hideAfterChildren),
-                    ]).then(([i]) => i())
+                    ]).then(([i]) => i && i())
 
                     delete el._x_hidePromise
                     delete el._x_hideChildren


### PR DESCRIPTION
There is a race condition in Alpine when using `x-transition` and `x-show`. It's tricky to reproduce. The code change here removes the JavaScript error: `Uncaught (in promise) TypeError: i is not a function`.

Normally, `el._x_hidePromise` is a Promise, so calling this is fine. However, when this code runs more than once in quick succession, one copy works just fine, and the next copy passes an `undefined` into the `Promise.all()`, so the `.then()` gets an `undefined`, which it then attempts to call as a function, resulting in the error reported.

The scenario that I've been looking into is a drop-down menu layout where putting my mouse over a top-level element reveals a sub menu. When I move my pointer over these top-level elements slowly, all is well. When I move my pointer over these top-level elements quickly, all is well. When I move my pointer back-and-forth over these top-level elements quickly, I can trigger this bug.

With the code changes in this pull request applied, I am no longer able to reproduce the bug with these same steps. As far as I can tell, this fixes https://github.com/alpinejs/alpine/discussions/1672 and fixes https://github.com/alpinejs/alpine/discussions/3832#discussioncomment-7413593.