### PR TITLE
[UI][Tabs] Prevent tab focus on mousedown

### DIFF
--- a/packages/ui/src/tabs.js
+++ b/packages/ui/src/tabs.js
@@ -105,6 +105,11 @@ function handleTab(el, Alpine) {
         '@keydown.up.prevent.stop'() { this.$focus.within(this.$data.__activeTabs()).withWrapAround().prev() },
         '@keydown.left.prevent.stop'() { this.$focus.within(this.$data.__activeTabs()).withWrapAround().prev() },
         ':tabindex'() { return this.$tab.isSelected ? 0 : -1 },
+        // This is important because we want to only focus the tab when it gets focus
+        // OR it finished the click event (mouseup). However, if you perform a `click`,
+        // then you will first get the `focus` and then get the `click` event.
+        // See https://github.com/tailwindlabs/headlessui/pull/1192
+        '@mousedown'(event) { event.preventDefault() },
         '@focus'() {
             if (this.$data.__manualActivation) {
                 this.$el.focus()


### PR DESCRIPTION
Currently a tab gets the focus when you receive the mousedown event instead of the full click.
This is different from how tabs usually work everywhere else (including Tailwind Headless UI that fixed it with this PR: https://github.com/tailwindlabs/headlessui/pull/1192).

Unfortunately, it's not easily testable because cypress doesn't behave that way but chrome and firefox do.

This seem to cause some interoperability issues with x-dialog too: https://github.com/alpinejs/alpine/discussions/4230#discussioncomment-9532452 (The OP didn't provide an example though).