### PR TITLE
Add `shouldStopAtNode` callback to `closestDataStack`

### DIFF
--- a/packages/alpinejs/src/scope.js
+++ b/packages/alpinejs/src/scope.js
@@ -15,18 +15,20 @@ export function hasScope(node) {
     return !! node._x_dataStack
 }
 
-export function closestDataStack(node) {
+export function closestDataStack(node, shouldStopAtNode = () => false) {
     if (node._x_dataStack) return node._x_dataStack
 
+    if (shouldStopAtNode(node)) return []
+
     if (typeof ShadowRoot === 'function' && node instanceof ShadowRoot) {
-        return closestDataStack(node.host)
+        return closestDataStack(node.host, shouldStopAtNode)
     }
 
     if (! node.parentNode) {
         return []
     }
 
-    return closestDataStack(node.parentNode)
+    return closestDataStack(node.parentNode, shouldStopAtNode)
 }
 
 export function closestDataProxy(el) {


### PR DESCRIPTION
# The Scenario

When Livewire contextualises `wire:click` expressions, it prefixes bare identifiers with `$wire.` so they resolve against the component. For example, `wire:click="$js.select(user)"` becomes `$wire.$js.select($wire.user)`.

To support Alpine-scoped variables (like `x-for` iteration items), Livewire needs to check Alpine's scope chain before prefixing. However, `closestDataStack` traverses all the way up the DOM tree, which means Alpine scope from *outside* the Livewire component can incorrectly override `$wire` properties.

# The Problem

There's currently no way to tell `closestDataStack` where to stop collecting scope. It always traverses to the root of the document.

# The Solution

Add an optional `shouldStopAtNode` callback parameter to `closestDataStack`. When provided, the function stops traversing and returns an empty array if `shouldStopAtNode(node)` returns `true`.

```javascript
// Default behaviour (unchanged)
Alpine.closestDataStack(el)

// Stop at a specific boundary
Alpine.closestDataStack(el, node => {
    return node.hasAttribute && node.hasAttribute('wire:id')
})
```

This allows Livewire to collect Alpine scope only within the component boundary.