### PR TITLE
feat(x-model): add .change, .blur, and .enter event modifiers

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -55,19 +55,47 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
         })
     }
 
-    // If the element we are binding to is a select, a radio, or checkbox
-    // we'll listen for the change event instead of the "input" event.
-    let event = (el.tagName.toLowerCase() === 'select')
-        || ['checkbox', 'radio'].includes(el.type)
-        || (modifiers.includes('lazy') || modifiers.includes('change'))
-            ? 'change' : 'input'
+    // Check for explicit event modifiers (.change, .blur, .enter)
+    let hasChangeModifier = modifiers.includes('change') || modifiers.includes('lazy')
+    let hasBlurModifier = modifiers.includes('blur')
+    let hasEnterModifier = modifiers.includes('enter')
+    let hasExplicitEventModifiers = hasChangeModifier || hasBlurModifier || hasEnterModifier
 
-    // We only want to register the event listener when we're not cloning, since the
-    // mutation observer handles initializing the x-model directive already when
-    // the element is inserted into the DOM. Otherwise we register it twice.
-    let removeListener = isCloning ? () => {} : on(el, event, modifiers, (e) => {
-        setValue(getInputValue(el, modifiers, e, getValue()))
-    })
+    let removeListener
+
+    if (isCloning) {
+        removeListener = () => {}
+    } else if (hasExplicitEventModifiers) {
+        // When explicit event modifiers are present, attach listeners for each specified event
+        let listeners = []
+
+        let syncValue = (e) => setValue(getInputValue(el, modifiers, e, getValue()))
+
+        if (hasChangeModifier) {
+            listeners.push(on(el, 'change', modifiers, syncValue))
+        }
+
+        if (hasBlurModifier) {
+            listeners.push(on(el, 'blur', modifiers, syncValue))
+        }
+
+        if (hasEnterModifier) {
+            listeners.push(on(el, 'keydown', modifiers, (e) => {
+                if (e.key === 'Enter') syncValue(e)
+            }))
+        }
+
+        removeListener = () => listeners.forEach(remove => remove())
+    } else {
+        // Default behavior: select, checkbox, radio use 'change', others use 'input'
+        let event = (el.tagName.toLowerCase() === 'select')
+            || ['checkbox', 'radio'].includes(el.type)
+                ? 'change' : 'input'
+
+        removeListener = on(el, event, modifiers, (e) => {
+            setValue(getInputValue(el, modifiers, e, getValue()))
+        })
+    }
 
     if (modifiers.includes('fill'))
         if ([undefined, null, ''].includes(getValue())

--- a/packages/docs/src/en/directives/model.md
+++ b/packages/docs/src/en/directives/model.md
@@ -320,6 +320,58 @@ This is handy for things like real-time form-validation where you might not want
 <span x-show="username.length > 20">The username is too long.</span>
 ```
 
+<a name="change"></a>
+### `.change`
+
+`.change` syncs the data only when the input loses focus and its value has changed (the native `change` event). This is functionally equivalent to `.lazy`.
+
+```alpine
+<input type="text" x-model.change="username">
+```
+
+<a name="blur"></a>
+### `.blur`
+
+`.blur` syncs the data when the input loses focus, regardless of whether the value has changed.
+
+```alpine
+<input type="text" x-model.blur="email">
+```
+
+<a name="enter"></a>
+### `.enter`
+
+`.enter` syncs the data when the user presses the Enter key. This is useful for search fields where you want to trigger an action only when the user explicitly submits.
+
+```alpine
+<input type="text" x-model.enter="search">
+```
+
+> Note: `.enter` does not prevent the default behavior. If the input is inside a form, the form will still submit.
+
+<a name="combining-event-modifiers"></a>
+### Combining Event Modifiers
+
+The `.change`, `.blur`, and `.enter` modifiers can be combined to sync on multiple events. This is useful when you want to give users flexibility in how they submit data.
+
+```alpine
+<!-- Sync on blur OR enter -->
+<input type="text" x-model.blur.enter="search" placeholder="Press Enter or click away">
+
+<!-- Sync on change, blur, OR enter -->
+<input type="text" x-model.change.blur.enter="message">
+```
+
+<!-- START_VERBATIM -->
+<div class="demo">
+    <div x-data="{ search: '' }">
+        <input type="text" x-model.blur.enter="search" placeholder="Press Enter or click away">
+
+        <div class="pt-4">Search: <span x-text="search"></span></div>
+    </div>
+</div>
+<!-- END_VERBATIM -->
+
 <a name="number"></a>
 ### `.number`
 

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -506,3 +506,105 @@ test(
     }
 );
 
+test('x-model.change only updates on change event',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.change="foo">
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('bar')
+        get('span').should(haveText(''))
+        get('input').blur()
+        get('span').should(haveText('bar'))
+    }
+)
+
+test('x-model.blur only updates on blur event',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.blur="foo">
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('bar')
+        get('span').should(haveText(''))
+        get('input').blur()
+        get('span').should(haveText('bar'))
+    }
+)
+
+test('x-model.enter only updates on enter keypress',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.enter="foo">
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('bar')
+        get('span').should(haveText(''))
+        get('input').type('{enter}')
+        get('span').should(haveText('bar'))
+    }
+)
+
+test('x-model.change.blur updates on both change and blur',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.change.blur="foo">
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('bar')
+        get('span').should(haveText(''))
+        get('input').blur()
+        get('span').should(haveText('bar'))
+    }
+)
+
+test('x-model.change.blur.enter updates on any of the three events',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.change.blur.enter="foo">
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        // Test enter
+        get('span').should(haveText(''))
+        get('input').type('bar')
+        get('span').should(haveText(''))
+        get('input').type('{enter}')
+        get('span').should(haveText('bar'))
+        // Clear and test blur
+        get('input').clear()
+        get('input').type('baz')
+        get('input').blur()
+        get('span').should(haveText('baz'))
+    }
+)
+
+test('x-model.lazy still works as alias for change',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.lazy="foo">
+        <span x-text="foo"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('bar')
+        get('span').should(haveText(''))
+        get('input').blur()
+        get('span').should(haveText('bar'))
+    }
+)
+


### PR DESCRIPTION
## Overview

By default, `x-model` syncs on every keystroke (`input` event). The existing `.lazy` modifier delays sync until `change`, but there's no way to sync on blur or Enter keypress.

This PR adds three new event modifiers that give you fine-grained control over when `x-model` syncs:

| Modifier | Syncs when... |
|----------|---------------|
| `.change` | Input loses focus after value changed (alias for `.lazy`) |
| `.blur` | Input loses focus |
| `.enter` | User presses Enter |

### Combining modifiers

These modifiers can be combined to sync on multiple events:

```html
<!-- Sync on blur OR Enter -->
<input x-model.blur.enter="search">

<!-- Sync on change, blur, OR Enter -->
<input x-model.change.blur.enter="message">
```

### Use cases

- **Search fields**: Use `.enter` to only search when user presses Enter
- **Form validation**: Use `.blur` to validate when user leaves a field
- **Performance**: Use `.change` to reduce reactivity on large forms

### Notes

- `.enter` does NOT prevent default behavior (forms still submit)
- `.lazy` remains supported as an alias for `.change`
- Default `x-model` behavior is unchanged