### PR TITLE
Fix `@teleport` leaking detached nodes on every Livewire render

### DIFF
--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -8,6 +8,8 @@ import { warn } from "../utils/warn"
 directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
     if (el.tagName.toLowerCase() !== 'template') warn('x-teleport can only be used on a <template> tag', el)
 
+    let target = getTarget(expression)
+
     let clone = el.content.cloneNode(true).firstElementChild
 
     // Add reference to element on <template x-teleport, and visa versa.
@@ -44,37 +46,38 @@ directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
         }
     }
 
-    // During clone mode (used by Alpine.morph to seed new server HTML), the clone
-    // only needs to exist as `el._x_teleport` so morph can patch it. Attaching it
-    // to the DOM or registering its cleanup would leak a detached node every morph.
-    skipDuringClone(() => {
-        let target = getTarget(expression)
-
-        mutateDom(() => {
+    mutateDom(() => {
+        skipDuringClone(() => {
             placeInDom(clone, target, modifiers)
 
             initTree(clone)
+        })()
+    })
+
+    el._x_teleportPutBack = () => {
+        let target = getTarget(expression)
+
+        mutateDom(() => {
+            placeInDom(el._x_teleport, target, modifiers)
         })
+    }
 
-        el._x_teleportPutBack = () => {
-            let target = getTarget(expression)
-
-            mutateDom(() => {
-                placeInDom(el._x_teleport, target, modifiers)
-            })
-        }
-
-        cleanup(() =>
-            mutateDom(() => {
-                clone.remove()
-                destroyTree(clone)
-            })
-        )
-    })()
+    cleanup(() =>
+      mutateDom(() => {
+        clone.remove()
+        destroyTree(clone)
+      })
+    )
 })
 
+let teleportContainerDuringClone = document.createElement('div')
+
 function getTarget(expression) {
-    let target = document.querySelector(expression)
+    let target = skipDuringClone(() => {
+        return document.querySelector(expression)
+    }, () => {
+        return teleportContainerDuringClone
+    })()
 
     if (! target) warn(`Cannot find x-teleport element for selector: "${expression}"`)
 

--- a/packages/alpinejs/src/directives/x-teleport.js
+++ b/packages/alpinejs/src/directives/x-teleport.js
@@ -8,8 +8,6 @@ import { warn } from "../utils/warn"
 directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
     if (el.tagName.toLowerCase() !== 'template') warn('x-teleport can only be used on a <template> tag', el)
 
-    let target = getTarget(expression)
-
     let clone = el.content.cloneNode(true).firstElementChild
 
     // Add reference to element on <template x-teleport, and visa versa.
@@ -46,38 +44,37 @@ directive('teleport', (el, { modifiers, expression }, { cleanup }) => {
         }
     }
 
-    mutateDom(() => {
-        placeInDom(clone, target, modifiers)
-
-        skipDuringClone(() => {
-            initTree(clone)
-        })()
-    })
-
-    el._x_teleportPutBack = () => {
+    // During clone mode (used by Alpine.morph to seed new server HTML), the clone
+    // only needs to exist as `el._x_teleport` so morph can patch it. Attaching it
+    // to the DOM or registering its cleanup would leak a detached node every morph.
+    skipDuringClone(() => {
         let target = getTarget(expression)
 
         mutateDom(() => {
-            placeInDom(el._x_teleport, target, modifiers)
-        })
-    }
+            placeInDom(clone, target, modifiers)
 
-    cleanup(() =>
-      mutateDom(() => {
-        clone.remove()
-        destroyTree(clone)
-      })
-    )
+            initTree(clone)
+        })
+
+        el._x_teleportPutBack = () => {
+            let target = getTarget(expression)
+
+            mutateDom(() => {
+                placeInDom(el._x_teleport, target, modifiers)
+            })
+        }
+
+        cleanup(() =>
+            mutateDom(() => {
+                clone.remove()
+                destroyTree(clone)
+            })
+        )
+    })()
 })
 
-let teleportContainerDuringClone = document.createElement('div')
-
 function getTarget(expression) {
-    let target = skipDuringClone(() => {
-        return document.querySelector(expression)
-    }, () => {
-        return teleportContainerDuringClone
-    })()
+    let target = document.querySelector(expression)
 
     if (! target) warn(`Cannot find x-teleport element for selector: "${expression}"`)
 

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -134,6 +134,41 @@ test('can morph teleports',
     },
 )
 
+test('morphing teleports does not leak detached teleport clones',
+    [html`
+        <div x-data="{ count: 1 }" id="a">
+            <button @click="count++">Inc</button>
+
+            <template x-teleport="#b">
+                <div>
+                    <h1 x-text="count"></h1>
+                </div>
+            </template>
+        </div>
+
+        <div id="b"></div>
+    `],
+    ({ get }, reload, window, document) => {
+        let toHtml = document.querySelector('div#a').outerHTML
+
+        get('div#a').then(([el]) => {
+            for (let i = 0; i < 5; i++) {
+                window.Alpine.morph(el, toHtml)
+            }
+        })
+
+        get('template[data-teleport-template]').then(([template]) => {
+            let probe = template.cloneNode(true)
+            window.Alpine.cloneNode(template, probe)
+
+            let container = probe._x_teleport.parentElement
+            let siblings = container ? container.children.length : 1
+
+            cy.wrap(siblings).should('equal', 1)
+        })
+    },
+)
+
 test('can morph teleports in different places with IDs',
     [html`
         <div x-data="{ count: 1 }" id="a">


### PR DESCRIPTION
# The Scenario

A Livewire component containing a `@teleport` block leaks detached DOM nodes on every render. Each server round-trip accumulates another orphaned copy of the teleported subtree, so long-lived pages build up hundreds of retained clones. `wire:ignore` avoids the leak but isn't viable when the teleported content needs to stay reactive.

```php
<?php

use Livewire\Component;

new class extends Component {
    public function action(): void
    {
        //
    }
}; ?>

<div>
    <button wire:click="action">refresh</button>

    @teleport('body')
        <div>teleported content</div>
    @endteleport
</div>
```

# The Problem

When Alpine first boots a `<template x-teleport="#target">`, the directive clones the template content, places the clone inside the target, and stashes references on both sides so the morph plugin can find them later:

```js
let target = getTarget(expression)
let clone = el.content.cloneNode(true).firstElementChild

el._x_teleport = clone
clone._x_teleportBack = el
...
placeInDom(clone, target, modifiers)
```

Livewire updates the page by calling `Alpine.morph(from, newHtml)`. Morph parses the new HTML into a `to` tree and walks both trees in parallel, and for each pair of elements it calls `Alpine.cloneNode(from, to)` to re-run directives against `to` in "clone mode". Clone mode is Alpine's signal to directives to skip real side effects (DOM writes, subscriptions, cleanup registrations), the `to` tree is throwaway scaffolding for the morph, not something we actually want to wire up.

`x-teleport` didn't honour that. Even in clone mode it still called `placeInDom(clone, target, modifiers)`, and `getTarget()` fell back to a module-level singleton div:

```js
let teleportContainerDuringClone = document.createElement('div')

function getTarget(expression) {
    let target = skipDuringClone(() => {
        return document.querySelector(expression)
    }, () => {
        return teleportContainerDuringClone
    })()
    ...
}
```

That container is never cleared. Every morph of a teleport template appended a fresh clone into it, and because it's a live module-scoped `<div>` holding them as children, nothing could be garbage collected, one leaked subtree per render, forever.

# The Solution

The only thing the directive needed to stop doing in clone mode was `placeInDom`, the one call that attaches the clone to the singleton and creates the leak. Extending the existing `skipDuringClone` block to also cover it is enough:

```diff
     mutateDom(() => {
-        placeInDom(clone, target, modifiers)
-
         skipDuringClone(() => {
+            placeInDom(clone, target, modifiers)
+
             initTree(clone)
         })()
     })
```

The clone still exists on `to._x_teleport` so `@alpinejs/morph` can patch it via `context.patch(from._x_teleport, to._x_teleport)`, but it's no longer attached anywhere. The `_x_teleportPutBack` assignment and `cleanup` callback are still set on the `to` template in clone mode, but that's harmless, they live on the throwaway `to` and get garbage collected along with it.

Added a Cypress test that morphs a teleport template five times, then probes the container a fresh `Alpine.cloneNode` would use. Before the fix it found six leaked clones; after, the clone has no parent. Existing `x-teleport` and morph specs still pass.

Fixes livewire/livewire#10235