### PR TITLE
Add `ignore-nullish` modifier to `x-html` and `x-text`

### DIFF
--- a/packages/alpinejs/src/directives/x-html.js
+++ b/packages/alpinejs/src/directives/x-html.js
@@ -2,18 +2,22 @@ import { directive } from '../directives'
 import { initTree } from '../lifecycle'
 import { mutateDom } from '../mutation'
 
-directive('html', (el, { expression }, { effect, evaluateLater }) => {
+directive('html', (el, { expression, modifiers }, { effect, evaluateLater }) => {
     let evaluate = evaluateLater(expression)
 
     effect(() => {
         evaluate(value => {
-            mutateDom(() => {
-                el.innerHTML = value
+            value = value ?? null;
 
-                el._x_ignoreSelf = true
-                initTree(el)
-                delete el._x_ignoreSelf
-            })
+            if (!modifiers.includes('ignore-nullish') || value !== null) {
+                mutateDom(() => {
+                    el.innerHTML = value
+    
+                    el._x_ignoreSelf = true
+                    initTree(el)
+                    delete el._x_ignoreSelf
+                })    
+            }
         })
     })
 })

--- a/packages/alpinejs/src/directives/x-text.js
+++ b/packages/alpinejs/src/directives/x-text.js
@@ -1,14 +1,18 @@
 import { directive } from '../directives'
 import { mutateDom } from '../mutation'
 
-directive('text', (el, { expression }, { effect, evaluateLater }) => {
+directive('text', (el, { expression, modifiers }, { effect, evaluateLater }) => {
     let evaluate = evaluateLater(expression)
 
     effect(() => {
         evaluate(value => {
-            mutateDom(() => {
-                el.textContent = value
-            })
+            value = value ?? null;
+
+            if (!modifiers.includes('ignore-nullish') || value !== null) {
+                mutateDom(() => {
+                    el.textContent = value
+                })    
+            }
         })
     })
 })

--- a/packages/docs/src/en/directives/html.md
+++ b/packages/docs/src/en/directives/html.md
@@ -27,3 +27,25 @@ Here's a basic example of using `x-html` to display a user's username.
 <!-- END_VERBATIM -->
 
 Now the `<span>` tag's inner HTML will be set to "<strong>calebporzio</strong>".
+
+<a name="modifiers"></a>
+## Modifiers
+
+<a name="ignore-nullish"></a>
+### .ignore-nullish
+
+`.ignore-nullish` will ignore the value if it resolves to `null` or `undefined` and retain the currently set HTML.
+
+```alpine
+<section x-data="{ items: null }">
+    <ul x-html.ignore-nullish="items">
+        <li>
+            <em>Not loaded yet...</em>
+        </li>
+    </ul>
+
+    <button x-on:click="items = '<li>First item</li><li>Second item</li>'">Load Items</button>
+</section>
+```
+
+In the above example, with the `.ignore-nullish`, when the page finished loading it will retain the "Not loaded yet" HTML. Clicking the button will then replace that HTML with the list items.

--- a/packages/docs/src/en/directives/text.md
+++ b/packages/docs/src/en/directives/text.md
@@ -24,3 +24,21 @@ Here's a basic example of using `x-text` to display a user's username.
 <!-- END_VERBATIM -->
 
 Now the `<strong>` tag's inner text content will be set to "calebporzio".
+
+<a name="modifiers"></a>
+## Modifiers
+
+<a name="ignore-nullish"></a>
+### .ignore-nullish
+
+`.ignore-nullish` will ignore the value if it resolves to `null` or `undefined` and retain the currently set text.
+
+```alpine
+<section x-data="{ title: null }">
+    <h1 x-text.ignore-nullish="title">Not loaded yet</h1>
+
+    <button x-on:click="title = 'Loaded Title'">Load Title</button>
+</section>
+```
+
+In the above example, with the `.ignore-nullish`, when the page finished loading it will retain the "Not loaded yet" text. Clicking the button will then replace that text with the title.

--- a/tests/cypress/integration/directives/x-html.spec.js
+++ b/tests/cypress/integration/directives/x-html.spec.js
@@ -49,3 +49,23 @@ test('x-html runs even after x-if or x-for',
         get('span').should(haveText('bar'))
     }
 )
+
+test('x-html ignores nullish values when requested',
+    html`
+        <div x-data="{ html: '<span x-text=&quot;foo&quot;></span>', foo: 'bar', baz: 'quux', nullishHtml: null }">
+            <header x-html.ignore-nullish="html"></header>
+            <section x-html.ignore-nullish="nullishHtml">original html</section>
+
+            <button x-on:click="(html = null) || (nullishHtml = '<h3 x-text=&quot;baz&quot;></h3>')"
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('section').should(haveText('original html'))
+
+        get('button').click()
+
+        get('span').should(haveText('bar'))
+        get('h3').should(haveText('quux'))
+    }
+)

--- a/tests/cypress/integration/directives/x-text.spec.js
+++ b/tests/cypress/integration/directives/x-text.spec.js
@@ -34,3 +34,21 @@ test('sets text on SVG elements',
     `,
     ({ get }) => get('svg text').should(haveText('bar'))
 )
+
+test('ignores nullish values when requested',
+    html`
+        <div x-data="{ foo: null, baz: 'quux' }">
+            <button x-on:click="(foo = 'bar') && (baz = null)">Show "bar"</button>
+
+            <span x-text.ignore-nullish="foo">not set yet</span>
+            <section x-text.ignore-nullish="baz">not set yet</section>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('not set yet'))
+        get('section').should(haveText('quux'))
+        get('button').click()
+        get('span').should(haveText('bar'))
+        get('section').should(haveText('quux'))
+    }
+)


### PR DESCRIPTION
This add an `ignore-nullish` modifier to `x-html` and `x-text`. If the value is set to `null` or `undefined`, the currently set HTML/text will remain unchanged.

The main use case for this is to have the initial HTML/text set in the markup on page load.  See the updates to the documentation for examples.