### PR TITLE
Fix x-teleport by removing clone x-ignore

### DIFF
--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -51,8 +51,6 @@ directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
 
         skipDuringClone(() => {
             initTree(clone)
-
-            clone._x_ignore = true
         })()
     })
 

--- a/tests/cypress/integration/directives/x-teleport.spec.js
+++ b/tests/cypress/integration/directives/x-teleport.spec.js
@@ -204,3 +204,26 @@ test('$id honors x-id outside teleport',
         get('#b h1').should(haveText('foo-1'))
     },
 )
+
+test('conditionally added elements get initialised inside teleport',
+    [html`
+        <div x-data="{ show: false }" id="a">
+            <button @click="show = true">Show Teleport Content</button>
+
+            <template x-teleport="#b">
+                <div>
+                    <template x-if="show" >
+                        <p x-text="'Teleport content initialised'">Teleport content waiting</p>
+                    </template>
+                </div>
+            </template>
+        </div>
+
+        <div id="b"></div>
+    `],
+    ({ get }) => {
+        get('#b p').should('not.exist')
+        get('button').click()
+        get('#b p').should('exist').and('have.text', 'Teleport content initialised')
+    },
+)


### PR DESCRIPTION
As per the discussion here https://github.com/alpinejs/alpine/discussions/4467#discussioncomment-11461276 I've removed the Teleport clone x-ignore.

I've run the tests locally and they pass. I've also made a build of Livewire with it, run it's tests and all pass.

Fixes #4461, fixes #4467, fixes livewire/livewire#9067