### PR TITLE
Fix mask resurrecting key in object when it is cleared

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -52,6 +52,14 @@ export default function (Alpine) {
 
                 let updater = el._x_forceModelUpdate
                 el._x_forceModelUpdate = (value) => {
+                    // If the model value was cleared (e.g. the parent object was
+                    // removed), just clear the input — don't format and write back
+                    // as that would resurrect the model path with an empty value.
+                    if (value === undefined) {
+                        lastInputValue = ''
+                        return updater(value)
+                    }
+
                     value = String(value)
                     let template = templateFn(value)
                     if (template && template !== 'false') {

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -1,4 +1,4 @@
-import { haveData, haveValue, html, test } from '../../utils'
+import { haveData, haveText, haveValue, html, test } from '../../utils'
 
 test('x-mask',
     [html`<input x-data x-mask="(999) 999-9999">`],
@@ -291,5 +291,35 @@ test('x-mask masks programmatic x-model updates',
         get('button').click()
         get('input').should(haveValue('23,420'))
         get('div').should(haveData('value', '23,420'))
+    }
+)
+
+test('x-mask with x-model initializes missing object key',
+    [html`
+        <div x-data="{ form: {} }">
+            <input x-model="form.amount" x-mask:dynamic="$money($input)" id="1">
+            <span id="output" x-text="'amount' in form ? 'EXISTS:' + form.amount : 'GONE'"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#output').should(haveText('EXISTS:'))
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#output').should(haveText('EXISTS:1,234'))
+    }
+)
+
+test('x-mask does not resurrect x-model value when model is cleared',
+    [html`
+        <div x-data="{ form: { amount: '5000' } }">
+            <input x-model="form.amount" x-mask:dynamic="$money($input)">
+            <span id="output" x-text="'amount' in form ? 'EXISTS' : 'GONE'"></span>
+            <button @click="form = {}">clear</button>
+        </div>
+    `],
+    ({ get }) => {
+        get('input').should(haveValue('5,000'))
+        get('#output').should(haveText('EXISTS'))
+        get('button').click()
+        get('#output').should(haveText('GONE'))
     }
 )


### PR DESCRIPTION
When a reactive object is cleared (e.g. `form = {}`), Alpine's x-model effect fires `_x_forceModelUpdate(undefined)` on inputs still connected to the DOM. The mask plugin's wrapper around this function converts `undefined` to the string `"undefined"` via `String(value)`, formats it to `""`, then calls `el._x_model.set('')` — which evaluates `form.amount = ''`, resurrecting the deleted key with an empty value. In a Livewire context, this stale key gets sent back with the next server request, corrupting server-side state.

Steps to reproduce:
- Have an input with `x-model="form.amount"` and `x-mask:dynamic="$money($input)"`
- Set `form.amount` to a value (e.g. `'5000'`)
- Clear the parent object: `form = {}`
- Observe that `form.amount` reappears as an empty string

## Findings

The mask plugin wraps `_x_forceModelUpdate` (defined in x-model.js) to apply formatting before updating the DOM. The original function already handles `undefined` correctly for nested model paths (converts to `''` and updates the input). The issue is that the mask wrapper runs `String(value)` and `el._x_model.set(value)` unconditionally — even when the value is `undefined` because the model path no longer exists.

## Proposed solution

Add an early return in the mask wrapper when `value === undefined`. This skips the formatting/write-back path entirely and delegates to the original `_x_forceModelUpdate`, which already handles `undefined` properly. Crucially, `el._x_model.set()` is not called, so the deleted key is not recreated.