### PR TITLE
Fix `x-sort` crash when container has a `<template>` with no `.content`

### DIFF
--- a/packages/sort/src/index.js
+++ b/packages/sort/src/index.js
@@ -29,7 +29,7 @@ export default function (Alpine) {
         let preferences = {
             hideGhost: ! modifiers.includes('ghost'),
             useHandles: !! el.querySelector(handleSelector)
-                || Array.from(el.querySelectorAll('template')).some(tmpl => tmpl.content.querySelector(handleSelector)),
+                || Array.from(el.querySelectorAll('template')).some(tmpl => tmpl.content?.querySelector(handleSelector)),
             group: getGroupName(el, modifiers),
         }
 

--- a/packages/sort/src/index.js
+++ b/packages/sort/src/index.js
@@ -29,7 +29,7 @@ export default function (Alpine) {
         let preferences = {
             hideGhost: ! modifiers.includes('ghost'),
             useHandles: !! el.querySelector(handleSelector)
-                || Array.from(el.querySelectorAll('template')).some(tmpl => tmpl.content?.querySelector(handleSelector)),
+                || Array.from(el.querySelectorAll('template:not(svg template)')).some(tmpl => tmpl.content?.querySelector(handleSelector)),
             group: getGroupName(el, modifiers),
         }
 

--- a/tests/cypress/integration/plugins/sort.spec.js
+++ b/tests/cypress/integration/plugins/sort.spec.js
@@ -237,6 +237,24 @@ test.skip('can use custom sortablejs configuration',
     },
 )
 
+test.skip('does not throw when a sort item contains a template inside an SVG',
+    [html`
+        <div x-data>
+            <ul x-sort>
+                <li id="1">
+                    <svg><template name="line"><path></path></template></svg>
+                    foo
+                </li>
+                <li id="2">bar</li>
+            </ul>
+        </div>
+    `],
+    ({ get }) => {
+        get('ul li').eq(0).should(haveText('foo'))
+        get('ul li').eq(1).should(haveText('bar'))
+    },
+)
+
 test.skip('works with Livewire morphing',
     [html`
         <div x-data>

--- a/tests/cypress/integration/plugins/sort.spec.js
+++ b/tests/cypress/integration/plugins/sort.spec.js
@@ -237,14 +237,11 @@ test.skip('can use custom sortablejs configuration',
     },
 )
 
-test.skip('does not throw when a sort item contains a template inside an SVG',
+test('does not throw when a sort item contains a template inside an SVG',
     [html`
         <div x-data>
             <ul x-sort>
-                <li id="1">
-                    <svg><template name="line"><path></path></template></svg>
-                    foo
-                </li>
+                <li id="1"><svg><template name="line"><path></path></template></svg>foo</li>
                 <li id="2">bar</li>
             </ul>
         </div>


### PR DESCRIPTION
# The Scenario

Placing a `flux:chart` inside a `wire:sort:item` (with no `wire:sort:handle`) breaks drag-to-reorder and throws in the console:

<img width="1764" height="1620" alt="Screenshot 2026-04-21 at 08 49 37AM@2x" src="https://github.com/user-attachments/assets/bf6ddea4-419b-441c-ae6f-c9f3d1169958" />

```blade
<div wire:sort="handleSort">
    @foreach ($tasks as $task)
        <flux:card wire:key="{{ $task['id'] }}" wire:sort:item="{{ $task['id'] }}">
            <flux:chart :value="[10, 12, 11, 13, 15]">
                <flux:chart.svg>
                    <flux:chart.line />
                </flux:chart.svg>
            </flux:chart>
        </flux:card>
    @endforeach
</div>
```

# The Problem

`x-sort` auto-detects whether the sort container uses drag handles. If no handle element is found directly, it scans nested `<template>` elements for one:

```js
useHandles: !! el.querySelector(handleSelector)
    || Array.from(el.querySelectorAll('template')).some(tmpl => tmpl.content.querySelector(handleSelector)),
```

`querySelectorAll('template')` matches every element with tag name `template` regardless of namespace, but `.content` only exists on `HTMLTemplateElement`. Flux's chart hydrates its SVG from an HTML `<template>` and the hydrated `<svg>` contains nested `<template>` elements that were parsed in the SVG namespace, so they're `SVGElement` instances with no `.content` property. The unconditional `.querySelector` call on `tmpl.content` throws.

# The Solution

Guard the property access with optional chaining so non-`HTMLTemplateElement` matches are skipped:

```js
|| Array.from(el.querySelectorAll('template')).some(tmpl => tmpl.content?.querySelector(handleSelector)),
```

<img width="800" height="725" alt="Screenshot 2026-04-21 at 08 50 09AM" src="https://github.com/user-attachments/assets/2dce1f65-e18d-42bf-9829-c0fb1092d349" />

Fixes livewire/flux#2578