### PR TITLE
move dependencies from monorepo root to correct packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,13 @@
                 "packages/*"
             ],
             "devDependencies": {
-                "@floating-ui/dom": "^1.5.3",
                 "axios": "^0.21.1",
                 "chalk": "^4.1.1",
                 "cypress": "^7.0.0",
                 "cypress-plugin-tab": "^1.0.5",
                 "dot-json": "^1.2.2",
                 "esbuild": "~0.16.17",
-                "jest": "^26.6.3",
-                "sortablejs": "^1.15.2"
+                "jest": "^26.6.3"
             }
         },
         "node_modules/@alpinejs/anchor": {
@@ -1032,7 +1030,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
             "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
-            "dev": true,
             "dependencies": {
                 "@floating-ui/utils": "^0.1.3"
             }
@@ -1041,7 +1038,6 @@
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
             "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
-            "dev": true,
             "dependencies": {
                 "@floating-ui/core": "^1.4.2",
                 "@floating-ui/utils": "^0.1.3"
@@ -1050,8 +1046,7 @@
         "node_modules/@floating-ui/utils": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-            "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
-            "dev": true
+            "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -6846,8 +6841,7 @@
         "node_modules/sortablejs": {
             "version": "1.15.2",
             "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
-            "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA==",
-            "dev": true
+            "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -7870,7 +7864,7 @@
             }
         },
         "packages/alpinejs": {
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7878,17 +7872,20 @@
         },
         "packages/anchor": {
             "name": "@alpinejs/anchor",
-            "version": "3.14.4",
-            "license": "MIT"
+            "version": "3.14.8",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.5.3"
+            }
         },
         "packages/collapse": {
             "name": "@alpinejs/collapse",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT"
         },
         "packages/csp": {
             "name": "@alpinejs/csp",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -7896,12 +7893,12 @@
         },
         "packages/docs": {
             "name": "@alpinejs/docs",
-            "version": "3.14.4-revision.1",
+            "version": "3.14.8-revision.1",
             "license": "MIT"
         },
         "packages/focus": {
             "name": "@alpinejs/focus",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT",
             "dependencies": {
                 "focus-trap": "^6.9.4",
@@ -7918,17 +7915,17 @@
         },
         "packages/intersect": {
             "name": "@alpinejs/intersect",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT"
         },
         "packages/mask": {
             "name": "@alpinejs/mask",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT"
         },
         "packages/morph": {
             "name": "@alpinejs/morph",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT"
         },
         "packages/navigate": {
@@ -7941,22 +7938,25 @@
         },
         "packages/persist": {
             "name": "@alpinejs/persist",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT"
         },
         "packages/resize": {
             "name": "@alpinejs/resize",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT"
         },
         "packages/sort": {
             "name": "@alpinejs/sort",
-            "version": "3.14.4",
-            "license": "MIT"
+            "version": "3.14.8",
+            "license": "MIT",
+            "dependencies": {
+                "sortablejs": "^1.15.2"
+            }
         },
         "packages/ui": {
             "name": "@alpinejs/ui",
-            "version": "3.14.4",
+            "version": "3.14.8",
             "license": "MIT",
             "devDependencies": {}
         }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,13 @@
         "packages/*"
     ],
     "devDependencies": {
-        "@floating-ui/dom": "^1.5.3",
         "axios": "^0.21.1",
         "chalk": "^4.1.1",
         "cypress": "^7.0.0",
         "cypress-plugin-tab": "^1.0.5",
         "dot-json": "^1.2.2",
         "esbuild": "~0.16.17",
-        "jest": "^26.6.3",
-        "sortablejs": "^1.15.2"
+        "jest": "^26.6.3"
     },
     "scripts": {
         "build": "node ./scripts/build.js",

--- a/packages/anchor/package.json
+++ b/packages/anchor/package.json
@@ -13,5 +13,7 @@
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
-    "dependencies": {}
+    "dependencies": {
+        "@floating-ui/dom": "^1.5.3"
+    }
 }

--- a/packages/sort/package.json
+++ b/packages/sort/package.json
@@ -11,5 +11,8 @@
     "author": "Caleb Porzio",
     "license": "MIT",
     "main": "dist/module.cjs.js",
-    "module": "dist/module.esm.js"
+    "module": "dist/module.esm.js",
+    "dependencies": {
+        "sortablejs": "^1.15.2"
+    }
 }


### PR DESCRIPTION
package specific dependencies should always be defined inside the package, not in the monorepo root

in normal npm package scenario this would lead to the errors, but since all stuff, including external dependencies is bundled, esbuild can "borrow" the missing deps from the root, hiding the underlying problem

this PR is meant to move the deps into their correct places, so later on, hopefully, the bundling can be disabled, and the npm packages, will become actual npm packages, not CDN-ish builds, but served using NPM