### PR TITLE
Support multiple root elements in x-for templates

### DIFF
--- a/packages/docs/src/en/directives/for.md
+++ b/packages/docs/src/en/directives/for.md
@@ -49,10 +49,9 @@ You may also pass objects to `x-for`.
 </div>
 <!-- END_VERBATIM -->
 
-There are two rules worth noting about `x-for`:
+There is one rule worth noting about `x-for`:
 
 > `x-for` MUST be declared on a `<template>` element.
-> That `<template>` element MUST contain only one root element
 
 <a name="keys"></a>
 ## Keys
@@ -115,21 +114,40 @@ If you need to simply loop `n` number of times, rather than iterate through an a
 <a name="contents-of-a-template"></a>
 ## Contents of a `<template>`
 
-As mentioned above, an `<template>` tag must contain only one root element.
-
-For example, the following code will not work:
+Alpine supports multiple root elements inside an `x-for` template. Each iteration will render all children:
 
 ```alpine
-<template x-for="color in colors">
-    <span>The next color is </span><span x-text="color">
-</template>
+<table x-data="{ colors: ['Red', 'Orange', 'Yellow'] }">
+    <tr>
+        <template x-for="(color, index) in colors">
+            <td x-text="index"></td>
+            <td x-text="color"></td>
+        </template>
+    </tr>
+</table>
 ```
 
-but this code will work:
+If you only have one root element, that works too — it's just not required:
+
 ```alpine
 <template x-for="color in colors">
     <p>
         <span>The next color is </span><span x-text="color">
     </p>
 </template>
+```
+
+### Limitations with `<table>` elements
+
+HTML tables have strict parsing rules — a `<div>` is not valid inside `<tr>`, so the browser will strip it before Alpine runs. If you need to iterate table cells, either place multiple `<td>` elements directly in the template (as shown above) or use `<tr>` as the root element:
+
+```alpine
+<table x-data="{ colors: ['Red', 'Orange', 'Yellow'] }">
+    <template x-for="(color, index) in colors">
+        <tr>
+            <td x-text="index"></td>
+            <td x-text="color"></td>
+        </tr>
+    </template>
+</table>
 ```

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -858,6 +858,70 @@ test('nested x-for where inner loop uses multi-element',
     }
 )
 
+test('x-for multi-element works with x-if as one of the children',
+    html`
+        <div x-data="{ items: ['foo', 'bar'], show: true }">
+            <button x-on:click="show = !show">toggle</button>
+            <template x-for="item in items">
+                <h3 x-text="item"></h3>
+                <template x-if="show">
+                    <span x-text="item + '!'"></span>
+                </template>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('h3').should(haveLength(2))
+        get('span').should(haveLength(2))
+        get('span:nth-of-type(1)').should(haveText('foo!'))
+        get('button').click()
+        get('h3').should(haveLength(2))
+        get('span').should(notExist())
+        get('button').click()
+        get('span').should(haveLength(2))
+    }
+)
+
+test('x-for multi-element handles event listeners per iteration',
+    html`
+        <div x-data="{ items: ['foo', 'bar'], output: '' }">
+            <template x-for="item in items">
+                <h3 x-text="item"></h3>
+                <button x-on:click="output = item">click</button>
+            </template>
+            <span id="output" x-text="output"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#output').should(haveText(''))
+        get('button:nth-of-type(1)').click()
+        get('#output').should(haveText('foo'))
+        get('button:nth-of-type(2)').click()
+        get('#output').should(haveText('bar'))
+    }
+)
+
+test('x-for multi-element handles large lists',
+    html`
+        <div x-data="{ items: Array.from({length: 200}, (_, i) => i) }">
+            <button x-on:click="items = items.slice().reverse()">reverse</button>
+            <template x-for="item in items" :key="item">
+                <span x-text="item"></span>
+                <i x-text="item * 2"></i>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveLength(200))
+        get('i').should(haveLength(200))
+        get('span:nth-of-type(1)').should(haveText('0'))
+        get('span:nth-of-type(200)').should(haveText('199'))
+        get('button').click()
+        get('span:nth-of-type(1)').should(haveText('199'))
+        get('span:nth-of-type(200)').should(haveText('0'))
+    }
+)
+
 // To support rerendering alongside x-sort
 test('x-for handles moved elements correctly',
     html`


### PR DESCRIPTION
## Situation

`x-for` renders one element per iteration. Works great — until you need siblings:

```html
<tr>
    <template x-for="(color, idx) in colors">
        <td x-text="color"></td>
        <td x-text="idx"></td>
    </template>
</tr>
```

### What happens:

1. You put two `<td>`s in the template
2. Only the **first** `<td>` renders per iteration — the second is silently dropped
3. You try wrapping in a `<div>` — browser strips it (invalid inside `<tr>`)
4. No warning. No error. Just missing elements.

Known pain point since 2020 (#450, discussion #935).

## Problem

`x-for`'s clone logic hardcodes single-element extraction:

```js
let clone = document.importNode(templateEl.content, true).firstElementChild
```

- `.firstElementChild` grabs one element, discards the rest
- The lookup map, reordering, cleanup, and scope all assume one element per iteration
- No warning when children are dropped

## Solutions considered

| # | Approach | Verdict |
|---|----------|---------|
| 1 | Docs-only (original PR #4730) | ❌ Doesn't fix it. Several workarounds empirically broken. |
| 2 | Always use comment markers | ❌ Unnecessary overhead for single-element templates. |
| 3 | Auto-wrap in table elements | ❌ No valid HTML wrapper for `<td>` siblings inside `<tr>`. |
| 4 | New directive (`x-for-each`) | ❌ Two directives for one concept. Confusing. |
| 5 | Console warning | ⚡ Shipped separately in #4752. Visible failure, not a fix. |
| 7 | Fragment class abstraction | ❌ Overengineered. Comment markers are simpler. |
| **11** | **Auto-detect fragment mode** | ✅ **Chosen** |

## Chosen approach: auto-detect fragment mode

When `templateEl.content.children.length > 1` → switch to fragment mode with comment-node boundaries.
When `=== 1` → existing code, unchanged, zero overhead.

**Why:**
- 🟢 Vue 3 (fragment VNodes) and Svelte (comment anchors) both solved it this way
- 🟢 Alpine's morph plugin already uses this pattern (`Block` class with `startComment`/`endComment`)
- 🟢 `_x_lookup` and `_x_refreshXForScope` are fully internal — no public API changes
- 🟢 Comment nodes invisible to CSS, don't affect `:nth-child`, survive inside `<tr>`

Based on the problem identified in #4730 by @NightFurySL2001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)