### PR TITLE
Add minified ESM build output for each package

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -56,9 +56,10 @@ function bundleFile(package, file) {
             })
 
         },
-        // This file outputs two files: an esm module and a cjs module.
-        // The ESM one is meant for "import" statements (bundlers and new browsers)
-        // and the cjs one is meant for "require" statements (node).
+        // This file outputs three files: an esm module, a minified esm module,
+        // and a cjs module. The ESM ones are meant for "import" statements
+        // (bundlers and new browsers) and the cjs one is meant for "require"
+        // statements (node).
         'module.js': () => {
             build({
                 entryPoints: [`packages/${package}/builds/${file}`],
@@ -66,6 +67,19 @@ function bundleFile(package, file) {
                 bundle: true,
                 platform: 'neutral',
                 mainFields: ['module', 'main'],
+            })
+
+            // Build a minified ESM version for browsers loading modules
+            // directly (e.g. `<script type="module">` importing from node_modules).
+            build({
+                entryPoints: [`packages/${package}/builds/${file}`],
+                outfile: `packages/${package}/dist/${file.replace('.js', '.esm.min.js')}`,
+                bundle: true,
+                minify: true,
+                platform: 'neutral',
+                mainFields: ['module', 'main'],
+            }).then(() => {
+                outputSize(package, `packages/${package}/dist/${file.replace('.js', '.esm.min.js')}`)
             })
 
             build({


### PR DESCRIPTION
# The Scenario

Users loading Alpine directly in the browser via `<script type="module">` (no bundler) have been importing Alpine from a minified ESM file that was present in every npm tarball up to 3.15.10:

```html
<script type="module" src="/app.js"></script>
```

```js
import Alpine from '../node_modules/alpinejs/dist/module.esm.min.js';

window.$selectedFiles = Alpine.reactive([]);
Alpine.start();
```

From 3.15.11 onwards that file is gone, so the import fails and the page breaks.

# The Problem

`dist/module.esm.min.js` has never actually been produced by `scripts/build.js`. The `module.js` branch of `bundleFile()` only emits `module.esm.js` and `module.cjs.js`; only the `cdn.js` branch produces a `.min.js` variant:

```js
'module.js': () => {
    build({
        entryPoints: [`packages/${package}/builds/${file}`],
        outfile: `packages/${package}/dist/${file.replace('.js', '.esm.js')}`,
        ...
    })

    build({
        entryPoints: [`packages/${package}/builds/${file}`],
        outfile: `packages/${package}/dist/${file.replace('.js', '.cjs.js')}`,
        ...
    })
},
```

The file that shipped in previous releases was a stale artifact from a maintainer's local `dist/` folder, generated by an older build and swept into each `npm publish` because `dist/` is not cleaned before builds. The 3.14.9 and 3.15.10 tarballs on npm both contain byte-for-byte identical `module.esm.min.js` files with `version:"3.13.10"` baked in, meaning anyone importing that path for the last several releases has been running 3.13.10 code regardless of the installed version.

3.15.11 was the first release cut by the new GitHub Actions workflow, which runs from a clean checkout, so the stale file no longer rides along.

# The Solution

Add a legitimate minified ESM output to the `module.js` branch in `scripts/build.js`, mirroring the pattern already used by `cdn.js` / `cdn.min.js`:

```js
build({
    entryPoints: [`packages/${package}/builds/${file}`],
    outfile: `packages/${package}/dist/${file.replace('.js', '.esm.min.js')}`,
    bundle: true,
    minify: true,
    platform: 'neutral',
    mainFields: ['module', 'main'],
}).then(() => {
    outputSize(package, `packages/${package}/dist/${file.replace('.js', '.esm.min.js')}`)
})
```

This restores the file path users were already relying on and makes the no-bundler ESM use case a first-class build target. Because the file is now generated from the current source on every release, it will contain the correct `ALPINE_VERSION` rather than being frozen at 3.13.10.

The change applies uniformly to every module-emitting package (`alpinejs` plus the plugins), keeping the three module outputs consistent: `module.esm.js`, `module.esm.min.js`, `module.cjs.js`.

Fixes #4818