### PR TITLE
UI x-radio: fix keyboard navigation when value of first/last radio option is null

### DIFF
--- a/packages/ui/src/radio.js
+++ b/packages/ui/src/radio.js
@@ -106,8 +106,8 @@ function handleRoot(el, Alpine) {
                 __focusOptionNext() {
                     let option = this.__active
                     let all = this.__optionValues.filter(i => !this.__disabledOptions.has(i))
-                    let next = all[this.__optionValues.indexOf(option) + 1]
-                    next = next || all[0]
+                    let index = all.indexOf(option)
+                    let next = all.length > index + 1 ? all[index + 1] : all[0]
 
                     this.__optionElsByValue.get(next).focus()
                     this.__change(next)
@@ -115,8 +115,8 @@ function handleRoot(el, Alpine) {
                 __focusOptionPrev() {
                     let option = this.__active
                     let all = this.__optionValues.filter(i => !this.__disabledOptions.has(i))
-                    let prev = all[all.indexOf(option) - 1]
-                    prev = prev || all.slice(-1)[0]
+                    let index = all.indexOf(option)
+                    let prev = index >= 1 ? all[all.indexOf(option) - 1] : all.slice(-1)[0]
 
                     this.__optionElsByValue.get(prev).focus()
                     this.__change(prev)

--- a/tests/cypress/integration/plugins/ui/radio.spec.js
+++ b/tests/cypress/integration/plugins/ui/radio.spec.js
@@ -253,6 +253,49 @@ test('keyboard navigation works',
     },
 )
 
+test('keyboard navigation works when first option has null as value',
+    [html`
+        <main x-data="{ active: null }">
+            <div x-radio x-model="active">
+                <div x-radio:option option="option-null" :value="null"></div>
+                <div x-radio:option option="option-1" value="1"></div>
+                <div x-radio:option option="option-2" value="2"></div>
+            </div>
+
+            <input x-model="active" type="hidden">
+        </main>
+    `],
+    ({ get }) => {
+        get('[option="option-1"]').focus().type('{downarrow}')
+        get('[option="option-2"]').should(haveFocus()).type('{uparrow}')
+        get('[option="option-1"]').should(haveFocus()).type('{uparrow}')
+        get('[option="option-null"]').should(haveFocus()).type('{uparrow}')
+        get('[option="option-2"]').should(haveFocus()).type('{downarrow}')
+        get('[option="option-null"]').should(haveFocus())
+    },
+)
+
+test('keyboard navigation works when last option has null as value',
+    [html`
+        <main x-data="{ active: null }">
+            <div x-radio x-model="active">
+                <div x-radio:option option="option-1" value="1"></div>
+                <div x-radio:option option="option-2" value="2"></div>
+                <div x-radio:option option="option-null" :value="null"></div>
+            </div>
+
+            <input x-model="active" type="hidden">
+        </main>
+    `],
+    ({ get }) => {
+        get('[option="option-1"]').focus().type('{downarrow}')
+        get('[option="option-2"]').should(haveFocus()).type('{downarrow}')
+        get('[option="option-null"]').should(haveFocus()).type('{downarrow}')
+        get('[option="option-1"]').should(haveFocus()).type('{uparrow}')
+        get('[option="option-null"]').should(haveFocus())
+    },
+)
+
 test('has accessibility attributes',
     [html`
         <main x-data="{ active: null, access: [


### PR DESCRIPTION
When the first or last `x-radio:option` has null as value, then keyboard navigation does not work correctly. It skips that option because it thinks that is already reached the end or beginning of the options array (caused by `next || all[0]` or `prev || all.slice(-1)[0]`). See screen recordings as a visual example.


https://github.com/user-attachments/assets/aa7cdeed-cf67-415b-b346-ab63b68296bc


https://github.com/user-attachments/assets/22d762b3-a1d0-4e6b-8a9a-43a4249bca3f




