### PR TITLE
Revert Don't init trees within ignore elements (x-ignore)

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -85,9 +85,6 @@ export function interceptInit(callback) { initInterceptors.push(callback) }
 let markerDispenser = 1
 
 export function initTree(el, walker = walk, intercept = () => {}) {
-    // Don't init a tree within a parent that is being ignored...
-    if (findClosest(el, i => i._x_ignore)) return
-
     deferHandlingDirectives(() => {
         walker(el, (el, skip) => {
             // If the element has a marker, it's already been initialized...


### PR DESCRIPTION
Reason:

in async alpine plugin docs (https://async-alpine.dev/docs/upgrade/#html-attributes):

> x-ignore will now be automatically added to all components.

this breaking async alpine data because after livewire doing server request then morph the view, `x-ignore` attribute will be added automatically by async alpine. 

here's the simple example:

```html
<div x-load x-load-src="/toggle.js" x-data="simpleToggle">
    <button class="rounded-2xl bg-slate-800 p-2" type="button" x-on:click="open = !open">
        Toggle
    </button>

    <div x-show="open" x-cloak>foo</div>
    <div x-show="!open" x-cloak>bar</div>
</div>
```

toggle.js:

```js
export default () => {
    return {
        open: false,
    };
};
```

[Video_2024_12_07-4.webm](https://github.com/user-attachments/assets/5a49cfd2-a802-46cd-b61f-46d5718ef3d6)
