### PR TITLE
Fix invalid error on empty `x-data` in CSP Build

### DIFF
--- a/packages/csp/src/evaluator.js
+++ b/packages/csp/src/evaluator.js
@@ -30,7 +30,7 @@ function generateEvaluator(el, expression, dataStack) {
 
         let evaluatedExpression = expression.split('.').reduce(
             (currentScope, currentExpression) => {
-                if (currentScope[currentExpression] === undefined) {
+                if (currentExpression !== '{}' && currentScope[currentExpression] === undefined) {
                     throwExpressionError(el, expression)
                 }
 


### PR DESCRIPTION
This fixes the bug I reported here: https://github.com/alpinejs/alpine/discussions/4603