### PR TITLE
Update transition.md - changed span to div

### DIFF
--- a/packages/docs/src/en/directives/transition.md
+++ b/packages/docs/src/en/directives/transition.md
@@ -21,9 +21,9 @@ The simplest way to achieve a transition using Alpine is by adding `x-transition
 <div x-data="{ open: false }">
     <button @click="open = ! open">Toggle</button>
 
-    <span x-show="open" x-transition>
+    <div x-show="open" x-transition>
         Hello 👋
-    </span>
+    </div>
 </div>
 ```
 
@@ -32,9 +32,9 @@ The simplest way to achieve a transition using Alpine is by adding `x-transition
     <div x-data="{ open: false }">
         <button @click="open = ! open">Toggle</button>
 
-        <span x-show="open" x-transition>
+        <div x-show="open" x-transition>
             Hello 👋
-        </span>
+        </div>
     </div>
 </div>
 <!-- END_VERBATIM -->


### PR DESCRIPTION
With a span, the transition effect is not obvious because the element doesn't move so the documentation looks broken.

I confirmed this in MacOS for Firefox, Chrome, and Safari.