### PR TITLE
feat(csp): support template literals in evaluator

### DIFF
--- a/packages/csp/src/parser.js
+++ b/packages/csp/src/parser.js
@@ -37,6 +37,8 @@ class Tokenizer {
                 this.readIdentifierOrKeyword();
             } else if (char === '"' || char === "'") {
                 this.readString();
+            } else if (char === '`') {
+                this.readTemplateLiteral();
             } else if (char === '/' && this.peek() === '/') {
                 this.skipLineComment();
             } else {
@@ -156,6 +158,84 @@ class Tokenizer {
         }
 
         throw new Error(`Unterminated string starting at position ${start}`);
+    }
+
+    readTemplateLiteral() {
+        const start = this.position;
+        this.position++; // Skip opening backtick
+
+        this.tokens.push(new Token('TEMPLATE_START', '`', start, this.position));
+
+        let value = '';
+        let quasiStart = this.position;
+
+        while (this.position < this.input.length) {
+            const char = this.input[this.position];
+
+            if (char === '\\') {
+                this.position++;
+                if (this.position < this.input.length) {
+                    const escaped = this.input[this.position];
+                    switch (escaped) {
+                        case 'n': value += '\n'; break;
+                        case 't': value += '\t'; break;
+                        case 'r': value += '\r'; break;
+                        case '\\': value += '\\'; break;
+                        case '`': value += '`'; break;
+                        case '$': value += '$'; break;
+                        default: value += escaped;
+                    }
+                    this.position++;
+                }
+            } else if (char === '$' && this.peek() === '{') {
+                this.tokens.push(new Token('TEMPLATE_QUASI', value, quasiStart, this.position));
+                value = '';
+
+                this.position += 2; // Skip ${
+                this.tokens.push(new Token('TEMPLATE_EXPR_START', '${', this.position - 2, this.position));
+
+                let braceDepth = 1;
+                while (this.position < this.input.length && braceDepth > 0) {
+                    this.skipWhitespace();
+                    if (this.position >= this.input.length || (this.input[this.position] === '}' && braceDepth === 1)) break;
+
+                    const innerChar = this.input[this.position];
+                    if (innerChar === '{') {
+                        braceDepth++;
+                        this.readOperatorOrPunctuation();
+                    } else if (innerChar === '}') {
+                        braceDepth--;
+                        if (braceDepth > 0) this.readOperatorOrPunctuation();
+                    } else if (this.isDigit(innerChar)) {
+                        this.readNumber();
+                    } else if (this.isAlpha(innerChar) || innerChar === '_' || innerChar === '$') {
+                        this.readIdentifierOrKeyword();
+                    } else if (innerChar === '"' || innerChar === "'") {
+                        this.readString();
+                    } else {
+                        this.readOperatorOrPunctuation();
+                    }
+                }
+
+                if (this.position < this.input.length && this.input[this.position] === '}') {
+                    this.position++; // Skip closing }
+                    this.tokens.push(new Token('TEMPLATE_EXPR_END', '}', this.position - 1, this.position));
+                } else if (this.position >= this.input.length) {
+                    throw new Error(`Unterminated template expression starting at position ${this.position}`);
+                }
+                quasiStart = this.position;
+            } else if (char === '`') {
+                this.tokens.push(new Token('TEMPLATE_QUASI', value, quasiStart, this.position));
+                this.position++; // Skip closing backtick
+                this.tokens.push(new Token('TEMPLATE_END', '`', this.position - 1, this.position));
+                return;
+            } else {
+                value += char;
+                this.position++;
+            }
+        }
+
+        throw new Error(`Unterminated template literal starting at position ${start}`);
     }
 
     readOperatorOrPunctuation() {
@@ -465,6 +545,31 @@ class Parser {
         return args;
     }
 
+    parseTemplateLiteral() {
+        const quasis = [];
+        const expressions = [];
+
+        while (!this.match('TEMPLATE_END')) {
+            if (this.match('TEMPLATE_QUASI')) {
+                quasis.push({
+                    type: 'TemplateElement',
+                    value: this.previous().value
+                });
+            } else if (this.match('TEMPLATE_EXPR_START')) {
+                expressions.push(this.parseExpression());
+                this.consume('TEMPLATE_EXPR_END', '}');
+            } else {
+                throw new Error('Unexpected token in template literal');
+            }
+        }
+
+        return {
+            type: 'TemplateLiteral',
+            quasis,
+            expressions
+        };
+    }
+
     parsePrimary() {
         // Numbers
         if (this.match('NUMBER')) {
@@ -474,6 +579,11 @@ class Parser {
         // Strings
         if (this.match('STRING')) {
             return { type: 'Literal', value: this.previous().value };
+        }
+
+        // Template literals
+        if (this.match('TEMPLATE_START')) {
+            return this.parseTemplateLiteral();
         }
 
         // Booleans
@@ -876,6 +986,17 @@ class Evaluator {
                     result[key] = value;
                 }
                 return result;
+
+            case 'TemplateLiteral':
+                let templateResult = '';
+                for (let i = 0; i < node.quasis.length; i++) {
+                    templateResult += node.quasis[i].value;
+                    if (i < node.expressions.length) {
+                        const exprValue = this.evaluate({ node: node.expressions[i], scope, context, forceBindingRootScopeToFunctions });
+                        templateResult += exprValue == null ? '' : String(exprValue);
+                    }
+                }
+                return templateResult;
 
             default:
                 throw new Error(`Unknown node type: ${node.type}`);

--- a/tests/cypress/integration/plugins/csp-compatibility.spec.js
+++ b/tests/cypress/integration/plugins/csp-compatibility.spec.js
@@ -29,6 +29,14 @@ test.csp('supports x-model with dotted path',
     }
 )
 
+// Plain string instead of html`` — the tagged template's strings.raw mangles backticks
+test.csp('x-text with template literal interpolation',
+    ['<div x-data="{ count: 3 }"><span x-text="`Count: ${count}`"></span></div>'],
+    ({ get }) => {
+        get('span').should(haveText('Count: 3'))
+    }
+)
+
 test.csp('throws when accessing a global',
     [html`
         <button x-data x-on:click="document.write('evil')"></button>

--- a/tests/vitest/csp-evaluator.spec.js
+++ b/tests/vitest/csp-evaluator.spec.js
@@ -96,6 +96,62 @@ describe('cspRawEvaluator', () => {
     });
 });
 
+describe('Template literals', () => {
+    it('plain template literal', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+
+        expect(cspRawEvaluator(element, '`hello`')).toBe('hello')
+    });
+
+    it('template literal with interpolation', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { name: 'Alice' }
+
+        expect(cspRawEvaluator(element, '`hi ${name}`', { scope })).toBe('hi Alice')
+    });
+
+    it('template literal with multiple interpolations', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { a: 'x', b: 'y' }
+
+        expect(cspRawEvaluator(element, '`${a}-${b}`', { scope })).toBe('x-y')
+    });
+
+    it('template literal with expression', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { x: 2, y: 3 }
+
+        expect(cspRawEvaluator(element, '`result: ${x + y}`', { scope })).toBe('result: 5')
+    });
+
+    it('template literal with null interpolation', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { val: null }
+
+        expect(cspRawEvaluator(element, '`value: ${val}`', { scope })).toBe('value: ')
+    });
+
+    it('template literal with undefined interpolation', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { val: undefined }
+
+        expect(cspRawEvaluator(element, '`value: ${val}`', { scope })).toBe('value: ')
+    });
+
+    it('should block dangerous keywords inside interpolation', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+
+        expect(() => cspRawEvaluator(element, '`${document.cookie}`')).toThrow()
+    });
+
+    it('should block dangerous values inside interpolation', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let scope = { el: document.createElement('div') }
+
+        expect(() => cspRawEvaluator(element, '`${el.insertAdjacentHTML}`', { scope })).toThrow()
+    });
+});
+
 describe('MemberExpression assignments', () => {
     it('simple dot-path assignment (x-model="form.name" setter)', () => {
         let element = { parentNode: null, _x_dataStack: [] }

--- a/tests/vitest/csp-parser.spec.js
+++ b/tests/vitest/csp-parser.spec.js
@@ -514,8 +514,8 @@ describe('CSP Parser', () => {
             expect(() => generateRuntimeFunction('function() { return 5; }')).toThrow();
         });
 
-        it('should not support template literals', () => {
-            expect(() => generateRuntimeFunction('`hello`')).toThrow();
+        it('should support template literals', () => {
+            expect(generateRuntimeFunction('`hello`')()).toBe('hello');
         });
 
         it('should not support spread operator', () => {
@@ -628,6 +628,89 @@ describe('CSP Parser', () => {
             const el = document.createElement('div');
             const scope = { style: el.style };
             expect(() => generateRuntimeFunction('style.background = "red"')({ scope })).toThrow('DOM objects are prohibited');
+        });
+    });
+
+    describe('Template Literals', () => {
+        it('should parse plain template literal', () => {
+            expect(generateRuntimeFunction('`hello`')()).toBe('hello');
+        });
+
+        it('should parse empty template literal', () => {
+            expect(generateRuntimeFunction('``')()).toBe('');
+        });
+
+        it('should parse template literal with single interpolation', () => {
+            const scope = { name: 'world' };
+            expect(generateRuntimeFunction('`hello ${name}`')({ scope })).toBe('hello world');
+        });
+
+        it('should parse template literal with multiple interpolations', () => {
+            const scope = { a: 'foo', b: 'bar' };
+            expect(generateRuntimeFunction('`${a} and ${b}`')({ scope })).toBe('foo and bar');
+        });
+
+        it('should parse template literal with member expression', () => {
+            const scope = { obj: { prop: 'value' } };
+            expect(generateRuntimeFunction('`result: ${obj.prop}`')({ scope })).toBe('result: value');
+        });
+
+        it('should parse template literal with binary expression', () => {
+            const scope = { a: 2, b: 3 };
+            expect(generateRuntimeFunction('`sum: ${a + b}`')({ scope })).toBe('sum: 5');
+        });
+
+        it('should parse template literal with ternary expression', () => {
+            const scope = { x: true };
+            expect(generateRuntimeFunction('`${x ? "yes" : "no"}`')({ scope })).toBe('yes');
+        });
+
+        it('should handle escaped backtick', () => {
+            expect(generateRuntimeFunction('`escaped \\` backtick`')()).toBe('escaped ` backtick');
+        });
+
+        it('should handle escaped dollar-brace', () => {
+            expect(generateRuntimeFunction('`escaped \\${not interpolated}`')()).toBe('escaped ${not interpolated}');
+        });
+
+        it('should handle null/undefined interpolation as empty string', () => {
+            const scope = { val: null };
+            expect(generateRuntimeFunction('`value: ${val}`')({ scope })).toBe('value: ');
+        });
+
+        it('should handle number interpolation', () => {
+            const scope = { count: 42 };
+            expect(generateRuntimeFunction('`count: ${count}`')({ scope })).toBe('count: 42');
+        });
+
+        it('should handle newline escape sequence', () => {
+            expect(generateRuntimeFunction('`line1\\nline2`')()).toBe('line1\nline2');
+        });
+
+        it('should handle tab escape sequence', () => {
+            expect(generateRuntimeFunction('`col1\\tcol2`')()).toBe('col1\tcol2');
+        });
+
+        it('should throw on unterminated template literal', () => {
+            expect(() => generateRuntimeFunction('`unterminated')).toThrow('Unterminated template literal');
+        });
+
+        it('should throw on unclosed interpolation', () => {
+            expect(() => generateRuntimeFunction('`hello ${name')).toThrow('Unterminated template expression');
+        });
+
+        it('should parse consecutive interpolations with no text between', () => {
+            const scope = { a: 'x', b: 'y' };
+            expect(generateRuntimeFunction('`${a}${b}`')({ scope })).toBe('xy');
+        });
+
+        it('should use template literal as operand in ternary', () => {
+            const scope = { x: true };
+            expect(generateRuntimeFunction('x ? `yes` : `no`')({ scope })).toBe('yes');
+        });
+
+        it('should not support nested template literals', () => {
+            expect(() => generateRuntimeFunction('`outer ${`inner`}`')).toThrow();
         });
     });
 


### PR DESCRIPTION
The CSP evaluator does not recognize backtick strings, so `value: ${x}` throws while the equivalent 'value: ' + x works. This forces users into string concatenation that standard Alpine does not require.

Add template literal parsing with ${...} interpolation support. Expressions inside interpolations are fully parsed, so member access, arithmetic, and ternaries all work. null and undefined interpolations resolve to empty string, matching native JS behavior.

Ref: ECMA-262 11.8.6: Template Literal Lexical Components