### PR TITLE
fix(morph): close dialogs properly when removing open attribute

### DIFF
--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -174,8 +174,11 @@ function createMorphContext(options = {}) {
             let name = domAttributes[i].name;
 
             if (! to.hasAttribute(name)) {
-                // Remove attribute...
-                from.removeAttribute(name)
+                if (name === 'open' && from.nodeName === 'DIALOG' && from.open) {
+                    from.close()
+                } else {
+                    from.removeAttribute(name)
+                }
             }
         }
 

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -1061,3 +1061,41 @@ test('can ignore region between comment markers using skipUntil',
         get('li:nth-of-type(3)').should(haveText('baz'))
     },
 )
+
+test('morph properly closes dialog opened with showModal()',
+    [html`
+        <div x-data>
+            <dialog>
+                <p>Dialog content</p>
+            </dialog>
+            <button id="outside">Outside</button>
+        </div>
+    `],
+    ({ get }, reload, window, document) => {
+        // Open the dialog with showModal() so it enters the top layer
+        get('dialog').then(([dialog]) => {
+            dialog.showModal()
+            expect(dialog.open).to.be.true
+        })
+
+        // Morph to a version without 'open' attribute (same as original)
+        get('div').then(([el]) => {
+            window.Alpine.morph(el, `
+                <div x-data>
+                    <dialog>
+                        <p>Dialog content</p>
+                    </dialog>
+                    <button id="outside">Outside</button>
+                </div>
+            `)
+        })
+
+        // Dialog should be closed
+        get('dialog').then(([dialog]) => {
+            expect(dialog.open).to.be.false
+        })
+
+        // Page should not be inert — outside button should be clickable
+        get('#outside').click()
+    },
+)


### PR DESCRIPTION
## Summary

- Morphing a `<dialog>` that was opened via `showModal()` would call `removeAttribute('open')` directly. This hides the dialog visually but leaves it in the browser's **top layer**, making the entire page permanently inert (unclickable).
- Now detects `<dialog>` elements and calls `dialog.close()` instead, which properly exits the top layer.

## Changes

**`packages/morph/src/morph.js`** — In `patchAttributes`, when removing the `open` attribute from a `<dialog>`:

```js
// Before
from.removeAttribute(name)

// After
if (name === 'open' && from.nodeName === 'DIALOG' && from.open) {
    from.close()
} else {
    from.removeAttribute(name)
}
```

**`tests/cypress/integration/plugins/morph.spec.js`** — Added test that opens a dialog via `showModal()`, morphs it closed, and verifies the page remains interactive.

## Test plan

- [x] Existing morph tests pass (34/34)
- [x] New test: opens dialog with `showModal()`, morphs to remove `open`, asserts dialog is closed and page is not inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)