### PR TITLE
[docs] Update mask.md: adding "x-data" to the mask plugin examples

### DIFF
--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -69,7 +69,7 @@ The primary API for using this plugin is the `x-mask` directive.
 Let's start by looking at the following simple example of a date field:
 
 ```alpine
-<input x-mask="99/99/9999" placeholder="MM/DD/YYYY">
+<input x-data x-mask="99/99/9999" placeholder="MM/DD/YYYY">
 ```
 
 <!-- START_VERBATIM -->
@@ -97,7 +97,7 @@ Sometimes simple mask literals (i.e. `(999) 999-9999`) are not sufficient. In th
 Here's an example of a credit card input that needs to change it's mask based on if the number starts with the numbers "34" or "37" (which means it's an Amex card and therefore has a different format).
 
 ```alpine
-<input x-mask:dynamic="
+<input x-data x-mask:dynamic="
     $input.startsWith('34') || $input.startsWith('37')
         ? '9999 999999 99999' : '9999 9999 9999 9999'
 ">
@@ -119,7 +119,7 @@ Try it for yourself by typing a number that starts with "34" and one that doesn'
 `x-mask:dynamic` also accepts a function as a result of the expression and will automatically pass it the `$input` as the first parameter. For example:
 
 ```alpine
-<input x-mask:dynamic="creditCardMask">
+<input x-data x-mask:dynamic="creditCardMask">
 
 <script>
 function creditCardMask(input) {
@@ -139,7 +139,7 @@ Because writing your own dynamic mask expression for money inputs is fairly comp
 Here is a fully functioning money input mask:
 
 ```alpine
-<input x-mask:dynamic="$money($input)">
+<input x-data x-mask:dynamic="$money($input)">
 ```
 
 <!-- START_VERBATIM -->
@@ -151,7 +151,7 @@ Here is a fully functioning money input mask:
 If you wish to swap the periods for commas and vice versa (as is required in certain currencies), you can do so using the second optional parameter:
 
 ```alpine
-<input x-mask:dynamic="$money($input, ',')">
+<input x-data x-mask:dynamic="$money($input, ',')">
 ```
 
 <!-- START_VERBATIM -->
@@ -163,7 +163,7 @@ If you wish to swap the periods for commas and vice versa (as is required in cer
 You may also choose to override the thousands separator by supplying a third optional argument:
 
 ```alpine
-<input x-mask:dynamic="$money($input, '.', ' ')">
+<input x-data x-mask:dynamic="$money($input, '.', ' ')">
 ```
 
 <!-- START_VERBATIM -->
@@ -176,7 +176,7 @@ You may also choose to override the thousands separator by supplying a third opt
 You can also override the default precision of 2 digits by using any desired number of digits as the fourth optional argument:
 
 ```alpine
-<input x-mask:dynamic="$money($input, '.', ',', 4)">
+<input x-data x-mask:dynamic="$money($input, '.', ',', 4)">
 ```
 
 <!-- START_VERBATIM -->


### PR DESCRIPTION
Hello, Caleb and Alpine crew.

After trying for some time to make the mask plugin work on my setup (I use it with both the Livewire bundled version and the standalone one), I could only make it work after reading this discussion, specifically this comment:

https://github.com/alpinejs/alpine/discussions/2920#discussioncomment-4831861
> hello bro i found the fix problem by adding x-data attribute
> 
> according to this article
> 
> ```
> <div class="w-full" >
> <input wire:model.defer="budget" x-data x-mask:dynamic="$money($input)" class="input input-bordered w-full" type="text" name="budget" id="budget">
> </div>
> ```
> 
> https://justinbyrne.dev/blog/2022/5/22/masking-input-fields-with-alpinejs
> 
> hope it help

After putting the x-data, everything started to work as it should. I then wondered why the docs examples did not use the x-data in the HTML, so I decided to create this PR.

Fun-fact: The docs themselves use alpine and the "live-code" examples in the md file *do use* the x-data attribute alongside x-mask:

![image](https://github.com/user-attachments/assets/ca0d68a5-a298-4a39-855e-6cd9f1a5bf36)

So, this is the motivation for this PR. =) 
