### PR TITLE
Don't assign the normalEvaluator per default

### DIFF
--- a/packages/alpinejs/src/evaluator.js
+++ b/packages/alpinejs/src/evaluator.js
@@ -28,7 +28,7 @@ export function evaluateLater(...args) {
     return theEvaluatorFunction(...args)
 }
 
-let theEvaluatorFunction = normalEvaluator
+let theEvaluatorFunction = () => {}
 
 export function setEvaluator(newEvaluator) {
     theEvaluatorFunction = newEvaluator
@@ -82,11 +82,11 @@ function generateFunctionFromString(expression, el) {
                 ["__self", "scope"],
                 `with (scope) { __self.result = ${rightSideSafeExpression} }; __self.finished = true; return __self.result;`
             )
-            
+
             Object.defineProperty(func, "name", {
                 value: `[Alpine] ${expression}`,
             })
-            
+
             return func
         } catch ( error ) {
             handleError( error, el, expression )


### PR DESCRIPTION
Assigning the normal evaluator to theEvaluatorFunction means that it always needs to be exported.

CSP doesn't use the normalEvaluator and should not include it in any build. alpinsjs/src/index.js always assigns the normalEvaluator manually and works as expected, and it isn't included anymore in the csp builds.

* normalEvaluator also needed dependencies for unsafe functions which we don't want to include in the csp build
