### PR TITLE
feat: `x-on.passive.false` modifier

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -14,10 +14,13 @@ export default function on (el, event, modifiers, callback) {
 
     if (modifiers.includes("dot")) event = dotSyntax(event)
     if (modifiers.includes('camel')) event = camelCase(event)
-    if (modifiers.includes('passive')) options.passive = true
     if (modifiers.includes('capture')) options.capture = true
     if (modifiers.includes('window')) listenerTarget = window
     if (modifiers.includes('document')) listenerTarget = document
+
+    if (modifiers.includes('passive')) {
+        options.passive = modifiers[modifiers.indexOf('passive')+1] !== 'false'
+    }
 
     // By wrapping the handler with debounce & throttle first, we ensure that the wrapping logic itself is not
     // throttled/debounced, only the user's callback is. This way, if the user expects
@@ -73,7 +76,7 @@ export default function on (el, event, modifiers, callback) {
             if (isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers)) {
                 return
             }
-            
+
             next(e)
         })
     }

--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -343,6 +343,15 @@ If you are listening for touch events, it's important to add `.passive` to your 
 
 [→ Read more about passive listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners)
 
+<a name="passive-false"></a>
+### .passive.false
+
+In modern browsers, `wheel` and `touchmove` event listeners are passive by default. Pass `.passive.false` to make these events cancelable, so that you can call `preventDefault` on them.
+
+```alpine
+<div @touchstart.passive.false="console.log($event.cancelable)">...</div>
+```
+
 ### .capture
 
 Add this modifier if you want to execute this listener in the event's capturing phase, e.g. before the event bubbles from the target element up the DOM.

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -60,7 +60,7 @@ test('nested data modified in event listener updates affected attribute bindings
     }
 )
 
-test('.passive modifier should disable e.preventDefault()',
+test.only('.passive modifier should disable e.preventDefault()',
     html`
         <div x-data="{ defaultPrevented: null }">
             <button
@@ -76,6 +76,23 @@ test('.passive modifier should disable e.preventDefault()',
     ({ get }) => {
         get('button').click()
         get('div').should(haveData('defaultPrevented', false))
+    }
+)
+
+test.only('.passive.false modifier should enable e.preventDefault()',
+    html`
+        <div
+            x-data="{ defaultPrevented: null }"
+            x-on:touchmove.passive.false="
+                $event.preventDefault();
+                defaultPrevented = $event.defaultPrevented;
+            ">
+            <br>
+        </div>
+    `,
+    ({ get }) => {
+        get('div').trigger('touchmove')
+        get('div').should(haveData('defaultPrevented', true))
     }
 )
 


### PR DESCRIPTION
Replaces #4404 

Make events that are passive by default cancelable:

```html
<div x-on.touchmove.passive.false="console.log($event.cancelable)"></div>
```

### Use Case

Detect the axis of a `touchmove` gesture and call `preventDefault` if it's the x-axis (useful for preventing document scolling if interacting with a slider).


