### PR TITLE
feat: `x-on` `.passive.false` modifier

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -14,10 +14,14 @@ export default function on (el, event, modifiers, callback) {
 
     if (modifiers.includes("dot")) event = dotSyntax(event)
     if (modifiers.includes('camel')) event = camelCase(event)
-    if (modifiers.includes('passive')) options.passive = true
     if (modifiers.includes('capture')) options.capture = true
     if (modifiers.includes('window')) listenerTarget = window
     if (modifiers.includes('document')) listenerTarget = document
+
+    if (modifiers.includes('passive')) {
+        let nextModifier = modifiers[modifiers.indexOf('passive')+1]
+        options.passive = nextModifier === 'false' ? false : true
+    }
 
     // By wrapping the handler with debounce & throttle first, we ensure that the wrapping logic itself is not
     // throttled/debounced, only the user's callback is. This way, if the user expects
@@ -73,7 +77,7 @@ export default function on (el, event, modifiers, callback) {
             if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
                 return
             }
-            
+
             next(e)
         })
     }

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -343,6 +343,15 @@ If you are listening for touch events, it's important to add `.passive` to your 
 
 [→ Read more about passive listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners)
 
+<a name="passive-false"></a>
+### .passive.false
+
+In modern browsers, `wheel` and `touchmove` event listeners are passive by default. If, for some reason, you need to call `preventDefault` on such an event, you can do so by adding `.passive.false` to your listener.
+
+```alpine
+<div @touchstart.passive.false="console.log($event.cancelable)">...</div>
+```
+
 ### .capture
 
 Add this modifier if you want to execute this listener in the event's capturing phase, e.g. before the event bubbles from the target element up the DOM.

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -79,6 +79,23 @@ test('.passive modifier should disable e.preventDefault()',
     }
 )
 
+test('.passive.false modifier should enable e.preventDefault()',
+    html`
+        <div
+            x-data="{ defaultPrevented: null }"
+            x-on:touchmove.passive.false="
+                $event.preventDefault();
+                defaultPrevented = $event.defaultPrevented;
+            ">
+            <br>
+        </div>
+    `,
+    ({ get }) => {
+        get('div').trigger('touchmove')
+        get('div').should(haveData('defaultPrevented', true))
+    }
+)
+
 test('.stop modifier',
     html`
         <div x-data="{ foo: 'bar' }">


### PR DESCRIPTION
As discussed in #4403 , this PR adds a way to set event listeners to `{passive: false}`:

```html
<div x-on.touchmove.passive.false="console.log($event.cancelable)"></div>
```
**Use case**

In horizontal sliders, it's necessary to stop vertical scrolling of the viewport when flicking through the slides. Registering a non-passive touchmove handler makes this possible:

- register a `touchstart` event and save the x-coordinate
- register a `touchmove` event with `{passive: false}` and check if the x-coordinate is more than 3 (or whatever) pixels away from the `touchstart` coordinate. If so, disable vertical scrolling by calling `e.preventDefault()`

```ts
{
  touching: false,
  touchStartCoords: {x: 0, y: 0},

  bindings: {
    "@touchstart.document.capture": "onTouchStart",
    "@touchmove.document.passive.false": "onTouchMove", // possible through this PR
  },
  
  onTouchStart(e: TouchEvent) {
    const target = e.target as HTMLElement;
    this.touching = this.$root.contains(target);
  
    this.touchStartCoords = {
      x: e.touches[0].pageX,
      y: e.touches[0].pageY,
    };
  },
  
  onTouchMove(e: TouchEvent) {
    const { cancelable } = e;
    const { touching } = this;
  
    if (!touching || !cancelable) return;
  
    const moveVector = {
      x: e.touches[0].pageX - this.touchStartCoords.x,
      y: e.touches[0].pageY - this.touchStartCoords.y,
    };
  
    if (Math.abs(moveVector.x) > 3) {
      e.preventDefault();
    }
  },
}

```

**Checks**

- [x] New test included
- [x] Documentation updated 

**Questions** 

- I tried to also add an explicit way to set `{passive: true}` using `x-on.passive.true` but wasn't able to get it to work. The handler in the cypress test just didn't fire at all (`defaultPrevented` stayed `null`, even after the click). But then I thought why even provide `passive.true` if that's the current behavior of `.passive` already?
- further down in `on.js`, would we need to add `"false"` to the list in `isListeningForASpecificKeyThatHasntBeenPressed`? Not sure what the function does exactly.
- Naming: are there better alternatives to `.passive.false`, as there are no other options as for example in the `.transition` modifier?
  - `.no-passive` as suggested by @ekwoka ?
  - `.passive-false` ?
  - is there some convention already in Alpine.js on how to deal with boolean values where both explicit `true` as `false` is possible?