### PR TITLE
Flush `x-model.blur` value before form submit handlers run

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -66,6 +66,18 @@ export default function on (el, event, modifiers, callback) {
 
     if (modifiers.includes('self')) handler = wrapHandler(handler, (next, e) => { e.target === el && next(e) })
 
+    // Flush any pending model updates before submit handlers run
+    // (e.g. x-model.blur inputs that haven't synced yet).
+    if (event === 'submit') {
+        handler = wrapHandler(handler, (next, e) => {
+            if (e.target._x_pendingModelUpdates) {
+                e.target._x_pendingModelUpdates.forEach(fn => fn())
+            }
+
+            next(e)
+        })
+    }
+
     // Handle :keydown and :keyup listeners.
     // Handle :click and :auxclick listeners.
     if (isKeyEvent(event) || isClickEvent(event)) {

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -642,3 +642,21 @@ test('x-model.enter.blur updates on enter OR blur (enter should work)',
     }
 )
 
+test('x-model.blur syncs value before form submit handler runs',
+    html`
+    <div x-data="{ value: '', capturedValue: '' }">
+        <form @submit.prevent="capturedValue = value">
+            <input x-model.blur="value" type="text">
+        </form>
+        <span id="captured" x-text="capturedValue"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('input').type('hello')
+        get('#captured').should(haveText(''))
+        // Submit the form without blurring the input first
+        get('form').then(([form]) => form.requestSubmit())
+        get('#captured').should(haveText('hello'))
+    }
+)
+


### PR DESCRIPTION
# The Scenario

When using `x-model.blur` on an input inside a form, submitting the form by pressing Enter from that input does not sync the input's value before the submit handler runs. The handler sees stale (empty) data.

```html
<div x-data="{ name: '' }">
    <form @submit.prevent="console.log('name:', name)">
        <input x-model.blur="name" type="text">
        <button type="submit">Submit</button>
    </form>
</div>
```

# The Problem

The browser fires events in this order when Enter is pressed inside a form input:

1. `keydown` (Enter) on the input
2. `submit` on the form
3. `blur` on the input (only after submit)

Since `blur` fires **after** `submit`, Alpine's `x-model.blur` listener never syncs the value before the `@submit` handler executes. The `.change` and `.enter` modifiers are not affected — the browser fires `change` and `keydown` before `submit`.

# The Solution

When `x-model.blur` is used on an input inside a form, a pending model update callback is registered on the form element (`el.form._x_pendingModelUpdates`). The `on()` event utility then flushes any pending model updates before running submit handlers.

- **`x-model.js`**: When `.blur` is present and the input is inside a form, registers a sync callback on the form element and cleans it up when the directive is removed
- **`on.js`**: When setting up any `submit` event handler, wraps it to flush `_x_pendingModelUpdates` on the form before the handler executes