### PR TITLE
Fix $watch firing callback when primitive value unchanged

### DIFF
--- a/packages/alpinejs/src/reactivity.js
+++ b/packages/alpinejs/src/reactivity.js
@@ -68,16 +68,20 @@ export function watch(getter, callback) {
         JSON.stringify(value)
 
         if (! firstTime) {
-            // We have to queue this watcher as a microtask so that
-            // the watcher doesn't pick up its own dependencies.
-            queueMicrotask(() => {
-                callback(value, oldValue)
+            // For objects, always fire (deep watching may have detected nested changes).
+            // For primitives, only fire if value actually changed.
+            if (typeof value === 'object' || value !== oldValue) {
+                // We have to queue this watcher as a microtask so that
+                // the watcher doesn't pick up its own dependencies.
+                let previousValue = oldValue
 
-                oldValue = value
-            })
-        } else {
-            oldValue = value
+                queueMicrotask(() => {
+                    callback(value, previousValue)
+                })
+            }
         }
+
+        oldValue = value
 
         firstTime = false
     })

--- a/tests/cypress/integration/magics/$watch.spec.js
+++ b/tests/cypress/integration/magics/$watch.spec.js
@@ -150,6 +150,34 @@ test('$watch ignores other dependencies',
 )
 
 
+test('$watch nested property does not fire when parent replaced but value unchanged',
+    html`
+        <div x-data="{ foo: { bar: { baz: 'hello' } }, callCount: 0 }" x-init="
+            $watch('foo.bar.baz', value => { callCount++ });
+        ">
+            <h1 x-text="foo.bar.baz"></h1>
+            <span x-text="callCount"></span>
+
+            <button id="same" x-on:click="foo = { bar: { baz: 'hello' } }"></button>
+            <button id="different" x-on:click="foo = { bar: { baz: 'world' } }"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('h1').should(haveText('hello'))
+        get('span').should(haveText('0'))
+
+        // Replace parent with same nested value - should NOT fire
+        get('button#same').click()
+        get('h1').should(haveText('hello'))
+        get('span').should(haveText('0')) // callCount should still be 0
+
+        // Replace with different value - SHOULD fire
+        get('button#different').click()
+        get('h1').should(haveText('world'))
+        get('span').should(haveText('1')) // callCount should be 1
+    }
+)
+
 test('deep $watch',
     html`
         <div x-data="{ foo: { bar: 'baz'}, bob: 'lob' }" x-init="


### PR DESCRIPTION
## Problem

When using `$watch` on a deeply nested primitive property (e.g., `$watch('foo.bar.baz', callback)`), the callback fires even when the actual value hasn't changed. This happens when you replace a parent object with a new one that contains the same nested value:

```js
Alpine.data('example', () => ({
  foo: { bar: { baz: 'hello' } },

  init() {
    this.$watch('foo.bar.baz', (value) => {
      console.log('changed!') // Fires even when value is still 'hello'
    })
  },

  update() {
    this.foo = { bar: { baz: 'hello' } } // Same value, but callback fires
  }
}))
```

## Investigation

Tested Vue 3's actual runtime behavior to establish the expected behavior:

| Scenario | Vue fires callback? |
|----------|---------------------|
| Watch primitive, replace parent with same value | **No** |
| Watch primitive, replace parent with different value | Yes |
| Watch object, replace with new object (same contents) | Yes |

Vue compares primitives by value and objects by reference.

Alpine's `watch()` function in `reactivity.js` was calling the callback unconditionally whenever the effect re-ran, without comparing old and new values.

## Solution

Added value comparison before firing the callback:

- **Primitives:** Compare with `!==`, skip callback if unchanged
- **Objects:** Always fire (since deep watching via `JSON.stringify` may have detected nested mutations, and object reference comparison would correctly fire for new objects anyway)

```js
if (typeof value === 'object' || value !== oldValue) {
    // fire callback
}
```

Also moved `oldValue` assignment outside the conditional to ensure it's always updated synchronously, preventing stale comparisons on subsequent effect runs.
