### PR TITLE
fix(docs): initialise data, fix typo in x-on example

### DIFF
--- a/packages/docs/src/en/directives/on.md
+++ b/packages/docs/src/en/directives/on.md
@@ -113,8 +113,9 @@ Here's an example of a button that changes behaviour when the `Shift` key is hel
 
 ```alpine
 <button type="button"
+    x-data="{ message: 'select' }"
     @click="message = 'selected'"
-    @click.shift="message = 'added to selection'">
+    @click.shift="message = 'added to selection'"
     @mousemove.shift="message = 'add to selection'"
     @mouseout="message = 'select'"
     x-text="message"></button>
@@ -124,6 +125,7 @@ Here's an example of a button that changes behaviour when the `Shift` key is hel
 <div class="demo">
     <div x-data="{ message: '' }">
         <button type="button"
+            x-data="{ message: 'select' }"
             @click="message = 'selected'"
             @click.shift="message = 'added to selection'"
             @mousemove.shift="message = 'add to selection'"


### PR DESCRIPTION
I found an example in the mouse events docs that:

* has an extra ">" between a button's attributes;
* doesn't have an initial label thus barely renders as a button:

<img width="760" height="321" alt="Screenshot 2025-11-08 at 09 15 04" src="https://github.com/user-attachments/assets/2846c05f-dd34-4fee-9239-b5a5e922ae49" />

See https://alpinejs.dev/directives/on#mouse-events