### PR TITLE
Clarify moved plugin skip metadata in Cypress suites

### DIFF
--- a/tests/cypress/integration/plugins/history.spec.js
+++ b/tests/cypress/integration/plugins/history.spec.js
@@ -1,7 +1,7 @@
 import { haveText, html, test } from '../../utils'
 
-// Skipping these tests because the plugin has been moved to livewire/livewire until it's stablhese tests because the plugin has been moved to livewire/livewire until it's stable...
-describe.skip('History tests', function () {
+// The history plugin suite is currently maintained in livewire/livewire.
+describe.skip('History tests (moved to livewire/livewire)', function () {
     test('value is reflected in query string upon changing',
         [html`
             <div x-data="{ count: $queryString(1) }">
@@ -218,4 +218,3 @@ describe.skip('History tests', function () {
         },
     )
 })
-

--- a/tests/cypress/integration/plugins/navigate.spec.js
+++ b/tests/cypress/integration/plugins/navigate.spec.js
@@ -1,8 +1,8 @@
-import { beEqualTo, beVisible, haveAttribute, haveFocus, haveText, html, notBeVisible, test } from '../../utils'
+import { beEqualTo, haveAttribute, haveFocus, haveText, html } from '../../utils'
 
-// Skipping these tests because the plugin has been moved to livewire/livewire until it's stablhese tests because the plugin has been moved to livewire/livewire until it's stable...
-describe.skip('Navigate tests', function () {
-    it.skip('navigates pages without reload',
+// The navigate plugin suite is currently maintained in livewire/livewire.
+describe.skip('Navigate tests (moved to livewire/livewire)', function () {
+    it('navigates pages without reload',
         () => {
             cy.intercept('/first', {
                 headers: { 'content-type': 'text/html' },
@@ -50,7 +50,7 @@ describe.skip('Navigate tests', function () {
         },
     )
 
-    it.skip('autofocuses autofocus elements',
+    it('autofocuses autofocus elements',
         () => {
             cy.intercept('/first', {
                 headers: { 'content-type': 'text/html' },
@@ -89,7 +89,7 @@ describe.skip('Navigate tests', function () {
         },
     )
 
-    it.skip('scripts and styles are properly merged/run or skipped',
+    it('scripts and styles are properly merged/run or skipped',
         () => {
             cy.intercept('/first', {
                 headers: { 'content-type': 'text/html' },


### PR DESCRIPTION
## Summary
- clean up stale/corrupted skip comments in the moved plugin test suites
- make skip reason explicit in suite titles for both `history` and `navigate`
- remove redundant inner `it.skip(...)` calls under `describe.skip(...)` in `navigate.spec.js`
- trim unused imports in `navigate.spec.js`

## Why
These suites are intentionally skipped because ownership moved to `livewire/livewire`, but the current metadata is noisy and partially corrupted. This keeps the intent clear for maintainers.

## Testing
- npm run vitest
- npm run build
