### PR TITLE
Fix `x-for` crashing on null-prototype objects like `Object.groupBy()` results

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -51,7 +51,7 @@ function loop(templateEl, iteratorNames, evaluateItems, evaluateKey) {
         if (isNumeric(items))
             items = Array.from({ length: items }, (_, i) => i + 1)
 
-        if (items === undefined) items = []
+        if (items === undefined || items === null) items = []
 
         // Support Set and Map objects by converting to arrays.
         if (items instanceof Set) items = Array.from(items)
@@ -188,7 +188,8 @@ function getIterationScopeVariables(iteratorNames, item, index, items) {
 }
 
 function isNumeric(subject){
-    return ! Array.isArray(subject) && ! isNaN(subject)
+    // `isNaN` throws on null-prototype objects, so skip objects before calling it.
+    return typeof subject !== 'object' && ! isNaN(subject)
 }
 
 function isObject(subject) {

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -634,6 +634,20 @@ test('iterates over a Map',
     }
 )
 
+test('iterates over a null-prototype object (e.g. Object.groupBy result)',
+    html`
+        <div x-data="{ items: Object.assign(Object.create(null), { a: 'foo', b: 'bar' }) }">
+            <template x-for="(value, key) in items" :key="key">
+                <span x-text="key + ':' + value"></span>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        get('span:nth-of-type(1)').should(haveText('a:foo'))
+        get('span:nth-of-type(2)').should(haveText('b:bar'))
+    }
+)
+
 // If x-for removes a child, all cleanups in the tree should be handled.
 test('x-for eagerly cleans tree',
     html`


### PR DESCRIPTION
# The Scenario

Iterating over a null-prototype object with `x-for` (for example, the object returned by `Object.groupBy()`) throws `TypeError: Cannot convert object to primitive value` instead of iterating over its entries. A plain object literal with the same shape works fine.

```html
<div x-data="{
    items: [
        { type: 'a', val: 1 },
        { type: 'b', val: 2 },
        { type: 'a', val: 3 },
    ],
    groupedItems() {
        return Object.groupBy(this.items, i => i.type)
    },
}">
    <template x-for="(group, groupName) in groupedItems()" :key="groupName">
        <div>
            <h3 x-text="groupName"></h3>
            <template x-for="item in group" :key="item.val">
                <div x-text="item.val"></div>
            </template>
        </div>
    </template>
</div>
```

# The Problem

`x-for` uses `isNumeric(items)` to detect the `x-for="i in 100"` shortcut. That helper calls `isNaN(subject)`, which coerces its argument to a primitive via `valueOf`/`toString`. Null-prototype objects have no such methods, so the coercion throws. Plain object literals inherit from `Object.prototype` and coerce to `"[object Object]"` without issue, which is why the bug only shows up for things like `Object.groupBy()` (or any `Object.create(null)`-style object).

```js
function isNumeric(subject){
    return ! Array.isArray(subject) && ! isNaN(subject)
}
```

# The Solution

Filter out objects before calling `isNaN`. Objects are never numeric, so excluding them up front is both correct and sidesteps the coercion throw. `null` now falls out of the numeric path (since `typeof null === 'object'`), so the `undefined` guard is extended to cover it as well.

```js
function isNumeric(subject){
    // `isNaN` throws on null-prototype objects, so skip objects before calling it.
    return typeof subject !== 'object' && ! isNaN(subject)
}
```

Fixes #4824