### PR TITLE
Fix $watch oldValue for objects

### DIFF
--- a/tests/cypress/integration/magics/$watch.spec.js
+++ b/tests/cypress/integration/magics/$watch.spec.js
@@ -198,3 +198,57 @@ test('deep $watch',
     }
 )
 
+test('deep $watch receives old value',
+    html`
+        <div x-data="{ foo: { bar: 'baz' }, fresh: '', old: '' }" x-init="
+            $watch('foo', (value, oldValue) => { fresh = value.bar; old = oldValue.bar })
+        ">
+            <h1 x-text="fresh"></h1>
+            <h2 x-text="old"></h2>
+
+            <button x-on:click="foo.bar = 'bob'"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('h1').should(haveText('bob'))
+        get('h2').should(haveText('baz'))
+    }
+)
+
+test('deep $watch receives old value for arrays',
+    html`
+        <div x-data="{ list: ['one'], newVal: '', oldVal: '' }" x-init="
+            $watch('list', (value, oldValue) => { newVal = value.join(','); oldVal = oldValue.join(',') })
+        ">
+            <h1 x-text="newVal"></h1>
+            <h2 x-text="oldVal"></h2>
+
+            <button x-on:click="list.push('two')"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('h1').should(haveText('one,two'))
+        get('h2').should(haveText('one'))
+    }
+)
+
+test('deep $watch receives old value with null',
+    html`
+        <div x-data="{ foo: null, fresh: '', old: '' }" x-init="
+            $watch('foo', (value, oldValue) => { fresh = JSON.stringify(value); old = JSON.stringify(oldValue) })
+        ">
+            <h1 x-text="fresh"></h1>
+            <h2 x-text="old"></h2>
+
+            <button x-on:click="foo = { bar: 'baz' }"></button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('h1').should(haveText('{"bar":"baz"}'))
+        get('h2').should(haveText('null'))
+    }
+)
+


### PR DESCRIPTION
## Summary

- **Bug**: When deep-watching objects with `$watch`, `oldValue` was the same reference as `value`. By callback time, both reflected the already-mutated state. `oldValue.bar` showed `'bob'` instead of `'baz'`.
- **Fix**: Reuse the `JSON.stringify` result already computed for deep tracking (line 68), store it, and `JSON.parse` it back as `oldValue` when the callback fires. Zero additional stringify calls.
- **Tests**: 3 new tests — objects, arrays, and null→object transition. All 11 `$watch` tests pass.

### The bug

```js
$watch('foo', (value, oldValue) => {
    console.log(value.bar)    // 'bob'
    console.log(oldValue.bar) // Expected 'baz', got 'bob' ❌
})
```

`oldValue = value` stores a proxy reference. For objects, both point to the same reactive proxy — the old state is lost.

### The fix

```diff
- JSON.stringify(value)
+ let newJSON = JSON.stringify(value)

- let previousValue = oldValue
+ let previousValue = typeof oldValue === 'object'
+     ? JSON.parse(oldValueJSON)
+     : oldValue

  oldValue = value
+ oldValueJSON = newJSON
```

Follows `entangle.js` precedent (`JSON.parse(JSON.stringify())`). Same JSON edge-case limitations already exist on line 68.

Closes #3293. Related: #4406 (original PR by @Suall1969 who identified the fix direction), #3046, #3617.

## Test plan

- [x] `deep $watch receives old value` — object nested property change
- [x] `deep $watch receives old value for arrays` — array push mutation
- [x] `deep $watch receives old value with null` — null to object transition
- [x] All 8 existing `$watch` tests still pass
- [x] `entangle` and `x-data` tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)