### PR TITLE
Fix `x-model.blur` crash when input is removed from a form

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -84,12 +84,17 @@ directive('model', (el, { modifiers, expression }, { effect, cleanup }) => {
             // submit handler runs. Register a pending update on the form
             // so it can be flushed before submit handlers execute.
             if (el.form) {
+                let form = el.form
                 let syncCallback = () => syncValue({ target: el })
 
-                if (!el.form._x_pendingModelUpdates) el.form._x_pendingModelUpdates = []
-                el.form._x_pendingModelUpdates.push(syncCallback)
+                if (!form._x_pendingModelUpdates) form._x_pendingModelUpdates = []
+                form._x_pendingModelUpdates.push(syncCallback)
 
-                cleanup(() => el.form._x_pendingModelUpdates.splice(el.form._x_pendingModelUpdates.indexOf(syncCallback), 1))
+                cleanup(() => {
+                    if (form._x_pendingModelUpdates) {
+                        form._x_pendingModelUpdates.splice(form._x_pendingModelUpdates.indexOf(syncCallback), 1)
+                    }
+                })
             }
         }
 

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -660,6 +660,31 @@ test('x-model.blur syncs value before form submit handler runs',
     }
 )
 
+test('x-model.blur does not throw when input is removed from form',
+    html`
+    <div x-data="{ value: '' }">
+        <form>
+            <input x-model.blur="value" type="text">
+        </form>
+        <span x-text="value"></span>
+    </div>
+    `,
+    ({ get }) => {
+        get('input').type('hello')
+
+        // Remove the input from the form, triggering Alpine's MutationObserver cleanup.
+        // After detachment, el.form is null, so the cleanup callback must guard against this.
+        get('input').then(([input]) => {
+            input.remove()
+        })
+
+        // Wait for MutationObserver to process the removal and run cleanups
+        cy.wait(100)
+
+        get('input').should('not.exist')
+    }
+)
+
 test('x-model with dotted expression that evaluates to undefined does not overwrite value attribute',
     html`
     <div x-data="{ form: { agree: undefined } }">


### PR DESCRIPTION
# The Scenario

When using `x-model.blur` on an input inside a `<form>`, removing that input from the DOM (e.g. during a Livewire morph or wizard step change) throws an error:

```
TypeError: null is not an object (evaluating 'e.form._x_pendingModelUpdates')
```

This was introduced in Alpine v3.15.8 with the `_x_pendingModelUpdates` feature, which ensures `x-model.blur` values sync before form submit handlers run.

```html
<div x-data="{ value: '' }">
    <form>
        <input x-model.blur="value" type="text">
    </form>
</div>
```

# The Problem

The cleanup callback for the pending model update registration accesses `el.form` without guarding against null:

```js
cleanup(() => el.form._x_pendingModelUpdates.splice(
    el.form._x_pendingModelUpdates.indexOf(syncCallback), 1
))
```

When an input is removed from the DOM, Alpine's MutationObserver triggers cleanup. At that point, `el.form` returns `null` because the detached element is no longer associated with a form, causing the TypeError.

While the initial registration correctly guards with `if (el.form)`, the cleanup callback runs later when the DOM state has changed.

# The Solution

Capture the form reference in a local variable at registration time and use that in the cleanup callback with a null guard on `_x_pendingModelUpdates`. This ensures the cleanup targets the correct form element regardless of the input's DOM state when cleanup runs.

Fixes https://github.com/livewire/livewire/discussions/10145