### PR TITLE
Fix data loss when binding objects to regular attributes

### DIFF
--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -92,6 +92,7 @@ function bindAttribute(el, name, value) {
         el.removeAttribute(name)
     } else {
         if (isBooleanAttr(name)) value = name
+        if (isObjectAttr(value)) value = JSON.stringify(value)
 
         setIfChanged(el, name, value)
     }
@@ -174,6 +175,10 @@ function isBooleanAttr(attrName) {
 
 function attributeShouldntBePreservedIfFalsy(name) {
     return ! ['aria-pressed', 'aria-checked', 'aria-expanded', 'aria-selected'].includes(name)
+}
+
+function isObjectAttr(value) {
+    return typeof value === 'object' && value !== null
 }
 
 export function getBinding(el, name, fallback) {

--- a/tests/cypress/integration/directives/x-bind.spec.js
+++ b/tests/cypress/integration/directives/x-bind.spec.js
@@ -9,6 +9,24 @@ test('sets attribute bindings on initialize',
     ({ get }) => get('span').should(haveAttribute('foo', 'bar'))
 )
 
+test('object bound to regular attribute is serialized as JSON',
+    html`
+        <div x-data="{ config: { year: 2024, month: 3 } }">
+            <span :data-config="config"></span>
+        </div>
+    `,
+    ({ get }) => get('span').should(haveAttribute('data-config', '{"year":2024,"month":3}'))
+)
+
+test('array bound to regular attribute is serialized as JSON',
+    html`
+        <div x-data="{ items: [1, 2, 3] }">
+            <span :data-items="items"></span>
+        </div>
+    `,
+    ({ get }) => get('span').should(haveAttribute('data-items', '[1,2,3]'))
+)
+
 test('sets undefined nested keys to empty string',
     html`
         <div x-data="{ nested: {} }">


### PR DESCRIPTION
- Fixes #322
- Ref #3650

Hey, so. This has come up for us as well. When using `x-bind` to bind an object or array to a regular attribute (not `class` or `style`), the value is passed directly to `setAttribute`, which silently coerces it to the string `[object Object]`. The original data is permanently lost with no warning or error.

For example, `:data-config="{ id: 1, name: 'test' }"` sets the attribute to the literal string `[object Object]`, making the bound data unrecoverable. This is particularly problematic for `data-*` attributes, where passing structured data is a common pattern.

Alpine already handles object values specially for `class` and `style` bindings. This PR applies the same principle to regular attributes by JSON.stringifying object/array values before calling `setAttribute`. The serialized data is preserved and can be read back with `JSON.parse` by other libs, or whatever else.

- **Before:** `:data-config="{ id: 1 }"` → `data-config="[object Object]"` (data lost)
- **After:** `:data-config="{ id: 1 }"` → `data-config='{"id":1}'` (data preserved)

There's no impact on Alpine's internal data flow coz the original object is stored in bindings before `bindAttribute` is called, and `getBinding()`/`extractProp()` read from `_x_bindings` first.

**The JSON serialization only affects the DOM attribute representation** (QOL / common expectation?), Alpine's own APIs continue to return the original object.

In our case, we're an independant library that needs to interoperate, I assume that's why others are needing this fixed too. Seeing `[object Object]` is a bit meh. Same as having to ship a custom directive just for this.