### PR TITLE
Fix x-mask triggering update requests on load

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -40,7 +40,16 @@ export default function (Alpine) {
             }
 
             // Override x-model's initial value...
-            if (el._x_model) el._x_model.set(el.value)
+            if (el._x_model) {
+                // If the x-model value is the same, don't override it as that will trigger updates...
+                if (el._x_model.get() === el.value) return
+
+                // If the x-model value is `null` and the input value is an empty 
+                // string, don't override it as that will trigger updates...
+                if (el._x_model.get() === null && el.value === '') return
+
+                el._x_model.set(el.value)
+            }
         })
 
         const controller = new AbortController()

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -89,6 +89,21 @@ test('x-mask with x-model with initial value',
     },
 )
 
+test('x-mask with x-model if initial value is null it should remain null',
+    [html`
+        <div x-data="{ value: null }">
+            <input x-mask="(999) 999-9999" x-model="value" id="1">
+            <input id="2" x-model="value">
+            <span id="3" x-text="value === null ? 'NULL' : value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveValue(''))
+        get('#2').should(haveValue(''))
+        get('#3').contains('NULL')
+    },
+)
+
 test('x-mask with a falsy input',
     [html`<input x-data x-mask="">`],
     ({ get }) => {


### PR DESCRIPTION
Currently if you have are using `x-mask` with Livewire and you are using `wire:model.live`, `x-mask` is triggering a network request on page load and changing the default value from `null` to an empty string.

Loading the below Volt component immediately triggers a request and the `dd()` is called.

This PR fixes it by adding a check to see if the `_x_model` value is the same as what is being set by the mask and skips the set. Or if the set value is an empty string and the `_x_model` value is `null` then it will also skip it. This is only for the initial load of the mask. Everything else should still run the same.

Fixes livewire/flux#751

```blade
<?php

use Livewire\Volt\Component;

new class extends Component {
    public $phone_number_masked;
    public $phone_number;

    public function updated()
    {
        dd('masked', $this->phone_number_masked, 'not masked', $this->phone_number);
    }
};

?>

<div>
    <input type="text" wire:model.live="phone_number_masked" x-mask="99999-999999" />
    <input type="text" wire:model.live="phone_number" />
</div>
```

<img width="779" alt="image" src="https://github.com/user-attachments/assets/8c71dee0-e61c-4ad7-9c5f-b9818bcc5c55" />
