### PR TITLE
Fix `x-id` evaluation order so `$id` resolves consistently inside `x-data`

### DIFF
--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -206,8 +206,8 @@ const DEFAULT = 'DEFAULT'
 let directiveOrder = [
     'ignore',
     'ref',
-    'data',
     'id',
+    'data',
     'anchor',
     'bind',
     'init',

--- a/tests/cypress/integration/magics/$id.spec.js
+++ b/tests/cypress/integration/magics/$id.spec.js
@@ -128,6 +128,28 @@ test('$id scopes can be reset',
     }
 )
 
+test('$id resolves consistently when x-id and x-data are on the same element',
+    html`
+        <div x-data>
+            <div
+                x-id="['a']"
+                x-data="{ idFromData: $id('a'), anotherIdFromData: $id('a') }"
+            >
+                <p><span id="from-data" x-text="idFromData"></span></p>
+                <p><span id="from-data-2" x-text="anotherIdFromData"></span></p>
+                <p><span id="from-text" x-text="$id('a')"></span></p>
+                <p><span id="from-text-2" x-text="$id('a')"></span></p>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('#from-data').should(haveText('a-1'))
+        get('#from-data-2').should(haveText('a-1'))
+        get('#from-text').should(haveText('a-1'))
+        get('#from-text-2').should(haveText('a-1'))
+    }
+)
+
 test('can be used with morph without losing track',
     [html`
         <div x-data>


### PR DESCRIPTION
# The Scenario

When `x-id` and `x-data` are on the same element, `$id('name')` inside the `x-data` expression returns a different id than `$id('name')` in descendants — breaking ARIA wiring that relies on them matching.

```html
<div
    x-id="['a']"
    x-data="{ idFromData: $id('a') }"
>
    <p>From <code>x-data</code>: <strong x-text="idFromData"></strong></p>   <!-- a-1 -->
    <p>From <code>x-text</code>: <strong x-text="$id('a')"></strong></p>     <!-- a-2 -->
</div>
```

# The Problem

`data` runs before `id` in the directive order. So `$id('a')` inside `x-data` finds no `_x_ids` on its ancestor yet and falls back to the global counter (returns `1`). Then `x-id` runs and calls `findAndIncrementId` again (returns `2`), which becomes the actual id root. Descendants resolve `a-2` while the `x-data` scope holds `a-1`.

# The Solution

Swap `id` ahead of `data` in `directiveOrder` so the id root is registered first.

`x-id` only takes a static array of name strings, so it doesn't need `x-data` scope to evaluate. Docs, tests, and real-world usage all use this pattern.

Fixes #4817