### PR TITLE
Add support for [x-sort:handle] attributes defined in template tags

### DIFF
--- a/packages/sort/src/index.js
+++ b/packages/sort/src/index.js
@@ -25,7 +25,9 @@ export default function (Alpine) {
 
         let preferences = {
             hideGhost: ! modifiers.includes('ghost'),
-            useHandles: !! el.querySelector('[x-sort\\:handle]'),
+            useHandles: (!! el.querySelector('[x-sort\\:handle]')) || Array.from(el.querySelectorAll('template')).some(
+                tmpl => !! tmpl.content.querySelector('[x-sort\\:handle]')
+            ),
             group: getGroupName(el, modifiers),
         }
 

--- a/tests/cypress/integration/plugins/sort.spec.js
+++ b/tests/cypress/integration/plugins/sort.spec.js
@@ -49,9 +49,40 @@ test.skip('can use a custom handle',
         get('ul li').eq(0).should(haveText('handle - foo'))
         get('ul li').eq(1).should(haveText('handle - bar'))
 
+        get('#1').drag('#2').then(() => {
+            get('ul li').eq(0).should(haveText('handle - foo'))
+            get('ul li').eq(1).should(haveText('handle - bar'))
+        })
+
         get('#1 span').drag('#2').then(() => {
             get('ul li').eq(0).should(haveText('handle - bar'))
             get('ul li').eq(1).should(haveText('handle - foo'))
+        })
+    },
+)
+
+test('can use a custom handle with x-for',
+    [html`
+        <div x-data="{items: ['1', '2']}">
+            <ul x-sort>
+                <template x-for="item in items" :key="item">
+                    <li :id="item"><span x-sort:handle>handle</span> - <span x-text="item"></span></li>
+                </template>
+            </ul>
+        </div>
+    `],
+    ({ get }) => {
+        get('ul li').eq(0).should(haveText('handle - 1'))
+        get('ul li').eq(1).should(haveText('handle - 2'))
+
+        get('#1').drag('#2').then(() => {
+            get('ul li').eq(0).should(haveText('handle - 1'))
+            get('ul li').eq(1).should(haveText('handle - 2'))
+        })
+
+        get('#1 span').eq(0).drag('#2').then(() => {
+            get('ul li').eq(0).should(haveText('handle - 2'))
+            get('ul li').eq(1).should(haveText('handle - 1'))
         })
     },
 )


### PR DESCRIPTION
Closes #4482

Many developer uses x-sort with x-for. In this cases, when x-sort gets processed there's technically no `[x-sort:handle]` in any of the children even when the x-for template would create element with said attribute.

The MR adds some additional logic (in the real word there will probably just be 1 single tag as a direct children but it takes a more generic approach) to support [x-sort:handle] defined in template tags (likely x-for).