### PR TITLE
Handle all types of whitespace in class lists, not just spaces

### DIFF
--- a/packages/alpinejs/src/utils/classes.js
+++ b/packages/alpinejs/src/utils/classes.js
@@ -12,7 +12,7 @@ export function setClasses(el, value) {
 }
 
 function splitClasses(classString) {
-  return classString.split(/\s/).filter(Boolean)
+    return classString.split(/\s/).filter(Boolean)
 }
 
 function setClassesFromString(el, classString) {

--- a/tests/cypress/integration/directives/x-bind-class.spec.js
+++ b/tests/cypress/integration/directives/x-bind-class.spec.js
@@ -82,7 +82,7 @@ test('classes are removed before being added',
     }
 )
 
-test.only('extra whitespace in class binding string syntax is ignored',
+test('extra whitespace in class binding string syntax is ignored',
     html`
         <div x-data>
             <span x-bind:class="'  foo  bar \n baz '"></span>

--- a/tests/cypress/integration/directives/x-transition.spec.js
+++ b/tests/cypress/integration/directives/x-transition.spec.js
@@ -81,27 +81,25 @@ test('transition:enter in nested x-show visually runs',
     }
 )
 
-test('extra whitespace in transition string syntax is ignored',
-  html`
-      <style>
-          .transition { transition-property: background-color, border-color, color, fill, stroke; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-          .duration-100 { transition-duration: 100ms; }
-      </style>
-      <div x-data="{ show: false }">
-          <button x-on:click="show = ! show"></button>
+test('newlines in transition class string are handled',
+    html`
+        <style>
+            .transition { transition-property: background-color, border-color, color, fill, stroke; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
+            .duration-100 { transition-duration: 100ms; }
+        </style>
+        <div x-data="{ show: false }">
+            <button x-on:click="show = ! show"></button>
 
-          <span
-              x-show="show"
-              x-transition:enter="transition  duration-100 \n  \n     some-class-on-newline-with-lotsa-whitespace "
-          >thing</span>
-      </div>
-  `,
-  ({ get }) => {
-      get('span').should(beHidden())
-      get('button').click()
-      get('span').should(beVisible())
-      get('span').should(haveClasses(['transition', 'duration-100', 'some-class-on-newline-with-lotsa-whitespace']))
-  }
+            <span x-show="show" x-transition:enter="transition
+                duration-100">thing</span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(beHidden())
+        get('button').click()
+        get('span').should(beVisible())
+        get('span').should(haveClasses(['transition', 'duration-100']))
+    }
 )
 
 test('transition duration and delay with and without ms syntax',


### PR DESCRIPTION
Closes #4419

Cherry-picked from #4419 by @mattvague with review fixes applied.

## Original description
Fixes bug [mentioned here](https://github.com/alpinejs/alpine/discussions/4418) where using a newline in e.g. x-transition:enter would throw an error

## Review fixes applied
- Fixed 2-space indentation in `splitClasses` to match project's 4-space style
- Removed `test.only` from x-bind:class test (would skip all other tests in the file)
- Rewrote transition test to use actual newlines in the HTML template instead of `\n` escape sequences — the `html` tag function uses `strings.raw`, so `\n` stays as literal backslash-n and doesn't actually test the newline bug
- Verified the rewritten transition test fails on `main` and passes with the fix