### PR TITLE
Fix in-place x-data attribute mutations being ignored

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -41,9 +41,6 @@ directive('data', ((el, { expression }, { cleanup }) => {
         // Assign new/updated values — triggers reactive effects
         Object.assign(existingReactive, data)
 
-        // Restore magics in case cleanup stripped them
-        injectMagics(existingReactive, el)
-
         // Re-add scope (cleanup already removed it via undo())
         let undo = addScopeToNode(el, existingReactive)
 

--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -5,7 +5,7 @@ import { addRootSelector } from '../lifecycle'
 import { interceptClone, isCloning, isCloningLegacy } from '../clone'
 import { addScopeToNode } from '../scope'
 import { injectMagics, magic } from '../magics'
-import { reactive } from '../reactivity'
+import { reactive, raw } from '../reactivity'
 import { evaluate } from '../evaluator'
 
 addRootSelector(() => `[${prefix('data')}]`)
@@ -25,6 +25,44 @@ directive('data', ((el, { expression }, { cleanup }) => {
 
     if (data === undefined || data === true) data = {}
 
+    // Check for previous reactive data (stashed before cleanup could remove it)
+    let existingReactive = el._x_previousData
+
+    if (existingReactive) {
+        let rawExisting = raw(existingReactive)
+
+        // Remove keys that no longer exist in the new expression
+        Object.keys(rawExisting).forEach(key => {
+            if (key.startsWith('$')) return
+            if (key === 'init' || key === 'destroy') return
+            if (!(key in data)) delete existingReactive[key]
+        })
+
+        // Assign new/updated values — triggers reactive effects
+        Object.assign(existingReactive, data)
+
+        // Restore magics in case cleanup stripped them
+        injectMagics(existingReactive, el)
+
+        // Re-add scope (cleanup already removed it via undo())
+        let undo = addScopeToNode(el, existingReactive)
+
+        // Skip initInterceptors — interceptors like $persist were already
+        // initialized on the first run and their state should be preserved.
+
+        // Note: init() intentionally re-fires on the root element (not children).
+        // In practice, Livewire/morphing x-data expressions are plain data objects
+        // that won't have init, so this is a no-op for the primary use case.
+        existingReactive['init'] && evaluate(el, existingReactive['init'])
+
+        cleanup(() => {
+            existingReactive['destroy'] && evaluate(el, existingReactive['destroy'])
+            undo()
+        })
+
+        return
+    }
+
     injectMagics(data, el)
 
     let reactiveData = reactive(data)
@@ -32,6 +70,9 @@ directive('data', ((el, { expression }, { cleanup }) => {
     initInterceptors(reactiveData)
 
     let undo = addScopeToNode(el, reactiveData)
+
+    // Stash for future in-place mutations
+    el._x_previousData = reactiveData
 
     reactiveData['init'] && evaluate(el, reactiveData['init'])
 

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -117,6 +117,7 @@ export function destroyTree(root, walker = walk) {
         cleanupElement(el)
         cleanupAttributes(el)
         delete el._x_marker
+        delete el._x_previousData
     })
 }
 

--- a/tests/cypress/integration/mutation.spec.js
+++ b/tests/cypress/integration/mutation.spec.js
@@ -237,6 +237,70 @@ test('reinitializes component when x-data attribute is changed in-place',
     }
 )
 
+test('in-place x-data mutation removes keys that no longer exist',
+    html`
+        <div x-data="{ count: 1, label: 'hi' }">
+            <span id="count" x-text="count"></span>
+            <span id="label" x-text="typeof label"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('#count').should(haveText('1'))
+        get('#label').should(haveText('string'))
+
+        get('div').then(($div) => {
+            $div[0].setAttribute('x-data', '{ count: 99 }')
+        })
+
+        get('#count').should(haveText('99'))
+        get('#label').should(haveText('undefined'))
+    }
+)
+
+test('in-place x-data mutation preserves child component state',
+    html`
+        <div id="parent" x-data="{ count: 1 }">
+            <span id="parent-count" x-text="count"></span>
+            <div x-data="{ childState: 'preserved' }">
+                <span id="child-state" x-text="childState"></span>
+                <span id="child-parent" x-text="count"></span>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('#parent-count').should(haveText('1'))
+        get('#child-state').should(haveText('preserved'))
+        get('#child-parent').should(haveText('1'))
+
+        get('#parent').then(($div) => {
+            $div[0].setAttribute('x-data', '{ count: 99 }')
+        })
+
+        get('#parent-count').should(haveText('99'))
+        get('#child-state').should(haveText('preserved'))
+        get('#child-parent').should(haveText('99'))
+    }
+)
+
+test('in-place x-data mutation handles rapid consecutive changes',
+    html`
+        <div x-data="{ count: 1 }">
+            <span x-text="count"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('1'))
+
+        get('div').then(($div) => {
+            $div[0].setAttribute('x-data', '{ count: 5 }')
+            $div[0].setAttribute('x-data', '{ count: 10 }')
+            $div[0].setAttribute('x-data', '{ count: 99 }')
+        })
+
+        get('span').should(haveText('99'))
+    }
+)
+
 test(
     "previously initialized elements are not reinitialized on being moved",
     html`

--- a/tests/cypress/integration/mutation.spec.js
+++ b/tests/cypress/integration/mutation.spec.js
@@ -239,21 +239,21 @@ test('reinitializes component when x-data attribute is changed in-place',
 
 test('in-place x-data mutation removes keys that no longer exist',
     html`
-        <div x-data="{ count: 1, label: 'hi' }">
+        <div x-data="{ count: 1, extra: 'hi' }">
             <span id="count" x-text="count"></span>
-            <span id="label" x-text="typeof label"></span>
+            <span id="extra-type" x-text="typeof extra"></span>
         </div>
     `,
     ({ get }) => {
         get('#count').should(haveText('1'))
-        get('#label').should(haveText('string'))
+        get('#extra-type').should(haveText('string'))
 
         get('div').then(($div) => {
             $div[0].setAttribute('x-data', '{ count: 99 }')
         })
 
         get('#count').should(haveText('99'))
-        get('#label').should(haveText('undefined'))
+        get('#extra-type').should(haveText('undefined'))
     }
 )
 

--- a/tests/cypress/integration/mutation.spec.js
+++ b/tests/cypress/integration/mutation.spec.js
@@ -220,6 +220,23 @@ test('no side effects when directives are added to an element that is removed af
     }
 )
 
+test('reinitializes component when x-data attribute is changed in-place',
+    html`
+        <div x-data="{ count: 1 }">
+            <span x-text="count"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('1'))
+
+        get('div').then(($div) => {
+            $div[0].setAttribute('x-data', '{ count: 99 }')
+        })
+
+        get('span').should(haveText('99'))
+    }
+)
+
 test(
     "previously initialized elements are not reinitialized on being moved",
     html`


### PR DESCRIPTION
## The Reproduction

- You have a component: `<div x-data="{ count: 1 }"><span x-text="count"></span></div>`
- Something changes the attribute in-place: `el.setAttribute('x-data', '{ count: 99 }')`
- The DOM attribute updates, but the displayed value stays `1`
- This is exactly what happens during a Livewire morph — Livewire updates `x-data` via `setAttribute`, and Alpine ignores it

## The Problem

When Alpine first initializes a component, child directives like `x-text` snapshot the reactive data into a closure:

```js
// evaluator.js
let dataStack = [overriddenMagics, ...closestDataStack(el)]
```

When `x-data` changes in-place, Alpine's mutation observer fires a cleanup/re-add cycle. Alpine *does* create new reactive data on the element — but all the child effects (`x-text`, `x-bind`, etc.) are still watching the **old** reactive object through their closed-over `dataStack`. The new data exists, but nothing is subscribed to it, so nothing re-renders.

## Chosen Solution

Instead of creating a brand new reactive object when `x-data` changes, we **reuse the existing one** and update it in-place with `Object.assign`. Since all child effects are already subscribed to that reactive proxy, mutating it triggers re-renders automatically — no re-initialization needed.

The key changes:

1. **Stash the reactive object** on `el._x_previousData` after first initialization
2. **On subsequent x-data changes**, retrieve the stashed object, delete removed keys, and `Object.assign` new values in — this triggers all existing reactive effects
3. **Skip `initInterceptors`** so things like `$persist` keep their state
4. **Clean up `_x_previousData`** in `destroyTree` to prevent stale references

This approach was chosen because it:
- Preserves all child component state
- Preserves interceptor state (`$persist`, etc.)
- Requires no changes to the evaluator or reactivity system
- Is minimal and surgical — only touches `x-data.js` and `lifecycle.js`

## Other Solutions Explored

**Destroy + re-init subtree** — Tear down the whole component tree and reinitialize from scratch. This would work but blows away all child component state, re-fires every `init()`, resets `$persist`, and could cause visual jank with transitions. Too heavy-handed.

**Make evaluator dataStack live instead of snapshotted** — Fix the root architectural issue by making `closestDataStack(el)` resolve fresh on every evaluation instead of being captured in a closure. Elegant, but a deeper refactor of the evaluator internals, and effects won't automatically re-trigger for a *new* reactive object they've never subscribed to. Would need pairing with another mechanism to re-queue effects.

**Reactive scope chain proxy** — Replace `_x_dataStack` with a single reactive proxy that acts as a scope chain. Would eliminate this class of bugs entirely, but it's a major refactor touching the evaluator, scope system, and all directives. Too risky for a targeted fix.

**Fix in Livewire/morph instead** — Handle `x-data` specially in the morph algorithm (remove element, update, re-insert). But every morph library would need this knowledge, and it still loses component state. Fragile and doesn't fix the general `setAttribute` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)