### PR TITLE
Fix x-anchor crash during wire:navigate cleanup

### DIFF
--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -21,9 +21,9 @@ export default function (Alpine) {
         let previousReference = null
         let release = null
 
-        let effector = effect(() => {
+        effect(() => {
             let reference = evaluate(expression)
-            if (! reference) throw 'Alpine: no element provided to x-anchor...'
+            if (! reference) return
 
             if (previousReference !== reference) {
                 if (release) release()
@@ -54,7 +54,6 @@ export default function (Alpine) {
         })
 
         cleanup(() => {
-            effector()
             if (release) release()
         })
     },


### PR DESCRIPTION
The reactive effect introduced in #4735 stored the effect runner as `effector` and called `effector()` during cleanup. Calling a Vue effect runner re-executes the callback — it doesn't stop it. Alpine's directive system already stops the effect via `cleanupEffect` from `elementBoundEffect`, so the extra call was both redundant and harmful.

During `wire:navigate`, Livewire's `destroyTree` walks the DOM depth-first. The `x-ref` element is cleaned up before the `x-anchor` element, deleting the ref. When x-anchor's cleanup then re-ran the effect, `evaluate("$refs.button")` returned `undefined`, hitting the `throw` and blocking navigation.

**Fix:** Remove the `effector()` call from cleanup (unnecessary), and `return` instead of `throw` on a missing reference (graceful during teardown, and safe because directive ordering guarantees refs exist on first run).

Fixes https://github.com/livewire/livewire/discussions/10166

🤖 Generated with [Claude Code](https://claude.com/claude-code)