### PR TITLE
Added new modifier to Focus plugin

### DIFF
--- a/packages/docs/src/en/plugins/focus.md
+++ b/packages/docs/src/en/plugins/focus.md
@@ -308,10 +308,10 @@ By default, when `x-trap` traps focus within an element, it focuses the first fo
 
 By adding `.noautofocus`, Alpine will not automatically focus any elements when trapping focus.
 
-<a name="preventscroll"></a>
-#### .preventscroll
+<a name="nofocusscroll"></a>
+#### .nofocusscroll
 
-By default, when `x-trap` activates, it will scroll to the currently focused element inside its content. Adding `.preventscroll` disables this behavior.
+By default, when `x-trap` activates, it will scroll to the currently focused element inside its content. Adding `.nofocusscroll` disables this behavior.
 
 For example:
 
@@ -319,7 +319,7 @@ For example:
 <div x-data="{ open: false }">
     <button @click="open = true">Open Dialog</button>
 
-    <div x-show="open" x-trap.preventscroll="open">
+    <div x-show="open" x-trap.nofocusscroll="open">
         Dialog Contents
         
         <input type="text" name="your_name" autofocus>

--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -116,7 +116,7 @@ export default function (Alpine) {
                 if (autofocusEl) options.initialFocus = autofocusEl
             }
 
-            if (modifiers.includes('preventscroll')) {
+            if (modifiers.includes('nofocusscroll')) {
                 options.preventScroll = true
             }
 

--- a/tests/cypress/integration/plugins/focus.spec.js
+++ b/tests/cypress/integration/plugins/focus.spec.js
@@ -462,12 +462,12 @@ test('x-trap handles dynamically added focusable elements',
     },
 )
 
-test('can trap focus with preventscroll',
+test('can trap focus with nofocusscroll',
     [html`
         <div x-data="{ open: false }">
             <button id="open" @click="open = true">open</button>
 
-            <div x-trap.preventscroll="open" style="height: 100px; overflow: auto;">
+            <div x-trap.nofocusscroll="open" style="height: 100px; overflow: auto;">
                 <div style="height: 300px;"></div>
                 <button id="inside">inside</button>
             </div>
@@ -475,7 +475,7 @@ test('can trap focus with preventscroll',
     `],
     ({ get }) => {
         get('#open').click()
-        get('[x-trap\\.preventscroll]').should(($el) => {
+        get('[x-trap\\.nofocusscroll]').should(($el) => {
             expect($el[0].scrollTop).to.equal(0)
         })
     },


### PR DESCRIPTION
Underlaying focus-trap library supports disabling the scroll to currently focussed element.

This specific usecase is required in my case for Filament which uses Livewire/Alpine under the hood for its modals.

If you have a very lenghty modal with a vertical scrollbar for its content, and you have a focussed element outside your viewport and you click anywhere in the modal (thus blurring the element triggering some Livewire changes) the x-trap gets re-initialized and automatically scrolls you to the focussed element.

This PR adds a new modifier (incl its docs) which effectively sets preventScroll in the options of the underlaying focus-trap instance. 

See also: https://github.com/focus-trap/focus-trap#:~:text=and%20selector%20strings.-,preventScroll,-%7Bboolean%7D%3A%20By 