### PR TITLE
feat(csp): support optional chaining and nullish coalescing in evaluator

### DIFF
--- a/packages/csp/src/parser.js
+++ b/packages/csp/src/parser.js
@@ -197,6 +197,12 @@ class Tokenizer {
         } else if (char === '-' && next === '-') {
             this.position += 2;
             this.tokens.push(new Token('OPERATOR', '--', start, this.position));
+        } else if (char === '?' && next === '?') {
+            this.position += 2;
+            this.tokens.push(new Token('OPERATOR', '??', start, this.position));
+        } else if (char === '?' && next === '.' && !this.isDigit(nextNext)) {
+            this.position += 2;
+            this.tokens.push(new Token('OPERATOR', '?.', start, this.position));
         }
         // Single-character operators and punctuation
         else {
@@ -252,7 +258,7 @@ class Parser {
     }
 
     parseTernary() {
-        const expr = this.parseLogicalOr();
+        const expr = this.parseNullishCoalescing();
 
         if (this.match('PUNCTUATION', '?')) {
             const consequent = this.parseExpression();
@@ -263,6 +269,23 @@ class Parser {
                 test: expr,
                 consequent,
                 alternate
+            };
+        }
+
+        return expr;
+    }
+
+    parseNullishCoalescing() {
+        let expr = this.parseLogicalOr();
+
+        while (this.match('OPERATOR', '??')) {
+            const operator = this.previous().value;
+            const right = this.parseLogicalOr();
+            expr = {
+                type: 'BinaryExpression',
+                operator,
+                left: expr,
+                right
             };
         }
 
@@ -444,6 +467,32 @@ class Parser {
                     callee: expr,
                     arguments: args
                 };
+            } else if (this.match('OPERATOR', '?.')) {
+                if (this.match('PUNCTUATION', '(')) {
+                    const args = this.parseArguments();
+                    expr = {
+                        type: 'OptionalCallExpression',
+                        callee: expr,
+                        arguments: args
+                    };
+                } else if (this.match('PUNCTUATION', '[')) {
+                    const property = this.parseExpression();
+                    this.consume('PUNCTUATION', ']');
+                    expr = {
+                        type: 'OptionalMemberExpression',
+                        object: expr,
+                        property,
+                        computed: true
+                    };
+                } else {
+                    const property = this.consume('IDENTIFIER');
+                    expr = {
+                        type: 'OptionalMemberExpression',
+                        object: expr,
+                        property: { type: 'Identifier', name: property.value },
+                        computed: false
+                    };
+                }
             } else {
                 break;
             }
@@ -704,6 +753,35 @@ class Evaluator {
 
                 return memberValue;
 
+            case 'OptionalMemberExpression':
+                const optObject = this.evaluate({ node: node.object, scope, context, forceBindingRootScopeToFunctions });
+                if (optObject == null) {
+                    return undefined;
+                }
+
+                let optProperty;
+                if (node.computed) {
+                    optProperty = this.evaluate({ node: node.property, scope, context, forceBindingRootScopeToFunctions });
+                } else {
+                    optProperty = node.property.name;
+                }
+
+                this.checkForDangerousKeywords(optProperty)
+
+                let optMemberValue = optObject[optProperty];
+
+                this.checkForDangerousValues(optMemberValue)
+
+                if (typeof optMemberValue === 'function') {
+                    if (forceBindingRootScopeToFunctions) {
+                        return optMemberValue.bind(scope);
+                    } else {
+                        return optMemberValue.bind(optObject);
+                    }
+                }
+
+                return optMemberValue;
+
             case 'CallExpression':
                 const args = node.arguments.map(arg => this.evaluate({ node: arg, scope, context, forceBindingRootScopeToFunctions }));
 
@@ -763,6 +841,65 @@ class Evaluator {
                 this.checkForDangerousValues(returnValue)
 
                 return returnValue
+
+            case 'OptionalCallExpression':
+                const optCallArgs = node.arguments.map(arg => this.evaluate({ node: arg, scope, context, forceBindingRootScopeToFunctions }));
+
+                let optCallReturnValue;
+
+                if (node.callee.type === 'MemberExpression' || node.callee.type === 'OptionalMemberExpression') {
+                    const obj = this.evaluate({ node: node.callee.object, scope, context, forceBindingRootScopeToFunctions });
+
+                    if (obj == null) return undefined;
+
+                    let prop;
+                    if (node.callee.computed) {
+                        prop = this.evaluate({ node: node.callee.property, scope, context, forceBindingRootScopeToFunctions });
+                    } else {
+                        prop = node.callee.property.name
+                    }
+
+                    this.checkForDangerousKeywords(prop)
+
+                    let func = obj[prop];
+                    if (func == null) return undefined;
+                    if (typeof func !== 'function') {
+                        throw new Error('Value is not a function');
+                    }
+
+                    optCallReturnValue = func.apply(obj, optCallArgs);
+                } else {
+                    if (node.callee.type === 'Identifier') {
+                        const name = node.callee.name;
+
+                        let func;
+                        if (name in scope) {
+                            func = scope[name];
+                        } else {
+                            return undefined;
+                        }
+
+                        if (func == null) return undefined;
+                        if (typeof func !== 'function') {
+                            throw new Error('Value is not a function');
+                        }
+
+                        const thisContext = context !== null ? context : scope;
+                        optCallReturnValue = func.apply(thisContext, optCallArgs);
+                    } else {
+                        const callee = this.evaluate({ node: node.callee, scope, context, forceBindingRootScopeToFunctions });
+                        if (callee == null) return undefined;
+                        if (typeof callee !== 'function') {
+                            throw new Error('Value is not a function');
+                        }
+
+                        optCallReturnValue = callee.apply(context, optCallArgs);
+                    }
+                }
+
+                this.checkForDangerousValues(optCallReturnValue)
+
+                return optCallReturnValue
 
             case 'UnaryExpression':
                 const argument = this.evaluate({ node: node.argument, scope, context, forceBindingRootScopeToFunctions });
@@ -830,6 +967,7 @@ class Evaluator {
                     case '>=': return left >= right;
                     case '&&': return left && right;
                     case '||': return left || right;
+                    case '??': return left != null ? left : right;
                     default:
                         throw new Error(`Unknown binary operator: ${node.operator}`);
                 }

--- a/tests/cypress/integration/plugins/csp-compatibility.spec.js
+++ b/tests/cypress/integration/plugins/csp-compatibility.spec.js
@@ -29,6 +29,19 @@ test.csp('supports x-model with dotted path',
     }
 )
 
+test.csp('x-text with optional chaining and nullish coalescing',
+    [html`
+        <div x-data="{ user: null, config: { theme: 'dark' } }">
+            <span id="fallback" x-text="user?.name ?? 'anonymous'"></span>
+            <span id="value" x-text="config?.theme ?? 'light'"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#fallback').should(haveText('anonymous'))
+        get('#value').should(haveText('dark'))
+    }
+)
+
 test.csp('throws when accessing a global',
     [html`
         <button x-data x-on:click="document.write('evil')"></button>

--- a/tests/vitest/csp-evaluator.spec.js
+++ b/tests/vitest/csp-evaluator.spec.js
@@ -96,6 +96,134 @@ describe('cspRawEvaluator', () => {
     });
 });
 
+describe('Optional chaining', () => {
+    it('obj?.prop returns value when obj exists', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { user: { name: 'Alice' } }
+
+        expect(cspRawEvaluator(element, 'user?.name', { scope })).toBe('Alice')
+    });
+
+    it('obj?.prop returns undefined when obj is null', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { user: null }
+
+        expect(cspRawEvaluator(element, 'user?.name', { scope })).toBe(undefined)
+    });
+
+    it('obj?.prop returns undefined when obj is undefined', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { user: undefined }
+
+        expect(cspRawEvaluator(element, 'user?.name', { scope })).toBe(undefined)
+    });
+
+    it('chained a?.b?.c', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+
+        expect(cspRawEvaluator(element, 'a?.b?.c', { scope: { a: { b: { c: 42 } } } })).toBe(42)
+        expect(cspRawEvaluator(element, 'a?.b?.c', { scope: { a: null } })).toBe(undefined)
+    });
+
+    it('computed optional access obj?.[key]', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { obj: { x: 'found' }, key: 'x' }
+
+        expect(cspRawEvaluator(element, 'obj?.[key]', { scope })).toBe('found')
+    });
+
+    it('fn?.() returns result when fn exists', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { fn: () => 99 }
+
+        expect(cspRawEvaluator(element, 'fn?.()', { scope })).toBe(99)
+    });
+
+    it('fn?.() returns undefined when fn is null', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { fn: null }
+
+        expect(cspRawEvaluator(element, 'fn?.()', { scope })).toBe(undefined)
+    });
+
+    it('obj.method?.() with member callee', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { obj: { greet: (name) => `hi ${name}` } }
+
+        expect(cspRawEvaluator(element, 'obj.greet?.("world")', { scope })).toBe('hi world')
+    });
+
+    it('security: obj?.__proto__ blocked', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { obj: {} }
+
+        expect(() => {
+            cspRawEvaluator(element, 'obj?.__proto__', { scope })
+        }).toThrow('prohibited')
+    });
+
+    it('security: $el?.insertAdjacentHTML blocked', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let domNode = document.createElement('div')
+        let scope = { $el: domNode }
+
+        expect(() => {
+            cspRawEvaluator(element, '$el?.insertAdjacentHTML', { scope })
+        }).toThrow('prohibited')
+    });
+});
+
+describe('Nullish coalescing', () => {
+    it('a ?? b returns a when a is not nullish', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: 'hello', b: 'fallback' }
+
+        expect(cspRawEvaluator(element, 'a ?? b', { scope })).toBe('hello')
+    });
+
+    it('a ?? b returns b when a is null', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: null, b: 'fallback' }
+
+        expect(cspRawEvaluator(element, 'a ?? b', { scope })).toBe('fallback')
+    });
+
+    it('a ?? b returns b when a is undefined', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: undefined, b: 'fallback' }
+
+        expect(cspRawEvaluator(element, 'a ?? b', { scope })).toBe('fallback')
+    });
+
+    it('a ?? b returns a when a is 0 (unlike ||)', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: 0, b: 'fallback' }
+
+        expect(cspRawEvaluator(element, 'a ?? b', { scope })).toBe(0)
+    });
+
+    it('a ?? b returns a when a is empty string (unlike ||)', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: '', b: 'fallback' }
+
+        expect(cspRawEvaluator(element, 'a ?? b', { scope })).toBe('')
+    });
+
+    it('a ?? b returns a when a is false (unlike ||)', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: false, b: 'fallback' }
+
+        expect(cspRawEvaluator(element, 'a ?? b', { scope })).toBe(false)
+    });
+
+    it('obj?.prop ?? default end-to-end', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+
+        expect(cspRawEvaluator(element, "user?.name ?? 'anon'", { scope: { user: { name: 'Alice' } } })).toBe('Alice')
+        expect(cspRawEvaluator(element, "user?.name ?? 'anon'", { scope: { user: null } })).toBe('anon')
+    });
+});
+
 describe('MemberExpression assignments', () => {
     it('simple dot-path assignment (x-model="form.name" setter)', () => {
         let element = { parentNode: null, _x_dataStack: [] }

--- a/tests/vitest/csp-parser.spec.js
+++ b/tests/vitest/csp-parser.spec.js
@@ -528,12 +528,14 @@ describe('CSP Parser', () => {
             expect(() => generateRuntimeFunction('[a, b] = arr')).toThrow();
         });
 
-        it('should not support optional chaining', () => {
-            expect(() => generateRuntimeFunction('obj?.prop')).toThrow();
+        it('should support optional chaining', () => {
+            const scope = { obj: { prop: 'value' } };
+            expect(generateRuntimeFunction('obj?.prop')({ scope })).toBe('value');
         });
 
-        it('should not support nullish coalescing', () => {
-            expect(() => generateRuntimeFunction('value ?? default')).toThrow();
+        it('should support nullish coalescing', () => {
+            const scope = { value: null, fallback: 'default' };
+            expect(generateRuntimeFunction('value ?? fallback')({ scope })).toBe('default');
         });
 
         it('should not support compound assignment', () => {
@@ -628,6 +630,137 @@ describe('CSP Parser', () => {
             const el = document.createElement('div');
             const scope = { style: el.style };
             expect(() => generateRuntimeFunction('style.background = "red"')({ scope })).toThrow('DOM objects are prohibited');
+        });
+    });
+
+    describe('Optional Chaining', () => {
+        it('should access property when object exists', () => {
+            const scope = { obj: { prop: 'value' } };
+            expect(generateRuntimeFunction('obj?.prop')({ scope })).toBe('value');
+        });
+
+        it('should return undefined when object is null', () => {
+            const scope = { obj: null };
+            expect(generateRuntimeFunction('obj?.prop')({ scope })).toBe(undefined);
+        });
+
+        it('should return undefined when object is undefined', () => {
+            const scope = { obj: undefined };
+            expect(generateRuntimeFunction('obj?.prop')({ scope })).toBe(undefined);
+        });
+
+        it('should handle chained optional access', () => {
+            const scope = { a: { b: { c: 'deep' } } };
+            expect(generateRuntimeFunction('a?.b?.c')({ scope })).toBe('deep');
+        });
+
+        it('should short-circuit chained optional access', () => {
+            const scope = { a: null };
+            expect(generateRuntimeFunction('a?.b?.c')({ scope })).toBe(undefined);
+        });
+
+        it('should handle computed optional access', () => {
+            const scope = { obj: { foo: 'bar' }, key: 'foo' };
+            expect(generateRuntimeFunction('obj?.[key]')({ scope })).toBe('bar');
+        });
+
+        it('should return undefined for computed access on null', () => {
+            const scope = { obj: null, key: 'foo' };
+            expect(generateRuntimeFunction('obj?.[key]')({ scope })).toBe(undefined);
+        });
+
+        it('should handle optional call when function exists', () => {
+            const scope = { fn: () => 42 };
+            expect(generateRuntimeFunction('fn?.()')({ scope })).toBe(42);
+        });
+
+        it('should return undefined for optional call on null', () => {
+            const scope = { fn: null };
+            expect(generateRuntimeFunction('fn?.()')({ scope })).toBe(undefined);
+        });
+
+        it('should return undefined for optional call on undefined', () => {
+            const scope = { fn: undefined };
+            expect(generateRuntimeFunction('fn?.()')({ scope })).toBe(undefined);
+        });
+
+        it('should handle optional call on member expression', () => {
+            const scope = { obj: { method: (x) => x * 2 } };
+            expect(generateRuntimeFunction('obj.method?.(5)')({ scope })).toBe(10);
+        });
+
+        it('should return undefined for optional call on missing method', () => {
+            const scope = { obj: {} };
+            expect(generateRuntimeFunction('obj.method?.()')({ scope })).toBe(undefined);
+        });
+
+        it('should block dangerous keywords with optional chaining', () => {
+            const scope = { obj: {} };
+            expect(() => generateRuntimeFunction('obj?.__proto__')({ scope })).toThrow('prohibited');
+        });
+
+        it('should block dangerous keywords with optional chaining on DOM element', () => {
+            const scope = { $el: document.createElement('div') };
+            expect(() => generateRuntimeFunction('$el?.insertAdjacentHTML')({ scope })).toThrow('prohibited');
+        });
+
+        it('should not confuse ternary with optional chaining', () => {
+            expect(generateRuntimeFunction('true ? 0.5 : 0')()).toBe(0.5);
+            expect(generateRuntimeFunction('false ? 0.5 : 0')()).toBe(0);
+        });
+    });
+
+    describe('Nullish Coalescing', () => {
+        it('should return left when not nullish', () => {
+            const scope = { a: 'hello', b: 'fallback' };
+            expect(generateRuntimeFunction('a ?? b')({ scope })).toBe('hello');
+        });
+
+        it('should return right when left is null', () => {
+            const scope = { a: null, b: 'fallback' };
+            expect(generateRuntimeFunction('a ?? b')({ scope })).toBe('fallback');
+        });
+
+        it('should return right when left is undefined', () => {
+            const scope = { a: undefined, b: 'fallback' };
+            expect(generateRuntimeFunction('a ?? b')({ scope })).toBe('fallback');
+        });
+
+        it('should return left when left is 0 (unlike ||)', () => {
+            const scope = { a: 0, b: 'fallback' };
+            expect(generateRuntimeFunction('a ?? b')({ scope })).toBe(0);
+        });
+
+        it('should return left when left is empty string (unlike ||)', () => {
+            const scope = { a: '', b: 'fallback' };
+            expect(generateRuntimeFunction('a ?? b')({ scope })).toBe('');
+        });
+
+        it('should return left when left is false (unlike ||)', () => {
+            const scope = { a: false, b: 'fallback' };
+            expect(generateRuntimeFunction('a ?? b')({ scope })).toBe(false);
+        });
+
+        it('should work with literal fallback', () => {
+            const scope = { a: null };
+            expect(generateRuntimeFunction("a ?? 'default'")({ scope })).toBe('default');
+        });
+    });
+
+    describe('Optional Chaining + Nullish Coalescing Combined', () => {
+        it('should combine optional chaining with nullish coalescing', () => {
+            const scope = { obj: { prop: 'value' } };
+            expect(generateRuntimeFunction("obj?.prop ?? 'default'")({ scope })).toBe('value');
+        });
+
+        it('should fall back when optional chaining returns undefined', () => {
+            const scope = { obj: null };
+            expect(generateRuntimeFunction("obj?.prop ?? 'default'")({ scope })).toBe('default');
+        });
+
+        it('should handle deeply chained with fallback', () => {
+            const scope = { a: { b: null } };
+            expect(generateRuntimeFunction("a?.b?.c ?? 'missing'")({ scope })).toBe('missing');
         });
     });
 


### PR DESCRIPTION
Add obj?.prop, obj?.[key], fn?.(), and a ?? b to the CSP evaluator, avoiding verbose ternary workarounds in templates. Route all optional paths through the existing checkForDangerousKeywords and checkForDangerousValues guards.

Like && and ||, ?? eagerly evaluates both operands rather than short-circuiting per spec. This is consistent with the existing evaluator pattern.

a?.b.c where a is null will throw rather than short-circuit the entire chain. Use a?.b?.c instead. Fixing this would require an OptionalExpression wrapper node to propagate short-circuit context.

Ref: ECMA-262 11.7: OptionalChainingPunctuator digit lookahead
Ref: ECMA-262 12.3.9: Optional Chains
Ref: ECMA-262 12.13: CoalesceExpression