### PR TITLE
Fix x-ref crash during child-element morph

### DIFF
--- a/packages/alpinejs/src/directives/x-ref.js
+++ b/packages/alpinejs/src/directives/x-ref.js
@@ -1,9 +1,13 @@
 import { closestRoot } from '../lifecycle'
+import { skipDuringClone } from '../clone'
 import { directive } from '../directives'
 
 function handler () {}
 
-handler.inline = (el, { expression }, { cleanup }) => {
+// Skip during clone because morph runs directives on detached elements
+// where closestRoot() has no x-data ancestor. Refs re-register on the
+// live DOM via the MutationObserver path after morph patches attributes.
+handler.inline = skipDuringClone((el, { expression }, { cleanup }) => {
     let root = closestRoot(el)
 
     if (! root._x_refs) root._x_refs = {}
@@ -11,6 +15,6 @@ handler.inline = (el, { expression }, { cleanup }) => {
     root._x_refs[expression] = el
 
     cleanup(() => delete root._x_refs[expression])
-}
+})
 
 directive('ref', handler)


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Cannot read property '_x_refs' of undefined` when calling `Alpine.morph()` on a child element (not the `x-data` root) that contains `x-ref` attributes
- Wraps `x-ref`'s inline handler with `skipDuringClone()` — the established Alpine pattern used by 10+ other directives
- Adds Cypress test that morphs a child `<section>` containing `x-ref` and verifies state preservation + ref resolution

## Problem

When morphing a child element, morph's `cloneNode()` runs directives on detached `to` elements whose parent chain has no `[x-data]` ancestor. `closestRoot()` returns `undefined`, and `x-ref` dereferences it → crash.

This affects htmx+Alpine users in production (reported in #3797, #3758, #3003).

## Why `skipDuringClone` over a null guard

The PR #4744 proposed `if (! root) return` — a valid fix, but `skipDuringClone` is the Alpine-established pattern for "this directive doesn't need to run during clone." Refs on detached `to` elements are discarded anyway; post-morph, refs re-register on live DOM via the MutationObserver path.

## Test plan

- [x] New test: morph child element with `x-ref` — no crash, state preserved, `$refs` resolves
- [x] All 35 morph tests pass
- [x] All 6 `$refs` tests pass  
- [x] All 4 clone tests pass

Closes #3797. Alternative to #4744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)