### PR TITLE
Add support for Set objects in x-for loop function

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -53,6 +53,10 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
 
         if (items === undefined) items = []
 
+        // Support Set and Map objects by converting to arrays.
+        if (items instanceof Set) items = Array.from(items)
+        if (items instanceof Map) items = Array.from(items)
+
         let lookup = el._x_lookup
         let prevKeys = el._x_prevKeys
         let scopes = []
@@ -62,13 +66,6 @@ function loop(el, iteratorNames, evaluateItems, evaluateKey) {
         // we need to generate all the keys for every iteration up
         // front. These will be our source of truth for diffing.
         if (isObject(items)) {
-            // Support Set object, convert into key value
-            if (items instanceof Set) {
-                items = Object.fromEntries(
-                    Array.from(items).map((value, key) => [key, value])
-                );
-            }
-
             items = Object.entries(items).map(([key, value]) => {
                 let scope = getIterationScopeVariables(iteratorNames, value, key, items)
 

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -606,6 +606,34 @@ test('x-for throws descriptive error when key is undefined',
     true
 )
 
+test('iterates over a Set',
+    html`
+        <div x-data="{ items: new Set(['foo', 'bar']) }">
+            <template x-for="item in items">
+                <span x-text="item"></span>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('foo'))
+        get('span:nth-of-type(2)').should(haveText('bar'))
+    }
+)
+
+test('iterates over a Map',
+    html`
+        <div x-data="{ items: new Map([['a', 'foo'], ['b', 'bar']]) }">
+            <template x-for="[key, value] in items">
+                <span x-text="key + ':' + value"></span>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('a:foo'))
+        get('span:nth-of-type(2)').should(haveText('b:bar'))
+    }
+)
+
 // If x-for removes a child, all cleanups in the tree should be handled.
 test('x-for eagerly cleans tree',
     html`


### PR DESCRIPTION
### Description

<!-- Explain what you are trying to achieve with this PR -->

`x-for` doesn't handle `Set`.
We are using `Object.entries(items)`. `Set` does not store values as enumerable object keys.

This PR adds the `x-for` to convert into key-value if the `items` is a `Set` object, then pass it into the existing `Object.entries(items)`.

### References

<!--
Add references to other documents/pages that are relevant to this
PR, such as related issues, documentation, etc.
-->

* https://github.com/alpinejs/alpine/discussions/4664