### PR TITLE
Fix x-if and x-for content duplicating during morph

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -125,6 +125,8 @@ function loop(templateEl, iteratorNames, evaluateItems, evaluateKey) {
             })
             added.forEach(clone => initTree(clone))
 
+            // Mark the last rendered element so morph can skip
+            // past these items instead of trying to diff them...
             if (prev !== templateEl) {
                 templateEl._x_lastRenderedEl = prev
             } else {

--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -7,7 +7,7 @@ import { mutateDom } from '../mutation'
 import { warn } from '../utils/warn'
 import { skipDuringClone } from '../clone'
 
-directive('for', (el, { expression }, { effect, cleanup }) => {
+directive('for', skipDuringClone((el, { expression }, { effect, cleanup }) => {
     let iteratorNames = parseForExpression(expression)
 
     let evaluateItems = evaluateLater(el, iteratorNames.items)
@@ -30,8 +30,9 @@ directive('for', (el, { expression }, { effect, cleanup }) => {
         )
 
         delete el._x_lookup
+        delete el._x_lastRenderedEl
     })
-})
+}))
 
 function refreshScope(scope) {
     return (newScope) => {
@@ -122,7 +123,13 @@ function loop(templateEl, iteratorNames, evaluateItems, evaluateKey) {
                 prev.after(clone)
                 prev = clone
             })
-            skipDuringClone(() => added.forEach(clone => initTree(clone)))()
+            added.forEach(clone => initTree(clone))
+
+            if (prev !== templateEl) {
+                templateEl._x_lastRenderedEl = prev
+            } else {
+                delete templateEl._x_lastRenderedEl
+            }
         })
     })
 }

--- a/packages/alpinejs/src/directives/x-if.js
+++ b/packages/alpinejs/src/directives/x-if.js
@@ -6,7 +6,7 @@ import { mutateDom } from '../mutation'
 import { warn } from "../utils/warn"
 import { skipDuringClone } from '../clone'
 
-directive('if', (el, { expression }, { effect, cleanup }) => {
+directive('if', skipDuringClone((el, { expression }, { effect, cleanup }) => {
     if (el.tagName.toLowerCase() !== 'template') warn('x-if can only be used on a <template> tag', el)
 
     let evaluate = evaluateLater(el, expression)
@@ -21,11 +21,12 @@ directive('if', (el, { expression }, { effect, cleanup }) => {
         mutateDom(() => {
             el.after(clone)
 
-            // These nodes will be "inited" as morph walks the tree...
-            skipDuringClone(() => initTree(clone))()
+            initTree(clone)
         })
 
         el._x_currentIfEl = clone
+
+        el._x_lastRenderedEl = clone
 
         el._x_undoIf = () => {
             mutateDom(() => {
@@ -35,6 +36,7 @@ directive('if', (el, { expression }, { effect, cleanup }) => {
             })
 
             delete el._x_currentIfEl
+            delete el._x_lastRenderedEl
         }
 
         return clone
@@ -53,4 +55,4 @@ directive('if', (el, { expression }, { effect, cleanup }) => {
     }))
 
     cleanup(() => el._x_undoIf && el._x_undoIf())
-})
+}))

--- a/packages/alpinejs/src/directives/x-if.js
+++ b/packages/alpinejs/src/directives/x-if.js
@@ -26,6 +26,8 @@ directive('if', skipDuringClone((el, { expression }, { effect, cleanup }) => {
 
         el._x_currentIfEl = clone
 
+        // Mark the last rendered element so morph can skip
+        // past it instead of trying to diff it...
         el._x_lastRenderedEl = clone
 
         el._x_undoIf = () => {

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -370,6 +370,9 @@ function createMorphContext(options = {}) {
             // Patch elements
             context.patch(currentFrom, currentTo)
 
+            // Directives like x-if and x-for insert sibling elements
+            // that they manage. Skip past them — they'll be handled
+            // by Alpine's reactivity after the morph completes...
             if (currentFrom._x_lastRenderedEl) {
                 currentFromNext = getNextSibling(from, currentFrom._x_lastRenderedEl)
             }

--- a/packages/morph/src/morph.js
+++ b/packages/morph/src/morph.js
@@ -370,6 +370,10 @@ function createMorphContext(options = {}) {
             // Patch elements
             context.patch(currentFrom, currentTo)
 
+            if (currentFrom._x_lastRenderedEl) {
+                currentFromNext = getNextSibling(from, currentFrom._x_lastRenderedEl)
+            }
+
             currentTo = currentTo && getNextSibling(to, currentTo) // dom.next(from, toChildren, currentTo))
 
             currentFrom = currentFromNext

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -1132,3 +1132,104 @@ test('can morph child element containing x-ref without crashing',
         get('input').should(haveFocus())
     },
 )
+
+test('morph with x-if does not duplicate content when data changes before morph',
+    [html`
+        <div x-data>
+            <div id="root">
+                <template x-if="$store.test.show">
+                    <p>Hello world!</p>
+                </template>
+
+                <button>Open</button>
+            </div>
+        </div>
+    `,
+    `
+        Alpine.store('test', { show: false })
+    `],
+    ({ get }, reload, window, document) => {
+        get('p').should('not.exist')
+
+        get('#root').then(async ([el]) => {
+            let toHtml = el.outerHTML
+
+            await window.Alpine.transaction(async () => {
+                window.Alpine.store('test').show = true
+
+                window.Alpine.morph(el, toHtml)
+            })
+
+            // Wait for deferred effects to flush (they're scheduled as a microtask after the transaction commits)...
+            await new Promise(queueMicrotask)
+
+            expect(el.querySelectorAll('p').length).to.equal(1)
+        })
+    },
+)
+
+test('morph with x-for does not duplicate items when data changes before morph',
+    [html`
+        <div x-data>
+            <div id="root">
+                <template x-for="item in $store.test.items" :key="item">
+                    <p x-text="item"></p>
+                </template>
+
+                <button>Load</button>
+            </div>
+        </div>
+    `,
+    `
+        Alpine.store('test', { items: [] })
+    `],
+    ({ get }, reload, window, document) => {
+        get('p').should('not.exist')
+
+        get('#root').then(async ([el]) => {
+            let toHtml = el.outerHTML
+
+            await window.Alpine.transaction(async () => {
+                window.Alpine.store('test').items = ['Apple', 'Banana', 'Cherry']
+
+                window.Alpine.morph(el, toHtml)
+            })
+
+            // Wait for deferred effects to flush (they're scheduled as a microtask after the transaction commits)...
+            await new Promise(queueMicrotask)
+
+            expect(el.querySelectorAll('p').length).to.equal(3)
+        })
+    },
+)
+
+test('morph preserves x-if content and nested Alpine state across morph',
+    [html`
+        <div x-data id="root">
+            <div x-data="{ showCounter: false }">
+                <button @click="showCounter = true" id="show-btn">show</button>
+
+                <template x-if="showCounter">
+                    <div x-data="{ count: 0 }">
+                        <button @click="count++" id="inc-btn">+</button>
+                        <span x-text="count" id="count"></span>
+                    </div>
+                </template>
+            </div>
+        </div>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = document.querySelector('#root').outerHTML
+
+        get('#count').should('not.exist')
+        get('#show-btn').click()
+        get('#count').should(haveText('0'))
+        get('#inc-btn').click()
+        get('#count').should(haveText('1'))
+
+        get('#root').then(([el]) => window.Alpine.morph(el, toHtml))
+
+        get('#count').should('be.visible')
+        get('#count').should(haveText('1'))
+    },
+)


### PR DESCRIPTION
# The scenario

`<template x-if>` evaluating `$wire` data renders its content twice when value becomes `true`.

```php
new class extends Component
{
    public bool $show = false;

    public function open()
    {
        $this->show = true;
    }
};
?>

<div>
    <template x-if="$wire.show">
        <p>Hello world!</p>
    </template>

    <button wire:click="open">Open</button>
</div>
```

Clicking _open_ causes the `<p>` tag to render twice.

```html
<div>
     <p>Hello world!</p>
     <p>Hello world!</p>

    <button wire:click="open">Open</button>
</div>
```

The same issue affects `<template x-for>`.

# The problem

`Alpine.transaction()` defers reactive effects until the morph completes, but the morph evaluates directives using the already-updated reactive data. For x-if and x-for — which insert sibling elements when they evaluate — this causes duplication:

1. **Data updates** — `$wire.show` becomes `true`. The x-if effect is deferred by the transaction.
2. **Morph runs** — Initializes Alpine directives on each server HTML element. x-if evaluates `$wire.show`, sees `true`, and injects a `<p>` into the server HTML tree.
3. **Morph patches** — The morph sees the injected `<p>` in the server HTML but not in the live DOM, and adds it.
4. **Transaction ends** — The deferred x-if effect fires, evaluates `$wire.show` as `true`, and adds the same `<p>` again.

```
Live DOM:              Server HTML:           Result:

<div>                  <div>                  <div>
├── <template x-if>    ├── <template x-if>    ├── <template x-if>
│                      ├── <p>                ├── <p>  ← from morph
├── <button>           ├── <button>           ├── <p>  ← from x-if effect
</div>                 </div>                 ├── <button>
                                              </div>
```

# The solution

We stop the morph from comparing x-if/x-for rendered content entirely. Both sides are handled:

**Server HTML** — x-if and x-for are wrapped in `skipDuringClone`, so they no longer evaluate during morph. The server HTML stays clean.

**Live DOM** — x-if and x-for declare the last element they rendered via `_x_lastRenderedEl`. The morph skips past these elements instead of trying to match them against the server HTML:

```js
if (currentFrom._x_lastRenderedEl) {
    currentFromNext = getNextSibling(from, currentFrom._x_lastRenderedEl)
}
```

The rendered content stays in place untouched — Alpine's reactivity handles any updates after the morph completes.

Fixes livewire/livewire#10097