### PR TITLE
Fix `&&` and `||` not short-circuiting in CSP evaluator

### DIFF
--- a/packages/csp/src/parser.js
+++ b/packages/csp/src/parser.js
@@ -812,7 +812,15 @@ class Evaluator {
 
             case 'BinaryExpression':
                 const left = this.evaluate({ node: node.left, scope, context, forceBindingRootScopeToFunctions });
-                const right = this.evaluate({ node: node.right, scope, context, forceBindingRootScopeToFunctions });
+
+                // Wrapped in a function so && and || can skip it when short-circuiting.
+                const evalRight = () => this.evaluate({ node: node.right, scope, context, forceBindingRootScopeToFunctions });
+
+                // Short-circuit && and || so side-effects on the right aren't evaluated when the result is already determined.
+                if (node.operator === '&&') return left && evalRight();
+                if (node.operator === '||') return left || evalRight();
+
+                const right = evalRight();
 
                 switch (node.operator) {
                     case '+': return left + right;
@@ -828,8 +836,6 @@ class Evaluator {
                     case '>': return left > right;
                     case '<=': return left <= right;
                     case '>=': return left >= right;
-                    case '&&': return left && right;
-                    case '||': return left || right;
                     default:
                         throw new Error(`Unknown binary operator: ${node.operator}`);
                 }

--- a/tests/vitest/csp-evaluator.spec.js
+++ b/tests/vitest/csp-evaluator.spec.js
@@ -94,6 +94,54 @@ describe('cspRawEvaluator', () => {
         expect(cspRawEvaluator(element, 'true || false')).toBe(true)
         expect(cspRawEvaluator(element, '!false')).toBe(true)
     });
+
+    it('&& evaluates right side when left side is truthy', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let rightCalled = false
+        let scope = {
+            left: true,
+            right: () => { rightCalled = true; return 'from right' },
+        }
+
+        expect(cspRawEvaluator(element, 'left && right()', { scope })).toBe('from right')
+        expect(rightCalled).toBe(true)
+    });
+
+    it('&& short-circuits when left side is falsy', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let rightCalled = false
+        let scope = {
+            left: false,
+            right: () => { rightCalled = true; return true },
+        }
+
+        expect(cspRawEvaluator(element, 'left && right()', { scope })).toBe(false)
+        expect(rightCalled).toBe(false)
+    });
+
+    it('|| short-circuits when left side is truthy', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let rightCalled = false
+        let scope = {
+            left: true,
+            right: () => { rightCalled = true; return false },
+        }
+
+        expect(cspRawEvaluator(element, 'left || right()', { scope })).toBe(true)
+        expect(rightCalled).toBe(false)
+    });
+
+    it('|| evaluates right side when left side is falsy', () => {
+        let element = { parentNode: null, _x_dataStack: [] }
+        let rightCalled = false
+        let scope = {
+            left: false,
+            right: () => { rightCalled = true; return 'from right' },
+        }
+
+        expect(cspRawEvaluator(element, 'left || right()', { scope })).toBe('from right')
+        expect(rightCalled).toBe(true)
+    });
 });
 
 describe('MemberExpression assignments', () => {


### PR DESCRIPTION
# The Scenario

In an app running Livewire's CSP build, a single `Flux::toast(...)` call renders two toasts instead of one when the page uses a grouped toast setup.

<img width="800" height="424" alt="Screenshot 2026-04-23 at 07 46 01AM" src="https://github.com/user-attachments/assets/d7cf4bc6-c2e8-43d4-8e64-2cda4dd6a226" />

```blade
<flux:toast.group position="top end">
    <flux:toast />
</flux:toast.group>
```

One toast appears correctly inside the group; a second appears separately, originating from the inner `<ui-toast>` element. Swapping the CSP build for the regular Livewire build makes it behave correctly.

# The Problem

Flux's inner `<ui-toast>` guards against handling the `toast-show` event when nested inside a group with a short-circuit expression:

```blade
<ui-toast x-on:toast-show.document="! $el.closest('ui-toast-group') && $el.showToast($event.detail)" ...>
```

Under the regular Alpine build this works correctly: when `$el.closest('ui-toast-group')` returns the group, the expression short-circuits and `showToast` is never called. Under the CSP build it doesn't, because the `BinaryExpression` handler in `packages/csp/src/parser.js` evaluates both operands up front before applying the operator:

```js
case 'BinaryExpression':
    const left = this.evaluate({ node: node.left, ... });
    const right = this.evaluate({ node: node.right, ... });

    switch (node.operator) {
        // ...
        case '&&': return left && right;
        case '||': return left || right;
    }
```

By the time `left && right` is computed, the right side has already run. Any `&&` or `||` expression with a side effect on the right leaks that side effect, regardless of the left value.

# The Solution

Wrap the right-hand evaluation in a function and only call it when short-circuiting doesn't apply:

```js
case 'BinaryExpression':
    const left = this.evaluate({ node: node.left, ... });

    // Wrapped in a function so && and || can skip it when short-circuiting.
    const evalRight = () => this.evaluate({ node: node.right, ... });

    // Short-circuit && and || so side-effects on the right aren't evaluated when the result is already determined.
    if (node.operator === '&&') return left && evalRight();
    if (node.operator === '||') return left || evalRight();

    const right = evalRight();

    switch (node.operator) { ... }
```

<img width="800" height="424" alt="Screenshot 2026-04-23 at 07 47 38AM" src="https://github.com/user-attachments/assets/43872c2d-0f04-4756-bd8b-b5fd3857ce0f" />

Four new tests in `tests/vitest/csp-evaluator.spec.js` cover both the happy path (right side runs when needed) and the short-circuit path (right side does not run) for both `&&` and `||`.

Fixes livewire/flux#2571