### PR TITLE
Warn when x-for template has multiple root elements

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -111,6 +111,9 @@ function loop(templateEl, iteratorNames, evaluateItems, evaluateKey) {
                     return
                 }
 
+                if (templateEl.content.children.length > 1)
+                    warn('x-for templates require a single root element, additional elements will be ignored.', templateEl)
+
                 let clone = document.importNode(templateEl.content, true).firstElementChild
                 let reactiveScope = reactive(scope)
                 addScopeToNode(clone, reactiveScope, templateEl)


### PR DESCRIPTION
## Summary

Adds a `console.warn` when an `x-for` template has multiple root elements. Currently only the first is rendered and the rest are silently dropped — this makes the failure visible.

Based on the problem identified in #4730 by @NightFurySL2001.

## Test plan

- [x] All 34 existing x-for tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)