### PR TITLE
Fix regression on x-ignore when removed

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -93,16 +93,16 @@ export function initTree(el, walker = walk, intercept = () => {}) {
             // If the element has a marker, it's already been initialized...
             if (el._x_marker) return
 
-            // Add a marker to the element so we can tell if it's been initialized...
-            // This is important so that we can prevent double-initialization of
-            // elements that are moved around on the page.
-            el._x_marker = markerDispenser++
-
             intercept(el, skip)
 
             initInterceptors.forEach(i => i(el, skip))
 
             directives(el, el.attributes).forEach(handle => handle())
+
+            // Add a marker to the element so we can tell if it's been initialized...
+            // This is important so that we can prevent double-initialization of
+            // elements that are moved around on the page.
+            if (!el._x_ignore) el._x_marker = markerDispenser++
 
             el._x_ignore && skip()
         })

--- a/tests/cypress/integration/directives/x-ignore.spec.js
+++ b/tests/cypress/integration/directives/x-ignore.spec.js
@@ -1,4 +1,4 @@
-import { haveText, html, notHaveClasses, notHaveText, test } from '../../utils'
+import { haveClasses, haveText, html, notHaveClasses, notHaveText, test } from '../../utils'
 
 test('x-ignore',
     html`
@@ -8,7 +8,9 @@ test('x-ignore',
             </div>
         </div>
     `,
-    ({ get }) => get('span').should(notHaveText('bar'))
+    ({ get }) => {
+        get('span').should(notHaveText('bar'))
+    }
 )
 
 test('x-ignore.self',
@@ -22,5 +24,23 @@ test('x-ignore.self',
     ({ get }) => {
         get('span').should(haveText('bar'))
         get('h1').should(notHaveClasses(['bar']))
+    }
+)
+
+test('can lazyload component',
+    html`
+        <div x-data="{ lazyLoad() {$el.querySelector('#lazy').removeAttribute('x-ignore'); Alpine.nextTick(() => Alpine.initTree($el.querySelector('#lazy')))} }">
+            <button @click="lazyLoad">Load</button>
+            <div x-data="{ foo: 'bar' }" id="lazy" x-ignore :class="foo">
+                <span x-text="foo"></span>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(notHaveText('bar'))
+        get('div#lazy').should(notHaveClasses(['bar']))
+        get('button').click()
+        get('span').should(haveText('bar'))
+        get('div#lazy').should(haveClasses(['bar']))
     }
 )

--- a/tests/cypress/integration/directives/x-ignore.spec.js
+++ b/tests/cypress/integration/directives/x-ignore.spec.js
@@ -27,7 +27,7 @@ test('x-ignore.self',
     }
 )
 
-test('can lazyload component',
+test('can lazyload a component',
     html`
         <div x-data="{ lazyLoad() {$el.querySelector('#lazy').removeAttribute('x-ignore'); Alpine.nextTick(() => Alpine.initTree($el.querySelector('#lazy')))} }">
             <button @click="lazyLoad">Load</button>


### PR DESCRIPTION
Release v3.14.4 introduce an _x_marker property to flag elements that were already initialised so they don't get initialised again when moved around (I think it was causing some issues in Livewire). However the code was also marking as initialised elements that were skipped by x-ignore.

This causes issues if x-ignore is removed and people calls initTree on the element: the subtree is initialised but the parent is skipped even if it wasn't previously initialised so, if it has x-data, it will trigger errors.

See https://github.com/alpinejs/alpine/discussions/4457

This PR changes the logic so _x_marker is not added when the element has x-ignore