### PR TITLE
:bug: Cleans up template directives memory

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -22,11 +22,13 @@ directive('for', (el, { expression }, { effect, cleanup }) => {
     effect(() => loop(el, iteratorNames, evaluateItems, evaluateKey))
 
     cleanup(() => {
-        Object.values(el._x_lookup).forEach(el => 
+        Object.values(el._x_lookup).forEach(el =>
             mutateDom(() => {
                 destroyTree(el)
+
                 el.remove()
-            }))
+            }
+        ))
 
         delete el._x_prevKeys
         delete el._x_lookup
@@ -142,13 +144,15 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
         // for browser performance.
 
         // We'll remove all the nodes that need to be removed,
-        // letting the mutation observer pick them up and
-        // clean up any side effects they had.
+        // and clean up any side effects they had.
         for (let i = 0; i < removes.length; i++) {
             let key = removes[i]
-            if (!(key in lookup)) continue
+
+            if (! (key in lookup)) continue
+
             mutateDom(() => {
                 destroyTree(lookup[key])
+
                 lookup[key].remove()
             })
 

--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -2,10 +2,9 @@ import { addScopeToNode } from '../scope'
 import { evaluateLater } from '../evaluator'
 import { directive } from '../directives'
 import { reactive } from '../reactivity'
-import { initTree } from '../lifecycle'
+import { initTree, destroyTree } from '../lifecycle'
 import { mutateDom } from '../mutation'
 import { warn } from '../utils/warn'
-import { dequeueJob } from '../scheduler'
 import { skipDuringClone } from '../clone'
 
 directive('for', (el, { expression }, { effect, cleanup }) => {
@@ -23,7 +22,11 @@ directive('for', (el, { expression }, { effect, cleanup }) => {
     effect(() => loop(el, iteratorNames, evaluateItems, evaluateKey))
 
     cleanup(() => {
-        Object.values(el._x_lookup).forEach(el => el.remove())
+        Object.values(el._x_lookup).forEach(el => 
+            mutateDom(() => {
+                destroyTree(el)
+                el.remove()
+            }))
 
         delete el._x_prevKeys
         delete el._x_lookup
@@ -143,15 +146,12 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
         // clean up any side effects they had.
         for (let i = 0; i < removes.length; i++) {
             let key = removes[i]
+            if (!(key in lookup)) continue
+            mutateDom(() => {
+                destroyTree(lookup[key])
+                lookup[key].remove()
+            })
 
-            // Remove any queued effects that might run after the DOM node has been removed.
-            if (!! lookup[key]._x_effects) {
-                lookup[key]._x_effects.forEach(dequeueJob)
-            }
-
-            lookup[key].remove()
-
-            lookup[key] = null
             delete lookup[key]
         }
 

--- a/packages/alpinejs/src/directives/x-if.js
+++ b/packages/alpinejs/src/directives/x-if.js
@@ -30,6 +30,7 @@ directive('if', (el, { expression }, { effect, cleanup }) => {
         el._x_undoIf = () => {
             mutateDom(() => {
                 destroyTree(clone)
+
                 clone.remove()
             })
 
@@ -40,7 +41,7 @@ directive('if', (el, { expression }, { effect, cleanup }) => {
     }
 
     let hide = () => {
-        if (!el._x_undoIf) return
+        if (! el._x_undoIf) return
 
         el._x_undoIf()
 

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -3,7 +3,6 @@ import { deferHandlingDirectives, directiveExists, directives } from "./directiv
 import { dispatch } from './utils/dispatch'
 import { walk } from "./utils/walk"
 import { warn } from './utils/warn'
-import { dequeueJob } from './scheduler'
 
 let started = false
 
@@ -99,11 +98,8 @@ export function initTree(el, walker = walk, intercept = () => {}) {
 
 export function destroyTree(root, walker = walk) {
     walker(root, el => {
-        walk(el, (node) => {
-            node._x_effects?.forEach(dequeueJob)
-        })
-        cleanupAttributes(el)
         cleanupElement(el)
+        cleanupAttributes(el)
     })
 }
 

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -3,6 +3,7 @@ import { deferHandlingDirectives, directiveExists, directives } from "./directiv
 import { dispatch } from './utils/dispatch'
 import { walk } from "./utils/walk"
 import { warn } from './utils/warn'
+import { dequeueJob } from './scheduler'
 
 let started = false
 
@@ -98,6 +99,9 @@ export function initTree(el, walker = walk, intercept = () => {}) {
 
 export function destroyTree(root, walker = walk) {
     walker(root, el => {
+        walk(el, (node) => {
+            node._x_effects?.forEach(dequeueJob)
+        })
         cleanupAttributes(el)
         cleanupElement(el)
     })

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -42,6 +42,7 @@ export function cleanupAttributes(el, names) {
 
 export function cleanupElement(el) {
     el._x_effects?.forEach(dequeueJob)
+
     while (el._x_cleanups?.length) el._x_cleanups.pop()()
 }
 

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -1,3 +1,4 @@
+import { dequeueJob } from "./scheduler";
 let onAttributeAddeds = []
 let onElRemoveds = []
 let onElAddeds = []
@@ -40,9 +41,8 @@ export function cleanupAttributes(el, names) {
 }
 
 export function cleanupElement(el) {
-    if (el._x_cleanups) {
-        while (el._x_cleanups.length) el._x_cleanups.pop()()
-    }
+    el._x_effects?.forEach(dequeueJob)
+    while (el._x_cleanups?.length) el._x_cleanups.pop()()
 }
 
 let observer = new MutationObserver(onMutate)

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -605,3 +605,37 @@ test('x-for throws descriptive error when key is undefined',
     ({ get }) => {},
     true
 )
+
+// If x-for removes a child, all cleanups in the tree should be handled.
+test('x-for eagerly cleans tree',
+    html`
+        <div x-data="{ show: 0, count: 0, items: [1,2,3] }">
+            <button id="toggle" @click="show^=true" x-text="count">Toggle</button>
+            <button id="remove" @click="items.pop()">Remove</button>
+            <template x-for="num in items" :key="num">
+                <div>
+                <template x-for="n in show">
+                    <p x-effect="if (n) count+=num">
+                    hello
+                    </p>
+                </template>
+                </div>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('#toggle').should(haveText('0'))
+        get('#toggle').click()
+        get('#toggle').should(haveText('6'))
+        get('#toggle').click()
+        get('#toggle').should(haveText('6'))
+        get('#toggle').click()
+        get('#toggle').should(haveText('12'))
+        get('#remove').click()
+        get('#toggle').should(haveText('12'))
+        get('#toggle').click()
+        get('#toggle').should(haveText('12'))
+        get('#toggle').click()
+        get('#toggle').should(haveText('15'))
+    }
+)

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -609,15 +609,18 @@ test('x-for throws descriptive error when key is undefined',
 // If x-for removes a child, all cleanups in the tree should be handled.
 test('x-for eagerly cleans tree',
     html`
-        <div x-data="{ show: 0, count: 0, items: [1,2,3] }">
-            <button id="toggle" @click="show^=true" x-text="count">Toggle</button>
+        <div x-data="{ show: 0, counts: [0,0,0], items: [0,1,2] }">
+            <button
+                id="toggle"
+                @click="show^=true"
+                x-text="counts.reduce((a,b)=>a+b)">
+                Toggle
+            </button>
             <button id="remove" @click="items.pop()">Remove</button>
             <template x-for="num in items" :key="num">
                 <div>
                 <template x-for="n in show">
-                    <p x-effect="if (n) count+=num">
-                    hello
-                    </p>
+                    <p x-effect="if (show) counts[num]++">hello</p>
                 </template>
                 </div>
             </template>
@@ -626,16 +629,16 @@ test('x-for eagerly cleans tree',
     ({ get }) => {
         get('#toggle').should(haveText('0'))
         get('#toggle').click()
-        get('#toggle').should(haveText('6'))
+        get('#toggle').should(haveText('3'))
+        get('#toggle').click()
+        get('#toggle').should(haveText('3'))
         get('#toggle').click()
         get('#toggle').should(haveText('6'))
-        get('#toggle').click()
-        get('#toggle').should(haveText('12'))
         get('#remove').click()
-        get('#toggle').should(haveText('12'))
+        get('#toggle').should(haveText('6'))
         get('#toggle').click()
-        get('#toggle').should(haveText('12'))
+        get('#toggle').should(haveText('6'))
         get('#toggle').click()
-        get('#toggle').should(haveText('15'))
+        get('#toggle').should(haveText('8'))
     }
 )

--- a/tests/cypress/integration/directives/x-if.spec.js
+++ b/tests/cypress/integration/directives/x-if.spec.js
@@ -110,3 +110,40 @@ test('x-if removed dom does not attempt skipping already-processed reactive effe
         get('div#div-also-not-editing').should(exist())
     }
 )
+
+// If x-if evaluates to false, all cleanups in the tree should be handled.
+test('x-if eagerly cleans tree',
+    html`
+        <div x-data="{ show: false, count: 0 }">
+            <button @click="show^=true" x-text="count">Toggle</button>
+            <template x-if="show">
+                <div>
+                <template x-if="true">
+                    <p x-effect="if (show) count++">
+                    hello
+                    </p>
+                </template>
+                </div>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').should(haveText('0'))
+        get('button').click()
+        get('button').should(haveText('1'))
+        get('button').click()
+        get('button').should(haveText('1'))
+        get('button').click()
+        get('button').should(haveText('2'))
+        get('button').click()
+        get('button').should(haveText('2'))
+        get('button').click()
+        get('button').should(haveText('3'))
+        get('button').click()
+        get('button').should(haveText('3'))
+        get('button').click()
+        get('button').should(haveText('4'))
+        get('button').click()
+        get('button').should(haveText('4'))
+    }
+)


### PR DESCRIPTION
Eagerly cleans up clones from `x-if` and `x-for` template directives.

Addresses: #4299 #4287 #4231 #1730 #3980 and others...


## The Problem
Basically, when x-if and x-for cleaned up their cloned elements, they mainly left it to the mutation observer to but this was not always correctly handling the tree when it came to these elements. Resulting in primarily non-destructive errors, but also in a significant memory leak.

The x-for would not dequeue any scheduled jobs, so already triggered effects would run even if x-for removed the element, while x-if would dequeue existing jobs, it would actually prevent many cleanups on nested elements from actually being run.

This mainly became an issue when x-if and x-templates were nested (in each other or themselves) as the duplication of elements and effects could escalate.

Due to how the mutation observer worked, it would not see the removed nested children when cleaning, as the nested tags would remove the element (without cleaning it) when they were cleaned, leaving the child completely detached and unobserved.

## The Change

Directly in the relevant directive, when the element is cleaned, instead of deferring handling to the mutation observer, immediately remove and clean the tree (similar to how `init` was not deferred to the mutation observer).

This also includes `destroyTree` taking on dequeuing of active jobs as it destroys the tree.

## Breakages?

None that I found or could think of. There shouldn't be any risk to actually cleaning the tree when it's removed, as opposed to some time a few milliseconds in the future.