### PR TITLE
docs: clearer variable name in x-bind example

### DIFF
--- a/packages/docs/src/en/directives/bind.md
+++ b/packages/docs/src/en/directives/bind.md
@@ -10,8 +10,8 @@ title: bind
 For example, here's a component where we will use `x-bind` to set the placeholder value of an input.
 
 ```alpine
-<div x-data="{ placeholder: 'Type here...' }">
-    <input type="text" x-bind:placeholder="placeholder">
+<div x-data="{ placeholderText: 'Type here...' }">
+    <input type="text" x-bind:placeholder="placeholderText">
 </div>
 ```
 
@@ -21,7 +21,7 @@ For example, here's a component where we will use `x-bind` to set the placeholde
 If `x-bind:` is too verbose for your liking, you can use the shorthand: `:`. For example, here is the same input element as above, but refactored to use the shorthand syntax.
 
 ```alpine
-<input type="text" :placeholder="placeholder">
+<input type="text" :placeholder="placeholderText">
 ```
 
 > Despite not being included in the above snippet, `x-bind` cannot be used if no parent element has `x-data` defined. [→ Read more about `x-data`](/directives/data)


### PR DESCRIPTION
Closes #4430

Cherry-picked from #4430 by @sa- with review fix applied (camelCase instead of snake_case).

## Summary
- Renames `placeholder` to `placeholderText` in the `x-bind` docs example to avoid confusion between the JS variable name and the HTML `placeholder` attribute
- Uses camelCase (`placeholderText`) instead of the original PR's snake_case (`placeholder_text`) to match JavaScript conventions used throughout Alpine's docs

## Original description (from @sa-)
> While I was reading through the docs I was quite confused because `placeholder` was both a variable name and an attribute for the input field. It took me unreasonably long to figure it out and I believe changing the variable name slightly would have helped me grok it faster.