### PR TITLE
Add `x-anchor.noflip` modifier

### DIFF
--- a/packages/anchor/src/index.js
+++ b/packages/anchor/src/index.js
@@ -14,7 +14,7 @@ export default function (Alpine) {
     })
 
     Alpine.directive('anchor', Alpine.skipDuringClone((el, { expression, modifiers, value }, { evaluate, effect, cleanup }) => {
-        let { placement, offsetValue, unstyled } = getOptions(modifiers)
+        let { placement, offsetValue, unstyled, allowFlip } = getOptions(modifiers)
 
         el._x_anchor = Alpine.reactive({ x: 0, y: 0 })
 
@@ -35,7 +35,7 @@ export default function (Alpine) {
 
                     computePosition(reference, el, {
                         placement,
-                        middleware: [flip(), shift({padding: 5}), offset(offsetValue)],
+                        middleware: [allowFlip && flip(), shift({padding: 5}), offset(offsetValue)],
                     }).then(({ x, y }) => {
                         unstyled || setStyles(el, x, y)
 
@@ -84,6 +84,7 @@ function getOptions(modifiers) {
         offsetValue = modifiers[idx + 1] !== undefined ? Number(modifiers[idx + 1]) : offsetValue
     }
     let unstyled = modifiers.includes('no-style')
+    let allowFlip = ! modifiers.includes('noflip')
 
-    return { placement, offsetValue, unstyled }
+    return { placement, offsetValue, unstyled, allowFlip }
 }

--- a/packages/docs/src/en/plugins/anchor.md
+++ b/packages/docs/src/en/plugins/anchor.md
@@ -143,6 +143,35 @@ You can add an offset to your anchored element using the `.offset.[px value]` mo
 </div>
 <!-- END_VERBATIM -->
 
+<a name="prevent-flipping"></a>
+## Prevent flipping position
+
+By default, `x-anchor` will flip the position of the anchored element if it doesn't have enough room to render below the reference element.
+
+You can prevent this behavior by adding the `.noflip` modifier:
+
+```alpine
+<div x-data="{ open: false }">
+    <button x-ref="button" @click="open = ! open">Toggle</button>
+
+    <div x-show="open" x-anchor.noflip="$refs.button">
+        Dropdown content
+    </div>
+</div>
+```
+
+<!-- START_VERBATIM -->
+<div x-data="{ open: false }" class="demo overflow-hidden">
+    <div class="flex justify-center">
+        <button x-ref="button" @click="open = ! open">Toggle</button>
+    </div>
+
+    <div x-show="open" x-anchor.noflip="$refs.button" class="bg-white rounded p-4 border shadow z-10">
+        Dropdown content
+    </div>
+</div>
+<!-- END_VERBATIM -->
+
 <a name="manual-styling"></a>
 ## Manual styling
 
@@ -210,4 +239,3 @@ Because `x-anchor` accepts a reference to any DOM element, you can use utilities
     </div>
 </div>
 <!-- END_VERBATIM -->
-

--- a/tests/cypress/integration/plugins/anchor.spec.js
+++ b/tests/cypress/integration/plugins/anchor.spec.js
@@ -34,3 +34,26 @@ test('can anchor to dynamic reference',
         })
     }
 )
+
+test('noflip modifier prevents automatic flipping',
+    [html`
+        <div x-data style="height: 100vh; display: flex; align-items: flex-end;">
+            <button x-ref="foo" style="margin-top: auto;">toggle</button>
+            <div x-anchor.bottom.noflip="$refs.foo" id="anchored">dropdown</div>
+        </div>
+    `],
+    ({ get }, reload) => {
+        get('#anchored').should(haveComputedStyle('position', 'absolute'))
+
+        // The element should be positioned below the button (bottom placement)
+        // even though there's no room — noflip prevents it from flipping to top
+        get('button').then(($btn) => {
+            let btnBottom = $btn[0].getBoundingClientRect().bottom
+
+            get('#anchored').then(($el) => {
+                let elTop = $el[0].getBoundingClientRect().top
+                expect(elTop).to.be.gte(btnBottom - 1)
+            })
+        })
+    },
+)


### PR DESCRIPTION
Adds a `.noflip` modifier to `x-anchor` that prevents automatic flipping of anchored elements when there's not enough room.

Rebased and conflict-resolved version of #4382 by @aguingand.

## Usage

```html
<div x-anchor.noflip="$refs.button">...</div>
<div x-anchor.bottom-start.noflip="$refs.button">...</div>
```

## Changes

- Parse `noflip` modifier → `allowFlip = !modifiers.includes('noflip')`
- Conditionally include flip middleware → `allowFlip && flip()`
- Added docs section with code example and live demo
- Added Cypress test verifying noflip prevents position flipping

Closes #4382