### PR TITLE
make docs more generic to package managers

### DIFF
--- a/packages/docs/src/en/advanced/csp.md
+++ b/packages/docs/src/en/advanced/csp.md
@@ -14,7 +14,7 @@ In order to accommodate environments where this CSP is necessary, Alpine offer's
 <a name="installation"></a>
 ## Installation
 
-You can use this build by either including it from a `<script>` tag or installing it via NPM:
+You can use this build by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -25,12 +25,13 @@ You can include this build's CDN as a `<script>` tag just like you would normall
 <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can alternatively install this build from NPM for use inside your bundle like so:
+You can alternatively install this build from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/csp
+bun install @alpinejs/csp
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/advanced/extending.md
+++ b/packages/docs/src/en/advanced/extending.md
@@ -47,8 +47,8 @@ If you want to extract your extension code into an external file, you will need 
 </html>
 ```
 
-<a name="via-npm"></a>
-### Via an NPM module
+<a name="via-package-manager"></a>
+### Via a package manager module
 
 If you imported Alpine into a bundle, you have to make sure you are registering any extension code IN BETWEEN when you import the `Alpine` global object, and when you initialize Alpine by calling `Alpine.start()`. For example:
 
@@ -307,7 +307,7 @@ Alpine.magic('clipboard', () => subject => {
 <a name="writing-and-sharing-plugins"></a>
 ## Writing and sharing plugins
 
-By now you should see how friendly and simple it is to register your own custom directives and magics in your application, but what about sharing that functionality with others via an NPM package or something?
+By now you should see how friendly and simple it is to register your own custom directives and magics in your application, but what about sharing that functionality with others via a package manager or something?
 
 You can get started quickly with Alpine's official "plugin-blueprint" package. It's as simple as cloning the repository and running `npm install && npm run build` to get a plugin authored.
 
@@ -348,7 +348,7 @@ That's it! Authoring a plugin for inclusion via a script tag is extremely simple
 <a name="bundle-module"></a>
 ### Bundle module
 
-Now let's say you wanted to author a plugin that someone could install via NPM and include into their bundle.
+Now let's say you wanted to author a plugin that someone could install via a package manager and include into their bundle.
 
 Like the last example, we'll walk through this in reverse, starting with what it will look like to consume this plugin:
 

--- a/packages/docs/src/en/essentials/installation.md
+++ b/packages/docs/src/en/essentials/installation.md
@@ -43,12 +43,13 @@ Note that you will still need to define a component with `x-data` in order for a
 <a name="as-a-module"></a>
 ## As a module
 
-If you prefer the more robust approach, you can install Alpine via NPM and import it into a bundle.
+If you prefer the more robust approach, you can install Alpine via a package manager and import it into a bundle.
 
-Run the following command to install it.
+Run one of the following commands to install it.
 
 ```shell
 npm install alpinejs
+bun install alpinejs
 ```
 
 Now import Alpine into your bundle and initialize it like so:

--- a/packages/docs/src/en/plugins/anchor.md
+++ b/packages/docs/src/en/plugins/anchor.md
@@ -16,7 +16,7 @@ The "anchoring" functionality used in this plugin is provided by the [Floating U
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -30,12 +30,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Anchor from NPM for use inside your bundle like so:
+You can install Anchor from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/anchor
+bun install @alpinejs/anchor
 ```
 
 Then initialize it from your bundle:
@@ -210,4 +211,3 @@ Because `x-anchor` accepts a reference to any DOM element, you can use utilities
     </div>
 </div>
 <!-- END_VERBATIM -->
-

--- a/packages/docs/src/en/plugins/collapse.md
+++ b/packages/docs/src/en/plugins/collapse.md
@@ -14,7 +14,7 @@ Because this behavior and implementation differs from Alpine's standard transiti
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -28,12 +28,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Collapse from NPM for use inside your bundle like so:
+You can install Collapse from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/collapse
+bun install @alpinejs/collapse
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/focus.md
+++ b/packages/docs/src/en/plugins/focus.md
@@ -16,7 +16,7 @@ Alpine's Focus plugin allows you to manage focus on a page.
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -30,12 +30,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Focus from NPM for use inside your bundle like so:
+You can install Focus from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/focus
+bun install @alpinejs/focus
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -14,7 +14,7 @@ This is useful for: lazy loading images and other content, triggering animations
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -28,12 +28,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Intersect from NPM for use inside your bundle like so:
+You can install Intersect from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/intersect
+bun install @alpinejs/intersect
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -20,7 +20,7 @@ This is useful for many different types of inputs: phone numbers, credit cards, 
 <div x-show="! expanded" class="absolute inset-0 flex justify-start items-end bg-gradient-to-t from-white to-[#ffffff66]"></div>
 <div x-show="expanded" x-collapse.min.80px class="markdown">
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -34,12 +34,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Mask from NPM for use inside your bundle like so:
+You can install Mask from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/mask
+bun install @alpinejs/mask
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/morph.md
+++ b/packages/docs/src/en/plugins/morph.md
@@ -33,7 +33,7 @@ The best way to understand its purpose is with the following interactive visuali
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -47,12 +47,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Morph from NPM for use inside your bundle like so:
+You can install Morph from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/morph
+bun install @alpinejs/morph
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/persist.md
+++ b/packages/docs/src/en/plugins/persist.md
@@ -14,7 +14,7 @@ This is useful for persisting search filters, active tabs, and other features wh
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -28,12 +28,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Persist from NPM for use inside your bundle like so:
+You can install Persist from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/persist
+bun install @alpinejs/persist
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/resize.md
+++ b/packages/docs/src/en/plugins/resize.md
@@ -14,7 +14,7 @@ This is useful for: custom size-based animations, intelligent sticky positioning
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -28,12 +28,13 @@ You can include the CDN build of this plugin as a `<script>` tag, just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Resize from NPM for use inside your bundle like so:
+You can install Resize from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/resize
+bun install @alpinejs/resize
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/plugins/sort.md
+++ b/packages/docs/src/en/plugins/sort.md
@@ -16,7 +16,7 @@ The drag functionality used in this plugin is provided by the [SortableJS](https
 <a name="installation"></a>
 ## Installation
 
-You can use this plugin by either including it from a `<script>` tag or installing it via NPM:
+You can use this plugin by either including it from a `<script>` tag or installing it via a package manager:
 
 ### Via CDN
 
@@ -30,12 +30,13 @@ You can include the CDN build of this plugin as a `<script>` tag; just make sure
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 ```
 
-### Via NPM
+### Via Package Manager
 
-You can install Sort from NPM for use inside your bundle like so:
+You can install Sort from a package manager for use inside your bundle like so:
 
 ```shell
 npm install @alpinejs/sort
+bun install @alpinejs/sort
 ```
 
 Then initialize it from your bundle:

--- a/packages/docs/src/en/upgrade-guide.md
+++ b/packages/docs/src/en/upgrade-guide.md
@@ -90,7 +90,7 @@ In V3, Alpine will automatically call `init()` methods on data objects.
 <a name="need-to-call-alpine-start"></a>
 ### Need to call Alpine.start() after import
 
-If you were importing Alpine V2 from NPM, you will now need to manually call `Alpine.start()` for V3. This doesn't affect you if you use Alpine's build file or CDN from a `<template>` tag.
+If you were importing Alpine V2 from a package manager, you will now need to manually call `Alpine.start()` for V3. This doesn't affect you if you use Alpine's build file or CDN from a `<template>` tag.
 
 ```js
 // 🚫 Before


### PR DESCRIPTION
for a long time NPM has basically been the de facto front end package manager. however, BunJS is making a strong push, and a good case for itself, so I think it'd be good for us to include it where appropriate.

we all know specific tooling comes and goes, so I've made the language *more generic* where appropriate, and refer to "a package manager" instead of specifically "NPM".

I've also then included the analogous `bun` command next to `npm` commands.