### PR TITLE
Stabilize sort drag helper and re-enable core tests

### DIFF
--- a/tests/cypress/integration/plugins/sort.spec.js
+++ b/tests/cypress/integration/plugins/sort.spec.js
@@ -1,11 +1,8 @@
 import { haveText, html, test } from '../../utils'
 
-/**
- * Skipping all these tests because they are flaky in CI.
- * They should all pass locally though...
- */
+const stableSortTest = test.retry(2)
 
-test.skip('basic drag sorting works',
+stableSortTest('basic drag sorting works',
     [html`
         <div x-data>
             <ul x-sort>
@@ -36,7 +33,7 @@ test.skip('basic drag sorting works',
     },
 )
 
-test.skip('can use a custom handle',
+stableSortTest('can use a custom handle',
     [html`
         <div x-data>
             <ul x-sort>
@@ -56,7 +53,7 @@ test.skip('can use a custom handle',
     },
 )
 
-test.skip('can move items between groups',
+stableSortTest('can move items between groups',
     [html`
         <div x-data>
             <ul x-sort x-sort:group="one">
@@ -85,7 +82,7 @@ test.skip('can move items between groups',
     },
 )
 
-test.skip('sort handle method',
+stableSortTest('sort handle method',
     [html`
         <div x-data="{ handle(key, position) { $refs.outlet.textContent = key+'-'+position } }">
             <ul x-sort="handle">

--- a/tests/cypress/support/drag.js
+++ b/tests/cypress/support/drag.js
@@ -15,8 +15,8 @@ function isAttached(element) {
 }
 
 const DragSimulator = {
-    MAX_TRIES: 5,
-    DELAY_INTERVAL_MS: 10,
+    MAX_TRIES: 20,
+    DELAY_INTERVAL_MS: 20,
     counter: 0,
     targetElement: null,
     rectsEqual(r1, r2) {
@@ -130,12 +130,14 @@ const DragSimulator = {
         })
     },
     drag(sourceWrapper, targetSelector, options) {
-        this.init(sourceWrapper, targetSelector, options)
+        return this.init(sourceWrapper, targetSelector, options)
             .then(() => this.dragstart())
             .then(() => this.dragover())
             .then((success) => {
                 if (success) {
-                    return this.drop().then(() => true)
+                    return this.drop()
+                        .then(() => cy.get('body', { log: false }).should('not.have.class', 'sorting'))
+                        .then(() => true)
                 } else {
                     return false
                 }
@@ -145,10 +147,12 @@ const DragSimulator = {
         const { deltaX, deltaY } = options
         const { top, left } = sourceWrapper.offset()
         const finalCoords = { clientX: left + deltaX, clientY: top + deltaY }
-        this.init(sourceWrapper, sourceWrapper, options)
+
+        return this.init(sourceWrapper, sourceWrapper, options)
             .then(() => this.dragstart({ clientX: left, clientY: top }))
             .then(() => this.dragover(finalCoords))
             .then(() => this.drop(finalCoords))
+            .then(() => cy.get('body', { log: false }).should('not.have.class', 'sorting'))
     },
 }
 


### PR DESCRIPTION
## Summary
- improve drag helper stability by returning the command chain from `drag`/`move`
- increase dragover retries/interval in the helper for slower CI timing
- wait for sort lifecycle completion (`body` no longer has `sorting`) before resolving drag helper
- re-enable a stable core subset of sort integration tests with retries:
  - basic drag sorting works
  - can use a custom handle
  - can move items between groups
  - sort handle method

## Why
Sort tests were fully skipped due CI flakiness. This pass improves determinism in the underlying drag helper and turns back on core coverage incrementally.

## Testing
- npm run vitest
- npm run build
- npm test *(fails locally in this environment because Cypress binary is not installed)*
