### PR TITLE
Fix bug in X-Mask where user input that matched the non wildcard value were being stripped

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -137,7 +137,7 @@ export function stripDown(template, input) {
         }
 
         for (let j = 0; j < inputToBeStripped.length; j++) {
-            if (inputToBeStripped[j] === template[i]) {
+            if (inputToBeStripped[j] === template[i] && template[i] !== inputToBeStripped[i]) {
                 inputToBeStripped = inputToBeStripped.slice(0, j) + inputToBeStripped.slice(j+1)
 
                 break;

--- a/tests/jest/mask.spec.js
+++ b/tests/jest/mask.spec.js
@@ -11,6 +11,8 @@ test('strip-down functionality', async () => {
     expect(stripDown('(999) 999-9999', '716 2256108')).toEqual('7162256108')
     expect(stripDown('(999) 999-9999', '(716) 2256108')).toEqual('7162256108')
     expect(stripDown('(999) 999-9999', '(716) 2-25--6108')).toEqual('7162256108')
+    expect(stripDown('+1 (999) 999-9999', '7162256108')).toEqual('7162256108')
+    expect(stripDown('ABC (999) 999-9999', '7162256108')).toEqual('7162256108')
 })
 
 test('formatMoney functionality', async () => {


### PR DESCRIPTION
Closes https://github.com/alpinejs/alpine/discussions/4252

Found where a non wildcard value matched the user input the value was being stripped, I added an additional check before stripping and added a couple test cases to the jest tests.


