### PR TITLE
update `x-cloak` CSS to allow conditional disabling

### DIFF
--- a/packages/docs/src/en/directives/cloak.md
+++ b/packages/docs/src/en/directives/cloak.md
@@ -12,13 +12,19 @@ Sometimes, when you're using AlpineJS for a part of your template, there is a "b
 For `x-cloak` to work however, you must add the following CSS to the page.
 
 ```css
-[x-cloak] { display: none !important; }
+[x-cloak=""] { display: none !important; }
 ```
 
 The following example will hide the `<span>` tag until its `x-show` is specifically set to true, preventing any "blip" of the hidden element onto screen as Alpine loads.
 
 ```alpine
 <span x-cloak x-show="false">This will not 'blip' onto screen at any point</span>
+```
+
+You can also disable the cloaking by setting the attribute to any non-empty string. This is helpful when you have an element that you know will be visible immediately and don't want it to "blip" in.
+
+```alpine
+<span x-cloak="off" x-show="true">This will show immediately</span>
 ```
 
 `x-cloak` doesn't just work on elements hidden by `x-show` or `x-if`: it also ensures that elements containing data are hidden until the data is correctly set. The following example will hide the `<span>` tag until Alpine has set its text content to the `message` property.


### PR DESCRIPTION
change the suggested `x-cloak` CSS to specifically only target the boolean `x-cloak` attribute or the attribute with an empty string value (`x-cloak=""`).

this means we will no longer target the attribute when it has a non-empty string value (`x-cloak="off"`).

the benefit this gives is we can conditionally disable the cloaking for elements we know will be visible immediately. this prevents a "blip in" from the hidden to visible state.

Here is a Blade example to show how it would work:

```blade
<div
    x-show="jsCondition"
    x-cloak="{{ $condition ? 'off' : '' }}"
>Alpine Rocks</div>
```

this works because, given these elements:

```html
<div x-cloak></div>
<div x-cloak=""></div>
<div x-cloak="off"></div>
```

we get this behavior:

| CSS Selector    | Matches        |
|-----------------|----------------|
| [x-cloak]       | all three      |
| [x-cloak=""]    | first two only |
| [x-cloak="off"] | third only     |

---

This ___is___ already possible by conditionally showing the `x-cloak`, but I think this solution provides a better looking code.

```blade
<div
    x-show="jsCondition"
    @if($condition)
        x-cloak
    @endif
>Alpine Rocks</div>
```