### PR TITLE
Escape attribute values in morph `setAttribute` patch

### DIFF
--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -552,7 +552,9 @@ function monkeyPatchDomSetAttributeToAllowAtSymbols() {
             return original.call(this, name, value)
         }
 
-        hostDiv.innerHTML = `<span ${name}="${value}"></span>`
+        let escapedValue = value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+
+        hostDiv.innerHTML = `<span ${name}="${escapedValue}"></span>`
 
         let attr = hostDiv.firstElementChild.getAttributeNode(name)
 


### PR DESCRIPTION
The morph plugin's `setAttribute` monkey-patch interpolates attribute values directly into an `innerHTML` string without escaping. This means values containing `"` or `&` could produce unexpected results.

This escapes `&` and `"` in the value before interpolation.

Note: the browser specs for `setAttribute` and `createAttribute` were updated in June 2025 ([whatwg/dom#1079](https://github.com/whatwg/dom/pull/1079)) to allow `@` in attribute names, which would make this monkey-patch unnecessary. However, we need to keep it for backwards compatibility with older browsers.