### PR TITLE
:bug: Fixes issue with setters accessing deeply nested data

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -72,7 +72,8 @@ let mergeProxyTrap = {
             ) || objects[objects.length - 1];
         const descriptor = Object.getOwnPropertyDescriptor(target, name);
         if (descriptor?.set && descriptor?.get)
-            return Reflect.set(target, name, value, thisProxy);
+            // Can't use Reflect.set here due to [upstream bug](https://github.com/vuejs/core/blob/31abdc8adad569d83b476c340e678c4daa901545/packages/reactivity/src/baseHandlers.ts#L148) in @vue/reactivity
+            return descriptor.set.call(thisProxy, value) || true;
         return Reflect.set(target, name, value);
     },
 }

--- a/tests/cypress/integration/scope.spec.js
+++ b/tests/cypress/integration/scope.spec.js
@@ -109,3 +109,51 @@ test(
         get("button").should(haveText("clicked"));
     }
 );
+
+test(
+    "properly merges the datastack with nested data",
+    [
+        html`
+            <div x-data="{ foo: { bar: 'fizz' } }">
+                <div x-data="{ bar: 'buzz' }">
+                    <span
+                        id="1"
+                        x-text="foo.bar + bar"
+                        @click="foo.bar = foo.bar + bar"
+                    ></span>
+                </div>
+                <span id="2" x-text="foo.bar"></span>
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("span#1").should(haveText("fizzbuzz"));
+        get("span#2").should(haveText("fizz"));
+        get("span#1").click();
+        get("span#1").should(haveText("fizzbuzzbuzz"));
+        get("span#2").should(haveText("fizzbuzz"));
+    }
+);
+
+test(
+    "handles getter setter pairs of object",
+    [
+        html`
+            <div x-data="{ foo:  { bar: 'fizzbuzz' } }">
+                <div
+                    x-data="{ get bar() { return this.foo.bar }, set bar(value) { this.foo.bar = value } }"
+                >
+                    <span id="one" x-text="bar" @click="bar = 'foobar'"></span>
+                </div>
+                <span id="two" x-text="foo.bar"></span>
+            </div>
+        `,
+    ],
+    ({ get }) => {
+        get("span#one").should(haveText("fizzbuzz"));
+        get("span#two").should(haveText("fizzbuzz"));
+        get("span#one").click();
+        get("span#one").should(haveText("foobar"));
+        get("span#two").should(haveText("foobar"));
+    }
+);


### PR DESCRIPTION
Solves an issue presented in Discord

Apparently there is an [upstream bug](https://github.com/vuejs/core/blob/31abdc8adad569d83b476c340e678c4daa901545/packages/reactivity/src/baseHandlers.ts#L148) in @vue/reactivity that, when using a setter to access deeply nested data on a part of `this` that was not in the same object, would error out. As vue was not respecting the `this` context when using reflection.

I intend to make a PR there to address this as well, but Alpine is broken by even updating one minor version, so this still needs to be addressed here.

The issue can be demonstrated here:

[3.13.0](https://awesomealpine.com/play/?coreplugins=0&html=PGRpdgogIHgtZGF0YT0ieyBmb286ICB7IGJhcjogJ2ZpenpidXp6JyB9LCBlcnJvcjogJycgfSIKICBjbGFzcz0icC0yIGZsZXggZmxleC1jb2wgZ2FwLTIgaXRlbXMtY2VudGVyIgogIEBlcnJvci53aW5kb3c9ImVycm9yID0gJGV2ZW50LmVycm9yIgo-CiAgPGRpdgogICAgeC1kYXRhPSJ7IGdldCBiYXIoKSB7IHJldHVybiB0aGlzLmZvby5iYXIgfSwgc2V0IGJhcih2YWx1ZSkgeyB0aGlzLmZvby5iYXIgPSB2YWx1ZSB9IH0iCiAgPgogICAgPGJ1dHRvbgogICAgICBjbGFzcz0icC0yIGJnLWdyYXktMjAwIHJvdW5kZWQiCiAgICAgIGlkPSJvbmUiCiAgICAgIHgtdGV4dD0iYmFyIgogICAgICBAY2xpY2s9ImJhciA9ICdmb29iYXInIgogICAgPjwvYnV0dG9uPgogIDwvZGl2PgogIDxzcGFuCiAgICBpZD0idHdvIgogICAgeC10ZXh0PSJmb28uYmFyIgogID48L3NwYW4-CiAgPHNwYW4KICAgIHgtdGV4dD0iYEVycm9yOiAke2Vycm9yfWAiCiAgICBjbGFzcz0idGV4dC1yZWQtNjAwIgogID48L3NwYW4-CjwvZGl2Pgo&script=Y29uc29sZS5sb2coJ2hlbGxvJyk7Cg&tw=1&v=3.13.0&panel=config)

[3.13.1](https://awesomealpine.com/play/?coreplugins=0&html=PGRpdgogIHgtZGF0YT0ieyBmb286ICB7IGJhcjogJ2ZpenpidXp6JyB9LCBlcnJvcjogJycgfSIKICBjbGFzcz0icC0yIGZsZXggZmxleC1jb2wgZ2FwLTIgaXRlbXMtY2VudGVyIgogIEBlcnJvci53aW5kb3c9ImVycm9yID0gJGV2ZW50LmVycm9yIgo-CiAgPGRpdgogICAgeC1kYXRhPSJ7IGdldCBiYXIoKSB7IHJldHVybiB0aGlzLmZvby5iYXIgfSwgc2V0IGJhcih2YWx1ZSkgeyB0aGlzLmZvby5iYXIgPSB2YWx1ZSB9IH0iCiAgPgogICAgPGJ1dHRvbgogICAgICBjbGFzcz0icC0yIGJnLWdyYXktMjAwIHJvdW5kZWQiCiAgICAgIGlkPSJvbmUiCiAgICAgIHgtdGV4dD0iYmFyIgogICAgICBAY2xpY2s9ImJhciA9ICdmb29iYXInIgogICAgPjwvYnV0dG9uPgogIDwvZGl2PgogIDxzcGFuCiAgICBpZD0idHdvIgogICAgeC10ZXh0PSJmb28uYmFyIgogID48L3NwYW4-CiAgPHNwYW4KICAgIHgtdGV4dD0iYEVycm9yOiAke2Vycm9yfWAiCiAgICBjbGFzcz0idGV4dC1yZWQtNjAwIgogID48L3NwYW4-CjwvZGl2Pgo&script=Y29uc29sZS5sb2coJ2hlbGxvJyk7Cg&tw=1&v=3.13.1&panel=config)

😞 