### PR TITLE
Add support for custom options and cancelable `$dispatch`

### DIFF
--- a/packages/alpinejs/src/utils/dispatch.js
+++ b/packages/alpinejs/src/utils/dispatch.js
@@ -1,12 +1,14 @@
 
-export function dispatch(el, name, detail = {}) {
-    el.dispatchEvent(
+export function dispatch(el, name, detail = {}, options = {}) {
+    return el.dispatchEvent(
         new CustomEvent(name, {
             detail,
             bubbles: true,
             // Allows events to pass the shadow DOM barrier.
             composed: true,
             cancelable: true,
+            // Allows overriding the default event options.
+            ...options
         })
     )
 }

--- a/packages/docs/src/en/magics/dispatch.md
+++ b/packages/docs/src/en/magics/dispatch.md
@@ -104,3 +104,42 @@ You can also use `$dispatch()` to trigger data updates for `x-model` data bindin
 ```
 
 This opens up the door for making custom input components whose value can be set via `x-model`.
+
+<a name="cancelable-events"></a>
+## Cancelable events
+
+You can use the returned value of `$dispatch` to check if the event was canceled or not. This is useful when you want to prevent the default behavior of an action.
+
+```alpine
+<div x-data x-on:open="$event.preventDefault()">
+    <div x-data="{ open: false }">
+        <button @click="if($dispatch('open')){ open = true; }">Click me</button>
+        <!-- When the button is pressed an event is dispatched and only if the result is truthy (not prevented by any handler) the content will be shown. -->
+        
+        <div x-show="open">
+            <h1>Hello</h1>
+        </div>
+    </div>
+</div>
+```
+
+This could be useful when you want to prevent opening/closing a modal or something like that by using event handlers.
+
+<a name="overwriting-options"></a>
+## Overwriting options
+
+You can use the third parameter of `$dispatch` to overwrite the default options of the event. For example, you can set `bubbles` to `false`:
+
+```alpine
+<!-- 🚫 Won't work because the event is being listened on the parent element -->
+<div x-data="{ title: 'Hello' }" x-on:update-title="title = $event.detail">
+    <button @click="$dispatch('update-title', 'Hello World!', {bubbles: false})">Click me</button>
+</div>
+
+<!-- ✅ Will work because the event is being listened on the same element -->
+<div x-data="{ title: 'Hello' }">
+    <button x-on:update-title="title = $event.detail" @click="$dispatch('update-title', 'Hello World!', {bubbles: false})">Click me</button>
+</div>
+```
+
+This is useful when you want to prevent the event from bubbling up to the parent elements.

--- a/tests/cypress/integration/magics/$dispatch.spec.js
+++ b/tests/cypress/integration/magics/$dispatch.spec.js
@@ -14,3 +14,53 @@ test('$dispatch dispatches events properly',
         get('span').should(haveText('baz'))
     }
 )
+
+test('$dispatch with bubbles overwrite to false shouldn\'t bubble (event handling on parent)',
+    html`
+        <div x-data="{ foo: 'bar' }" x-on:custom-event="foo = $event.detail.newValue">
+            <span x-text="foo"></span>
+
+            <button x-on:click="$dispatch('custom-event', {newValue: 'baz'}, {bubbles: false})">click me</button>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('button').click()
+        get('span').should(haveText('bar'))
+    }
+)
+
+test('$dispatch with bubbles overwrite to false shouldn\'t bubble (event handling on same element)',
+    html`
+        <div x-data="{ foo: 'bar' }">
+            <span x-text="foo"></span>
+
+            <button
+                x-on:custom-event="foo = $event.detail.newValue"
+                x-on:click="$dispatch('custom-event', {newValue: 'baz'}, {bubbles: false})">click me</button>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('button').click()
+        get('span').should(haveText('baz'))
+    }
+)
+
+test('$dispatch cancelable should be cancelable by $event.preventDefault()',
+    html`
+        <div x-data="{ foo: 'bar' }"
+             x-on:prevented-event="$event.preventDefault()">
+            <span x-text="foo"></span>
+
+            <button x-on:click="if($dispatch('not-prevented-event')){ foo = 'baz'; } if($dispatch('prevented-event')){ foo = 'bar'; }">
+                click me
+            </button>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('button').click()
+        get('span').should(haveText('baz'))
+    }
+)


### PR DESCRIPTION
### Proposal: Extend $dispatch Functionality
Hello everyone,
While working with AlpineJS to build a UI library for Laravel, I noticed some limitations in the magic function $dispatch. Specifically:

1. It doesn't allow extended options.
2. It doesn’t support proper cancellation via preventDefault.

These limitations can lead to issues when building modular, event-driven components. Below, I explain the motivation and propose a minimal enhancement.

## Problem Overview
1. Lack of Extendable Options
Currently, it's not possible to customize event behavior (e.g., disabling **bubbles**). This becomes problematic in cases like:

A modal and a dropdown both dispatching an event named `closed`.
When used together, the parent modal might unintentionally respond to the dropdown's event, causing conflicts.

Yes, we could rename events (e.g., `modal:closed` vs. `dropdown:closed`), but this doesn't solve issues with nested modals or more complex component structures.

2. Non-Cancelable in Practice
Although dispatched events are marked as `cancelable: true`, the function does not return the created CustomEvent.
As a result, it's not possible to check whether preventDefault() was called.

This prevents useful patterns like:

```
const event = $dispatch('close');
if (event) {
    // Proceed to close the modal
}
```

This kind of control is useful for building modular components.

## Proposed Solution
The required change is minimal:

1. Add support for a third parameter in $dispatch for passing native CustomEvent options (like **bubbles**, etc.).
2. Return the CustomEvent instance from $dispatch so developers can inspect and control event behavior.

## Benefits
Prevents event conflicts across nested or reused components.
Enables advanced workflows like conditional UI actions based on event handling.
Maintains backward compatibility while giving developers more flexibility and control.
