### PR TITLE
feat(persist): add 'exports' field for proper ESM/CJS resolution

### DIFF
--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -14,8 +14,8 @@
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
     "exports": {
-      "import": "./dist/module.esm.js",
-      "require": "./dist/module.cjs.js"
+        "import": "./dist/module.esm.js",
+        "require": "./dist/module.cjs.js"
     },
     "dependencies": {}
 }

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -13,5 +13,9 @@
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
+    "exports": {
+      "import": "./dist/module.esm.js",
+      "require": "./dist/module.cjs.js"
+    },
     "dependencies": {}
 }


### PR DESCRIPTION
Hi, there. Thank you for the awesome project! I'd like to propose the following change:
- What: add "exports" field to package.json, mapping ESM to ./dist/module.esm.js and CJS to ./dist/module.cjs.js
- Why: tools like Vite default to main when exports is absent, causing CJS to be used in dev server and breaking default export detection.
- How: update package.json, built & tested locally with Vite and Node (import/require).
- Backward compatibility: keeps existing main & module fields.