### PR TITLE
Remove unnecessary parentheses from bind.md example

### DIFF
--- a/packages/docs/src/en/directives/bind.md
+++ b/packages/docs/src/en/directives/bind.md
@@ -162,7 +162,7 @@ And like most expressions in Alpine, you can always use the result of a JavaScri
 The object keys can be anything you would normally write as an attribute name in Alpine. This includes Alpine directives and modifiers, but also plain HTML attributes. The object values are either plain strings, or in the case of dynamic Alpine directives, callbacks to be evaluated by Alpine.
 
 ```alpine
-<div x-data="dropdown()">
+<div x-data="dropdown">
     <button x-bind="trigger">Open Dropdown</button>
 
     <span x-bind="dialogue">Dropdown Contents</span>


### PR DESCRIPTION
When I saw this example using `x-data="dropdown()"` and [other examples](https://alpinejs.dev/globals/alpine-data#encapsulating-directives-with-x-bind) using ``x-data="dropdown"`` I wondered what caused this example to require parentheses. It seems like adding parentheses is redundant since the example code works both with and without them.