### PR TITLE
Fix: Remove element markers to allow reinitialization.

### DIFF
--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -82,27 +82,17 @@ let initInterceptors = []
 
 export function interceptInit(callback) { initInterceptors.push(callback) }
 
-let markerDispenser = 1
-
 export function initTree(el, walker = walk, intercept = () => {}) {
     // Don't init a tree within a parent that is being ignored...
     if (findClosest(el, i => i._x_ignore)) return
 
     deferHandlingDirectives(() => {
         walker(el, (el, skip) => {
-            // If the element has a marker, it's already been initialized...
-            if (el._x_marker) return
-
             intercept(el, skip)
 
             initInterceptors.forEach(i => i(el, skip))
 
             directives(el, el.attributes).forEach(handle => handle())
-
-            // Add a marker to the element so we can tell if it's been initialized...
-            // This is important so that we can prevent double-initialization of
-            // elements that are moved around on the page.
-            if (!el._x_ignore) el._x_marker = markerDispenser++
 
             el._x_ignore && skip()
         })
@@ -113,7 +103,6 @@ export function destroyTree(root, walker = walk) {
     walker(root, el => {
         cleanupElement(el)
         cleanupAttributes(el)
-        delete el._x_marker
     })
 }
 


### PR DESCRIPTION
This change removes the `_x_marker` system, which was previously used to track initialized elements and prevent double-initialization. By eliminating these markers elements can now be re-reinitialized if needed, rather than being skipped based on a prior state.