### PR TITLE
Fix getting the old value in deep watching

### DIFF
--- a/packages/alpinejs/src/reactivity.js
+++ b/packages/alpinejs/src/reactivity.js
@@ -57,6 +57,8 @@ export function elementBoundEffect(el) {
 }
 
 export function watch(getter, callback) {
+    const deepClone = obj => "structuredClone" in globalThis ? structuredClone(obj) : obj
+
     let firstTime = true
 
     let oldValue
@@ -73,10 +75,10 @@ export function watch(getter, callback) {
             queueMicrotask(() => {
                 callback(value, oldValue)
 
-                oldValue = value
+                oldValue = deepClone(raw(value))
             })
         } else {
-            oldValue = value
+            oldValue = deepClone(raw(value))
         }
 
         firstTime = false


### PR DESCRIPTION
This addresses the issue with old value in [deep watching](https://alpinejs.dev/magics/watch#deep-watching) as described in #3293. In contrast to #3046 and #3617, this PR relies exclusively on the [strcuturedClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) API and falls back to the current behaviour if not available, drastically simplifying things.