### PR TITLE
Fix focus documentation example code

### DIFF
--- a/packages/docs/src/en/plugins/focus.md
+++ b/packages/docs/src/en/plugins/focus.md
@@ -228,7 +228,7 @@ For example:
 
 ```alpine
 <div x-data="{ open: false }">
-    <button>Open Dialog</button>
+    <button @click="open = true">Open Dialog</button>
 
     <div x-show="open" x-trap.noscroll="open">
         Dialog Contents


### PR DESCRIPTION
Fix the issue in the x-trap.noscroll example code in documentation.