### PR TITLE
Remove global x-model radio flag and add regression tests

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -155,10 +155,7 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
         // If nested model key is undefined, set the default value to empty string.
         if (value === undefined && typeof expression === 'string' && expression.match(/\./)) value = ''
 
-        // @todo: This is nasty
-        window.fromModel = true
-        mutateDom(() => bind(el, 'value', value))
-        delete window.fromModel
+        mutateDom(() => bind(el, 'value', value, [], { fromModel: true }))
     }
 
     effect(() => {

--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -3,7 +3,7 @@ import { reactive } from '../reactivity'
 import { setClasses } from './classes'
 import { setStyles } from './styles'
 
-export default function bind(el, name, value, modifiers = []) {
+export default function bind(el, name, value, modifiers = [], { fromModel = false } = {}) {
     // Register bound data as pure observable data for other APIs to use.
     if (! el._x_bindings) el._x_bindings = reactive({})
 
@@ -13,7 +13,7 @@ export default function bind(el, name, value, modifiers = []) {
 
     switch (name) {
         case 'value':
-            bindInputValue(el, value)
+            bindInputValue(el, value, fromModel)
             break;
 
         case 'style':
@@ -38,7 +38,7 @@ export default function bind(el, name, value, modifiers = []) {
     }
 }
 
-function bindInputValue(el, value) {
+function bindInputValue(el, value, fromModel) {
     if (isRadio(el)) {
         // Set radio value from x-bind:value, if no "value" attribute exists.
         // If there are any initial state values, radio will have a correct
@@ -47,8 +47,7 @@ function bindInputValue(el, value) {
             el.value = value
         }
 
-        // @todo: yuck
-        if (window.fromModel) {
+        if (fromModel) {
             if (typeof value === 'boolean') {
                 el.checked = safeParseBoolean(el.value) === value
             } else {

--- a/tests/vitest/bind.spec.js
+++ b/tests/vitest/bind.spec.js
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import Alpine from '../../packages/alpinejs/src/index.js'
+
+let bind
+
+beforeAll(async () => {
+    Alpine.start()
+    bind = (await import('../../packages/alpinejs/src/utils/bind.js')).default
+})
+
+describe('bind(value) with radio inputs', () => {
+    it('does not update checked state outside x-model updates', () => {
+        let radio = document.createElement('input')
+        radio.type = 'radio'
+        radio.value = 'true'
+        radio.checked = false
+
+        bind(radio, 'value', true)
+
+        expect(radio.checked).toBe(false)
+    })
+
+    it('updates checked state when invoked by x-model updates', () => {
+        let truthy = document.createElement('input')
+        truthy.type = 'radio'
+        truthy.value = 'true'
+
+        let falsy = document.createElement('input')
+        falsy.type = 'radio'
+        falsy.value = 'false'
+
+        bind(truthy, 'value', true, [], { fromModel: true })
+        bind(falsy, 'value', true, [], { fromModel: true })
+
+        expect(truthy.checked).toBe(true)
+        expect(falsy.checked).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary
- replace the global `window.fromModel` flag with an explicit internal `{ fromModel: true }` option when syncing x-model values
- thread the new option through `bind()` -> `bindInputValue()` for radio handling
- add Vitest coverage for radio behavior with and without model-driven updates

## Why
Using a global flag for model synchronization can leak state and cause unintended coupling. This change keeps model context explicit and local.

## Testing
- npm run vitest
- npm run build
