### PR TITLE
Add an option to configure the MutationObserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7866,7 +7866,7 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7874,17 +7874,17 @@
         },
         "packages/anchor": {
             "name": "@alpinejs/anchor",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/collapse": {
             "name": "@alpinejs/collapse",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/csp": {
             "name": "@alpinejs/csp",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7892,12 +7892,12 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.13.8-revision.1",
+            "version": "3.14.1-revision.1",
             "license": "MIT"
         },
         "packages/focus": {
             "name": "@alpinejs/focus",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.9.4",
@@ -7914,17 +7914,17 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/mask": {
             "name": "@alpinejs/mask",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/morph": {
             "name": "@alpinejs/morph",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/navigate": {
@@ -7937,17 +7937,17 @@
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/sort": {
             "name": "@alpinejs/sort",
-            "version": "3.13.8",
+            "version": "3.14.1",
             "license": "MIT"
         },
         "packages/ui": {
             "name": "@alpinejs/ui",
-            "version": "3.13.8-beta.0",
+            "version": "3.14.1-beta.0",
             "license": "MIT",
             "devDependencies": {}
         }

--- a/packages/alpinejs/builds/cdn.js
+++ b/packages/alpinejs/builds/cdn.js
@@ -3,5 +3,5 @@ import Alpine from './../src/index'
 window.Alpine = Alpine
 
 queueMicrotask(() => {
-    Alpine.start(false)
+    Alpine.start()
 })

--- a/packages/alpinejs/builds/cdn.js
+++ b/packages/alpinejs/builds/cdn.js
@@ -3,5 +3,5 @@ import Alpine from './../src/index'
 window.Alpine = Alpine
 
 queueMicrotask(() => {
-    Alpine.start()
+    Alpine.start(false)
 })

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -6,7 +6,7 @@ import { warn } from './utils/warn'
 
 let started = false
 
-export function start() {
+export function start(observeFullDocument = true) {
     if (started) warn('Alpine has already been initialized on this page. Calling Alpine.start() more than once can cause problems.')
 
     started = true
@@ -16,7 +16,7 @@ export function start() {
     dispatch(document, 'alpine:init')
     dispatch(document, 'alpine:initializing')
 
-    startObservingMutations()
+    startObservingMutations(observeFullDocument)
 
     onElAdded(el => initTree(el, walk))
     onElRemoved(el => destroyTree(el))

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -1,3 +1,5 @@
+import { prefix } from './directives'
+
 let onAttributeAddeds = []
 let onElRemoveds = []
 let onElAddeds = []
@@ -49,8 +51,22 @@ let observer = new MutationObserver(onMutate)
 
 let currentlyObserving = false
 
-export function startObservingMutations() {
-    observer.observe(document, { subtree: true, childList: true, attributes: true, attributeOldValue: true })
+let isObservingFullDocument = true
+
+export function startObservingMutations(shouldObserveFullDocument = null) {
+    if (shouldObserveFullDocument !== null) {
+        isObservingFullDocument = shouldObserveFullDocument
+    }
+
+    const options = { subtree: true, childList: true, attributes: true, attributeOldValue: true }
+
+    if (isObservingFullDocument) {
+        observer.observe(document, options)
+    } else {
+        document.querySelectorAll(`[${prefix('data')}]`).forEach(el => {
+            observer.observe(el, options)
+        })
+    }
 
     currentlyObserving = true
 }


### PR DESCRIPTION
We are using Alpine on a website with a large DOM and many nodes changing from third-party scripts. We've found that Alpine's MutationObserver causes problems when watching the entire document, notably race conditions with other scripts modifying the DOM and an increase in INP as Alpine's mutation callback triggers a lot.

The option added in this PR lets us call `Alpine.start(false)` with the false flag, causing the MutationObserver only to watch `[x-data]` elements instead of the entire document. Of course, this means some functionality will not work as intended when a mutation happens outside an Alpine component, but for a page where each Alpine component only cares about its own contents this has a _huge_ performance benefit.