### PR TITLE
Fix Chrome warning when using `x-trap.inert`

### DIFF
--- a/packages/focus/src/index.js
+++ b/packages/focus/src/index.js
@@ -108,6 +108,8 @@ export default function (Alpine) {
                 fallbackFocus: () => el,
             }
 
+            let undoInert = () => {}
+
             if (modifiers.includes('noautofocus')) {
                 options.initialFocus = false
             } else {
@@ -116,9 +118,16 @@ export default function (Alpine) {
                 if (autofocusEl) options.initialFocus = autofocusEl
             }
 
+            if (modifiers.includes('inert')) {
+                options.onPostActivate = () => {
+                    Alpine.nextTick(() => {
+                        undoInert = setInert(el);
+                    });
+                }
+            }
+
             let trap = createFocusTrap(el, options)
 
-            let undoInert = () => {}
             let undoDisableScrolling = () => {}
 
             const releaseFocus = () => {
@@ -139,7 +148,6 @@ export default function (Alpine) {
                 // Start trapping.
                 if (value && ! oldValue) {
                     if (modifiers.includes('noscroll')) undoDisableScrolling = disableScrolling()
-                    if (modifiers.includes('inert')) undoInert = setInert(el)
 
                     // Activate the trap after a generous tick. (Needed to play nice with transitions...)
                     setTimeout(() => {


### PR DESCRIPTION
Related discussion: https://github.com/alpinejs/alpine/discussions/4634

In recent versions of Chromium, using the `inert` modifier with `x-trap` results in this warning:

> Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden.

![CleanShot 2025-06-12 at 18 08 39@2x](https://github.com/user-attachments/assets/9f5b48a7-b5fe-4f03-9ea6-8654327f3572)

Here’s a minimal reproduction:
https://codepen.io/magiclantern/pen/vEOjaVg/9827b04ae16fffe57feb1f762870aeaa

This seems to happen because `aria-hidden` is applied by the Focus plugin _before_ focus is trapped in the new container. 

This PR moves the call to `setInert()` into `focus-trap`’s [`onPostActivate` callback](https://github.com/focus-trap/focus-trap?tab=readme-ov-file#createoptions), where it runs after a tick.

Another solution would be to replace `aria-hidden="true"` with `inert`, but [Safari compatibility for `inert` is only >= 15.5](https://caniuse.com/?search=inert), which may not be sufficient? Perhaps it could be an option, but I couldn’t come up with a good / short enough name for a modifier.