### PR TITLE
Modify the CSP Evaluator to handle negated expressions

### DIFF
--- a/packages/csp/src/evaluator.js
+++ b/packages/csp/src/evaluator.js
@@ -25,10 +25,13 @@ function generateDataStack(el) {
 }
 
 function generateEvaluator(el, expression, dataStack) {
-    return (receiver = () => {}, { scope = {}, params = [] } = {}) => {
+    return (receiver = () => { }, { scope = {}, params = [] } = {}) => {
         let completeScope = mergeProxies([scope, ...dataStack])
 
-        let evaluatedExpression = expression.split('.').reduce(
+        let isNegated = expression.trim().charAt(0) === '!'
+        let expressionToEvaluate = isNegated ? expression.trim().slice(1) : expression.trim()
+
+        let evaluatedExpression = expressionToEvaluate.split('.').reduce(
             (currentScope, currentExpression) => {
                 if (currentScope[currentExpression] === undefined) {
                     throwExpressionError(el, expression)
@@ -39,19 +42,23 @@ function generateEvaluator(el, expression, dataStack) {
             completeScope,
         );
 
-        runIfTypeOfFunction(receiver, evaluatedExpression, completeScope, params)
+        function handleResult(result) {
+            receiver(isNegated ? !result : result)
+        }
+
+        runIfTypeOfFunction(handleResult, evaluatedExpression, completeScope, params)
     }
 }
 
 function throwExpressionError(el, expression) {
     console.warn(
-`Alpine Error: Alpine is unable to interpret the following expression using the CSP-friendly build:
+        `Alpine Error: Alpine is unable to interpret the following expression using the CSP-friendly build:
 
 "${expression}"
 
 Read more about the Alpine's CSP-friendly build restrictions here: https://alpinejs.dev/advanced/csp
 
 `,
-el
+        el
     )
 }

--- a/tests/cypress/integration/plugins/csp-compatibility.spec.js
+++ b/tests/cypress/integration/plugins/csp-compatibility.spec.js
@@ -8,7 +8,7 @@ test.csp('Can use components and basic expressions with CSP-compatible build',
             <button @click="change">Change Foo</button>
         </div>
     `,
-    `
+        `
         Alpine.data('test', () => ({
             foo: 'bar',
             change() { this.foo = 'baz' },
@@ -29,7 +29,7 @@ test.csp('Supports nested properties',
             <button @click="foo.change">Change Foo</button>
         </div>
     `,
-    `
+        `
         Alpine.data('test', () => ({
             foo: {
                 bar: 'baz',
@@ -41,5 +41,48 @@ test.csp('Supports nested properties',
         get('span').should(haveText('baz'))
         get('button').click()
         get('span').should(haveText('qux'))
+    }
+)
+
+test.csp('Supports simple negation',
+    [html`
+        <div x-data="test">
+            <span x-text="!foo"></span>
+
+            <button @click="toggle">Toggle Foo</button>
+        </div>
+    `,
+        `
+        Alpine.data('test', () => ({
+            foo: false,
+            toggle() { this.foo = !this.foo },
+        }))
+    `],
+    ({ get }) => {
+        get('span').should(haveText('true'))
+        get('button').click()
+        get('span').should(haveText('false'))
+    }
+)
+
+test.csp("Supports negation of function calls",
+    [html`
+        <div x-data="test">
+            <span x-text="!foo"></span>
+
+            <button @click="toggle">Toggle Foo</button>
+        </div>
+    `,
+        `
+        Alpine.data('test', () => ({
+            _foo: false,
+            foo() { return this._foo },
+            toggle() { this._foo = !this._foo },
+        }))
+    `],
+    ({ get }) => {
+        get('span').should(haveText('true'))
+        get('button').click()
+        get('span').should(haveText('false'))
     }
 )


### PR DESCRIPTION
This commit adds support to use straightforward negated expressions in Alpine directives in the CSP build.

While we (probably) do not want to rewrite a full CSP-save expression evaluator to handle expressions of arbitrary complexity, directives with negation are such a common use case that it makes sense to support them.

Consider, for example,

* `x-show="!loading"`
* `:disabled="!valid"`

In the CSP, we would have to write custom getters for each boolean attribute whose negation we might want to use, adding needless verbosity.

On the other hand, being a unary operator, hand-rolling negation is easy enough.

To test that it all works, we add relevant cypress tests to the csp spec to verify that we can negate both a plain attribute as well as the result of a function call.