### PR TITLE
Add .fixed positioning modifier to x-anchor

### DIFF
--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -1,4 +1,4 @@
-import { computePosition, autoUpdate, flip, offset, shift, size } from '@floating-ui/dom'
+import { computePosition, autoUpdate, flip, offset, shift } from '@floating-ui/dom'
 
 export default function (Alpine) {
     Alpine.magic('anchor', el => {
@@ -14,7 +14,7 @@ export default function (Alpine) {
     })
 
     Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { evaluate, effect, cleanup }) => {
-        let { placement, offsetValue, unstyled, strategy, matchWidth, allowFlip } = getOptions(modifiers)
+        let { placement, offsetValue, unstyled, strategy, allowFlip } = getOptions(modifiers)
 
         el._x_anchor = Alpine.reactive({ x: 0, y: 0 })
 
@@ -33,24 +33,10 @@ export default function (Alpine) {
                 let compute = () => {
                     let previousValue
 
-                    let middleware = [
-                        allowFlip && flip(),
-                        shift({padding: 5}),
-                        offset(offsetValue)
-                    ]
-
-                    if (matchWidth) {
-                        middleware.push(size({
-                            apply({rects, elements}) {
-                                elements.floating.style.width = `${rects.reference.width}px`
-                            },
-                        }))
-                    }
-
                     computePosition(reference, el, {
                         placement,
                         strategy,
-                        middleware,
+                        middleware: [allowFlip && flip(), shift({padding: 5}), offset(offsetValue)],
                     }).then(({ x, y }) => {
                         unstyled || setStyles(el, x, y, strategy)
 
@@ -101,7 +87,6 @@ function getOptions(modifiers) {
     let unstyled = modifiers.includes('no-style')
     let allowFlip = ! modifiers.includes('noflip')
     let strategy = modifiers.includes('fixed') ? 'fixed' : 'absolute'
-    let matchWidth = modifiers.includes('match-width')
 
-    return { placement, offsetValue, unstyled, strategy, matchWidth, allowFlip }
+    return { placement, offsetValue, unstyled, strategy, allowFlip }
 }

--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -1,4 +1,4 @@
-import { computePosition, autoUpdate, flip, offset, shift } from '@floating-ui/dom'
+import { computePosition, autoUpdate, flip, offset, shift, size } from '@floating-ui/dom'
 
 export default function (Alpine) {
     Alpine.magic('anchor', el => {
@@ -14,7 +14,7 @@ export default function (Alpine) {
     })
 
     Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { evaluate, effect, cleanup }) => {
-        let { placement, offsetValue, unstyled, strategy } = getOptions(modifiers)
+        let { placement, offsetValue, unstyled, strategy, matchWidth } = getOptions(modifiers)
 
         el._x_anchor = Alpine.reactive({ x: 0, y: 0 })
 
@@ -33,10 +33,24 @@ export default function (Alpine) {
                 let compute = () => {
                     let previousValue
 
+                    let middleware = [
+                        flip(),
+                        shift({padding: 5}),
+                        offset(offsetValue)
+                    ]
+
+                    if (matchWidth) {
+                        middleware.push(size({
+                            apply({rects, elements}) {
+                                elements.floating.style.width = `${rects.reference.width}px`
+                            },
+                        }))
+                    }
+
                     computePosition(reference, el, {
                         placement,
                         strategy,
-                        middleware: [flip(), shift({padding: 5}), offset(offsetValue)],
+                        middleware,
                     }).then(({ x, y }) => {
                         unstyled || setStyles(el, x, y, strategy)
 
@@ -89,5 +103,7 @@ function getOptions(modifiers) {
 
     let strategy = modifiers.includes('fixed') ? 'fixed' : 'absolute'
 
-    return { placement, offsetValue, unstyled, strategy }
+    let matchWidth = modifiers.includes('match-width')
+
+    return { placement, offsetValue, unstyled, strategy, matchWidth }
 }

--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -14,7 +14,7 @@ export default function (Alpine) {
     })
 
     Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { evaluate, effect, cleanup }) => {
-        let { placement, offsetValue, unstyled } = getOptions(modifiers)
+        let { placement, offsetValue, unstyled, strategy } = getOptions(modifiers)
 
         el._x_anchor = Alpine.reactive({ x: 0, y: 0 })
 
@@ -35,9 +35,10 @@ export default function (Alpine) {
 
                     computePosition(reference, el, {
                         placement,
+                        strategy,
                         middleware: [flip(), shift({padding: 5}), offset(offsetValue)],
                     }).then(({ x, y }) => {
-                        unstyled || setStyles(el, x, y)
+                        unstyled || setStyles(el, x, y, strategy)
 
                         // Only trigger Alpine reactivity when the value actually changes...
                         if (JSON.stringify({ x, y }) !== previousValue) {
@@ -61,17 +62,17 @@ export default function (Alpine) {
 
     // When cloning (or "morphing"), we will graft the style and position data from the live tree...
     (el, { expression, modifiers, value }, { cleanup, evaluate }) => {
-        let { placement, offsetValue, unstyled } = getOptions(modifiers)
+        let { placement, offsetValue, unstyled, strategy } = getOptions(modifiers)
 
         if (el._x_anchor) {
-            unstyled || setStyles(el, el._x_anchor.x, el._x_anchor.y)
+            unstyled || setStyles(el, el._x_anchor.x, el._x_anchor.y, strategy)
         }
     }))
 }
 
-function setStyles(el, x, y) {
+function setStyles(el, x, y, strategy = 'absolute') {
     Object.assign(el.style, {
-        left: x+'px', top: y+'px', position: 'absolute',
+        left: x+'px', top: y+'px', position: strategy,
     })
 }
 
@@ -86,5 +87,7 @@ function getOptions(modifiers) {
     }
     let unstyled = modifiers.includes('no-style')
 
-    return { placement, offsetValue, unstyled }
+    let strategy = modifiers.includes('fixed') ? 'fixed' : 'absolute'
+
+    return { placement, offsetValue, unstyled, strategy }
 }

--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -34,7 +34,7 @@ export default function (Alpine) {
                     let previousValue
 
                     let middleware = [
-                        flip(),
+                        allowFlip && flip(),
                         shift({padding: 5}),
                         offset(offsetValue)
                     ]
@@ -45,10 +45,6 @@ export default function (Alpine) {
                                 elements.floating.style.width = `${rects.reference.width}px`
                             },
                         }))
-                    }
-
-                    if(allowFlip){
-                        middleware.push(flip())
                     }
 
                     computePosition(reference, el, {

--- a/packages/docs/src/en/plugins/anchor.md
+++ b/packages/docs/src/en/plugins/anchor.md
@@ -145,6 +145,18 @@ You can instruct Floating UI to use a fixed positioning strategy by adding the `
 </div>
 <!-- END_VERBATIM -->
 
+You can also combine the .match-width modifier with .fixed to make the anchored element match the width of the reference element:
+
+```html
+<div x-data="{ open: false }">
+    <button x-ref="button" @click="open = ! open">Toggle</button>
+ 
+    <div x-show="open" x-anchor.fixed.match-width="$refs.button">
+        This element is now fixed to the viewport, anchored to the button, and matches the button's width.
+    </div>
+</div>
+```
+
 <a name="offset"></a>
 ## Offset
 

--- a/packages/docs/src/en/plugins/anchor.md
+++ b/packages/docs/src/en/plugins/anchor.md
@@ -116,6 +116,35 @@ Here is an example of using `.bottom-start` to position a dropdown below and to 
 </div>
 <!-- END_VERBATIM -->
 
+<a name="fixed-positioning"></a>
+### Fixed Positioning
+
+By default, `x-anchor` applies `position: absolute` to the anchored element. However, there are scenarios—such as when your reference element is inside a container with `overflow: hidden` or when you want the popover to stay pinned to the viewport during scroll—where you need fixed positioning instead.
+
+You can instruct Floating UI to use a fixed positioning strategy by adding the `.fixed` modifier:
+
+```html
+<div x-data="{ open: false }">
+    <button x-ref="button" @click="open = ! open">Toggle</button>
+ 
+    <div x-show="open" x-anchor.fixed="$refs.button">
+        This element is now fixed to the viewport, anchored to the button.
+    </div>
+</div>
+```
+
+<!-- START_VERBATIM -->
+<div x-data="{ open: false }" class="demo overflow-hidden">
+    <div class="flex justify-center">
+        <button x-ref="button" @click="open = ! open">Toggle</button>
+    </div>
+
+    <div x-show="open" x-anchor.fixed="$refs.button" class="bg-white rounded p-4 border shadow z-10">
+        Dropdown content
+    </div>
+</div>
+<!-- END_VERBATIM -->
+
 <a name="offset"></a>
 ## Offset
 

--- a/packages/docs/src/en/plugins/anchor.md
+++ b/packages/docs/src/en/plugins/anchor.md
@@ -117,18 +117,18 @@ Here is an example of using `.bottom-start` to position a dropdown below and to 
 <!-- END_VERBATIM -->
 
 <a name="fixed-positioning"></a>
-### Fixed Positioning
+### Fixed positioning
 
-By default, `x-anchor` applies `position: absolute` to the anchored element. However, there are scenarios—such as when your reference element is inside a container with `overflow: hidden` or when you want the popover to stay pinned to the viewport during scroll—where you need fixed positioning instead.
+By default, `x-anchor` applies `position: absolute` to the anchored element. This is fine for most cases, but it falls apart when the reference element lives inside a container with `overflow: hidden`, `overflow: clip`, or `overflow: auto`—the anchored element is clipped along with it.
 
-You can instruct Floating UI to use a fixed positioning strategy by adding the `.fixed` modifier:
+You can instruct Floating UI to use a fixed positioning strategy instead by adding the `.fixed` modifier:
 
 ```html
 <div x-data="{ open: false }">
     <button x-ref="button" @click="open = ! open">Toggle</button>
- 
+
     <div x-show="open" x-anchor.fixed="$refs.button">
-        This element is now fixed to the viewport, anchored to the button.
+        Dropdown content
     </div>
 </div>
 ```
@@ -145,17 +145,7 @@ You can instruct Floating UI to use a fixed positioning strategy by adding the `
 </div>
 <!-- END_VERBATIM -->
 
-You can also combine the .match-width modifier with .fixed to make the anchored element match the width of the reference element:
-
-```html
-<div x-data="{ open: false }">
-    <button x-ref="button" @click="open = ! open">Toggle</button>
- 
-    <div x-show="open" x-anchor.fixed.match-width="$refs.button">
-        This element is now fixed to the viewport, anchored to the button, and matches the button's width.
-    </div>
-</div>
-```
+> **Heads up:** a `transform`, `filter`, `perspective`, `backdrop-filter`, `will-change`, or `contain` on any ancestor element creates a new containing block for `position: fixed` descendants ([per the CSS spec](https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning)). When that happens, `.fixed` will behave like `position: absolute` relative to that ancestor—and won't escape its `overflow: hidden`. If `.fixed` seems to be doing nothing, check for a transformed ancestor.
 
 <a name="offset"></a>
 ## Offset
@@ -250,6 +240,18 @@ Below is an example of bypassing `x-anchor`'s internal styling and instead apply
     </div>
 </div>
 <!-- END_VERBATIM -->
+
+> **Combining `.no-style` with `.fixed`:** when you opt out of Alpine's internal styling and also want fixed positioning, remember to set `position: 'fixed'` yourself. `$anchor.x` and `$anchor.y` are returned in the coordinate space of whichever strategy is active—absolute coordinates are relative to the offset parent, fixed coordinates are relative to the viewport—so applying the wrong `position` will put your element in the wrong place.
+>
+> ```alpine
+> <div
+>     x-show="open"
+>     x-anchor.no-style.fixed="$refs.button"
+>     x-bind:style="{ position: 'fixed', top: $anchor.y+'px', left: $anchor.x+'px' }"
+> >
+>     Dropdown content
+> </div>
+> ```
 
 <a name="from-id"></a>
 ## Anchor to an ID

--- a/tests/cypress/integration/plugins/anchor.spec.js
+++ b/tests/cypress/integration/plugins/anchor.spec.js
@@ -57,3 +57,92 @@ test('noflip modifier prevents automatic flipping',
         })
     },
 )
+
+test('fixed modifier applies position: fixed',
+    [html`
+        <div x-data>
+            <button x-ref="foo">toggle</button>
+            <h1 x-anchor.fixed="$refs.foo" id="anchored">contents</h1>
+        </div>
+    `],
+    ({ get }) => {
+        get('#anchored').should(haveComputedStyle('position', 'fixed'))
+    },
+)
+
+test('absence of fixed modifier keeps default position: absolute',
+    [html`
+        <div x-data>
+            <button x-ref="foo">toggle</button>
+            <h1 x-anchor.bottom="$refs.foo" id="anchored">contents</h1>
+        </div>
+    `],
+    ({ get }) => {
+        get('#anchored').should(haveComputedStyle('position', 'absolute'))
+    },
+)
+
+test('fixed modifier order is interchangeable with placement modifiers',
+    [html`
+        <div x-data>
+            <button x-ref="foo">toggle</button>
+            <div x-anchor.bottom.fixed="$refs.foo" id="a">a</div>
+            <div x-anchor.fixed.bottom="$refs.foo" id="b">b</div>
+        </div>
+    `],
+    ({ get }) => {
+        get('#a').should(haveComputedStyle('position', 'fixed'))
+        get('#b').should(haveComputedStyle('position', 'fixed'))
+    },
+)
+
+test('fixed modifier still anchors when reference is inside a clipping parent',
+    [html`
+        <div x-data>
+            <div id="clip" style="position: relative; overflow: hidden; width: 150px; height: 40px;">
+                <button x-ref="foo" style="margin: 10px;">toggle</button>
+            </div>
+            <div x-anchor.fixed.bottom="$refs.foo" id="fixed-pop">fixed popover</div>
+        </div>
+    `],
+    ({ get }) => {
+        // With absolute strategy, the popover's offsetParent would be the
+        // clipping container (once it has position:relative), and overflow:
+        // hidden would cut it off. With the fixed strategy this PR adds,
+        // the popover's containing block is the viewport instead, so it
+        // escapes the clip.
+        get('#fixed-pop').should(haveComputedStyle('position', 'fixed'))
+
+        // And the popover should still be horizontally overlapping the button
+        // (it's anchored to it regardless of clipping).
+        get('button').then(($btn) => {
+            let btnRect = $btn[0].getBoundingClientRect()
+            get('#fixed-pop').then(($el) => {
+                let popRect = $el[0].getBoundingClientRect()
+                expect(popRect.left).to.be.lessThan(btnRect.right)
+                expect(popRect.right).to.be.greaterThan(btnRect.left)
+            })
+        })
+    },
+)
+
+test('fixed strategy survives a morph (clone branch re-applies strategy)',
+    [html`
+        <div id="wrap" x-data>
+            <button x-ref="foo">toggle</button>
+            <div x-anchor.fixed.bottom="$refs.foo" id="anchored">contents</div>
+        </div>
+    `],
+    ({ get }, reload, window, document) => {
+        get('#anchored').should(haveComputedStyle('position', 'fixed'))
+
+        // Morph the wrapper back into itself. This runs x-anchor's clone
+        // branch, which must re-apply position: fixed (not fall back to
+        // the hardcoded absolute that existed before this change).
+        let toHtml = document.querySelector('#wrap').outerHTML
+
+        get('#wrap').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('#anchored').should(haveComputedStyle('position', 'fixed'))
+    },
+)


### PR DESCRIPTION
## What

Adds a new `.fixed` modifier to the `x-anchor` directive that instructs Floating UI to use its `position: fixed` strategy instead of the default `position: absolute`.

```html
<div x-show="open" x-anchor.fixed="$refs.button">
    Dropdown content
</div>
```

## Why

`x-anchor` currently hardcodes `position: absolute` when applying styles. This works for most cases, but it breaks down when:

- The reference element lives inside a container with `overflow: hidden` / `overflow: clip` / `overflow: auto` — the popover gets clipped along with the parent.
- You want the popover to stay pinned to the viewport regardless of scroll.

Floating UI natively supports a `fixed` strategy for exactly this — Alpine just didn't have a way to pass it through.

## How

- `getOptions()` returns a new `strategy: 'fixed' | 'absolute'` field, derived from whether the `.fixed` modifier is present. Defaults to `'absolute'`, so existing `x-anchor` usage is byte-identical in behavior.
- `computePosition()` receives the `strategy` option.
- `setStyles()` takes the strategy as an argument (defaulting to `'absolute'`) and applies it as the CSS `position` value.
- The clone/morph branch also reads `strategy` from `getOptions(modifiers)` and forwards it to `setStyles()`. This is necessary for correctness: when `.fixed` is active, the `(x, y)` stored on `_x_anchor` are viewport-relative, so the pre-existing branch that called `setStyles(el, x, y)` would have applied viewport coordinates under `position: absolute` after a morph, placing the popover in the wrong spot. This PR implicitly fixes that.

## Backward compatibility

Fully additive. `strategy` defaults to `'absolute'` in every code path, and `setStyles` defaults its parameter to `'absolute'` too. Any existing `x-anchor` expression without the `.fixed` modifier produces identical output before and after this change.

## Documentation

- Tightens the Fixed positioning section's lede to describe when absolute falls short.
- Adds a prominent heads-up about the transformed-ancestor gotcha — if an ancestor has `transform`, `filter`, `perspective`, `backdrop-filter`, `will-change`, or `contain`, the CSS spec says it becomes a new containing block for `position: fixed` descendants, which is the #1 footgun when `.fixed` appears to do nothing.
- Adds a note under Manual styling explaining how to combine `.no-style` with `.fixed` correctly (the caller must apply `position: fixed` themselves, because `$anchor.x/y` are returned in the coordinate space of whichever strategy is active).

## Tests

New Cypress tests in `tests/cypress/integration/plugins/anchor.spec.js`:

- `.fixed` applies `position: fixed`
- absence of `.fixed` keeps the default `position: absolute` (backward-compat regression guard)
- modifier order is interchangeable (`.bottom.fixed` === `.fixed.bottom`)
- `.fixed` still correctly anchors when the reference lives inside a `position: relative; overflow: hidden` clipping container
- `.fixed` strategy survives an `Alpine.morph()` pass — verifies the clone-branch `setStyles` call now correctly re-applies the strategy

All existing anchor tests continue to pass unchanged.

## Scope

The `.match-width` modifier that was present in an earlier version of this PR has been removed. It is orthogonal to `.fixed` (works with either positioning strategy) and deserves its own PR where its inline-width override behavior and bundle cost can be reviewed on their own merits. A follow-up PR will reintroduce it with docs and tests.

---

Original work by @nicolagianelli. Scope cleanup, tests, and docs expansion by @calebporzio.