### PR TITLE
feat(x-anchor): allow dynamic reference to be used with x-anchor

### DIFF
--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -13,20 +13,20 @@ export default function (Alpine) {
         }
     })
 
-    Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { evaluate, effect, cleanup}) => {
+    Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { evaluate, effect, cleanup }) => {
         let { placement, offsetValue, unstyled } = getOptions(modifiers)
 
         el._x_anchor = Alpine.reactive({ x: 0, y: 0 })
 
         let previousReference = null
-        let release = null;        
+        let release = null
 
         let effector = effect(() => {
             let reference = evaluate(expression)
             if (! reference) throw 'Alpine: no element provided to x-anchor...'
 
             if (previousReference !== reference) {
-                if (release) release();
+                if (release) release()
 
                 previousReference = reference
 
@@ -52,7 +52,7 @@ export default function (Alpine) {
                 release = autoUpdate(reference, el, () => compute())
             }
         })
-        
+
         cleanup(() => {
             effector()
             if (release) release()

--- a/tests/cypress/integration/plugins/anchor.spec.js
+++ b/tests/cypress/integration/plugins/anchor.spec.js
@@ -1,4 +1,4 @@
-import { haveAttribute, haveComputedStyle, haveProperty, html, notHaveAttribute, test, beAnchoredTo } from '../../utils'
+import { haveAttribute, haveComputedStyle, html, notHaveAttribute, test } from '../../utils'
 
 test('can anchor an element',
     [html`
@@ -14,20 +14,23 @@ test('can anchor an element',
 
 test('can anchor to dynamic reference',
     [html`
-        <div x-data="{ reference: null }" 
-            x-init="reference = document.getElementById('foo')"
-        >
+        <div x-data="{ reference: null }" x-init="reference = document.getElementById('foo')">
             <button id="foo">toggle foo</button>
             <button id="bar" @click="reference = $el">toggle bar</button>
             <h1 id="baz" x-anchor="reference">contents</h1>
         </div>
     `],
-    ({ get }, reload) => {
-        get('#foo').then(foo => {
-            get('#baz').should(beAnchoredTo(foo))
+    ({ get }) => {
+        let originalLeft
+
+        get('#baz').then($el => {
+            originalLeft = $el[0].style.left
         })
-        get('#bar').click().then(bar => {
-            get('#baz').should(beAnchoredTo(bar))
+
+        get('#bar').click()
+
+        get('#baz').should($el => {
+            expect($el[0].style.left).not.to.eq(originalLeft)
         })
     }
 )

--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -155,27 +155,6 @@ export let haveComputedStyle = (name, value) => el => {
     expect(win.getComputedStyle(el[0]).getPropertyValue(name)).to.eq(value)
 }
 
-export let beAnchoredTo = (anchorEl, tolerance = 1) => el => {
-    const elRect = getBoundingRect(el, true)
-    const anchorElRect = getBoundingRect(anchorEl, true)
-    expect(elRect.left + elRect.width / 2).to.be.closeTo(anchorElRect.left + anchorElRect.width / 2, tolerance)
-    expect(elRect.top).to.be.closeTo(anchorElRect.bottom, tolerance)
-}
-
-export function getBoundingRect(el, useMarginBox = false) {
-    const rect = el[0].getBoundingClientRect()
-    if (!useMarginBox) return rect
-
-    const win = el[0].ownerDocument.defaultView
-    const style = win.getComputedStyle(el[0])
-    const top = rect.top - parseFloat(style.marginTop)
-    const left = rect.left - parseFloat(style.marginLeft)
-    const width = rect.width + parseFloat(style.marginLeft) + parseFloat(style.marginRight)
-    const height = rect.height + parseFloat(style.marginTop) + parseFloat(style.marginBottom)
-
-    return { ...rect, top: top, right: left + width, bottom: top + height, left: left, width: width, height: height, x: left, y: top,}
-}
-
 export function root(el) {
     if (el._x_dataStack) return el
 


### PR DESCRIPTION
Addresses: #4079

## Problem

Currently using `x-anchor` with a reference to an element does not allow for reactivity / changes to the reference. The element with `x-anchor` is permanently anchored to the initial reference throughout its lifecycle.

In the below example, the header element with id `baz` is anchored to the button with id `foo` on init. The button with id `bar` has a `@click` directive to change the `reference` variable to reference itself. 
```
<div x-data="{ reference: null }" x-init="reference = document.getElementById('foo')">
    <button id="foo">toggle foo</button>
    <button id="bar" @click="reference = $el">toggle bar</button>
    <h1 id="baz" x-anchor="reference">contents</h1>
</div>
```
The expected behavior is that when clicking `bar` button, the header element re-anchors to `bar`. However, the actual behavior is that the header remains anchored to `foo` button.

The current behavior is detrimental in certain use-cases, such as where a dropdown menu has multiple detached triggers that can each open and anchor to itself the same content. 

Ideally, `x-anchor` should react to changes to the reference, and immediately re-calculate the CSS positioning.

## Investigation

The expression is evaluated once at mount and then passed to @floating-ui/dom `autoUpdate`:

```
Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { cleanup, evaluate }) => {
        ...
        let reference = evaluate(expression)
        if (! reference) throw 'Alpine: no element provided to x-anchor...'
        let compute = () => {
            ...
        }
        let release = autoUpdate(reference, el, () => compute())
        cleanup(() => release())
    },
```

This means changes to the expression are not captured and re-evaluated to form an updated reference, which can be passed to @floating-ui/dom API.

## Solution

Introduce the `effect` API to the directive and store the previous reference, such that if the `x-anchor` expression changes and does not evaluate to the previous reference, we release the autoUpdate attached to the previous reference and create a new one.

```
Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { cleanup, evaluate }) => {
        ...
        let previousReference = null
        let release = null;  
        let effector = effect(() => {
            let reference = evaluate(expression)
            if (! reference) throw 'Alpine: no element provided to x-anchor...'
            if (previousReference !== reference) {
                if (release) release();
                previousReference = reference
                let compute = () => {
                   ...
                }
                release = autoUpdate(reference, el, () => compute())
            }
        })
        cleanup(() => {
            effector()
            if (release) release()
        })
    },
```

