### PR TITLE
Fix `x-bind:value` on `<option>` losing attribute when value is an empty string

### DIFF
--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -64,15 +64,7 @@ function bindInputValue(el, value) {
     } else if (el.tagName === 'SELECT') {
         updateSelect(el, value)
     } else if (el.tagName === 'OPTION') {
-        // The .value property of an <option> reflects its text content when no
-        // value attribute is present, so we must set the attribute explicitly
-        // to avoid el.value drifting when sibling directives (e.g. x-text) write text.
-        // null/undefined/false removes the attribute, allowing the DOM's text-fallback to apply.
-        if (value === null || value === undefined || value === false) {
-            if (el.hasAttribute('value')) el.removeAttribute('value')
-        } else {
-            setIfChanged(el, 'value', value)
-        }
+        bindAttribute(el, 'value', value)
     } else {
         if (el.value === value) return
 
@@ -102,6 +94,7 @@ function bindAttribute(el, name, value) {
         el.removeAttribute(name)
     } else {
         if (isBooleanAttr(name)) value = name
+        if (isObjectAttr(value)) value = JSON.stringify(value)
 
         setIfChanged(el, name, value)
     }
@@ -184,6 +177,10 @@ function isBooleanAttr(attrName) {
 
 function attributeShouldntBePreservedIfFalsy(name) {
     return ! ['aria-pressed', 'aria-checked', 'aria-expanded', 'aria-selected'].includes(name)
+}
+
+function isObjectAttr(value) {
+    return typeof value === 'object' && value !== null
 }
 
 export function getBinding(el, name, fallback) {

--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -63,6 +63,16 @@ function bindInputValue(el, value) {
         }
     } else if (el.tagName === 'SELECT') {
         updateSelect(el, value)
+    } else if (el.tagName === 'OPTION') {
+        // The .value property of an <option> reflects its text content when no
+        // value attribute is present, so we must set the attribute explicitly
+        // to avoid el.value drifting when sibling directives (e.g. x-text) write text.
+        // null/undefined/false removes the attribute, allowing the DOM's text-fallback to apply.
+        if (value === null || value === undefined || value === false) {
+            if (el.hasAttribute('value')) el.removeAttribute('value')
+        } else {
+            setIfChanged(el, 'value', value)
+        }
     } else {
         if (el.value === value) return
 

--- a/tests/cypress/integration/directives/x-bind.spec.js
+++ b/tests/cypress/integration/directives/x-bind.spec.js
@@ -519,3 +519,46 @@ test('x-bind updates checked attribute and property after user interaction',
         get('input').should(haveProperty('checked', true))
     }
 )
+
+test('option element value attribute is set when bound to empty string',
+    html`
+        <div x-data="{
+            options: [
+                { value: '', label: 'Empty' },
+                { value: 'foo', label: 'Foo' },
+                { value: 'bar', label: 'Bar' },
+            ]
+        }">
+            <select>
+                <template x-for="option in options" :key="option.label">
+                    <option :value="option.value" x-text="option.label"></option>
+                </template>
+            </select>
+        </div>
+    `,
+    ({ get }) => {
+        get('option:nth-of-type(1)').should(haveAttribute('value', ''))
+        get('option:nth-of-type(1)').should(haveValue(''))
+        get('option:nth-of-type(2)').should(haveAttribute('value', 'foo'))
+        get('option:nth-of-type(2)').should(haveValue('foo'))
+        get('option:nth-of-type(3)').should(haveAttribute('value', 'bar'))
+        get('option:nth-of-type(3)').should(haveValue('bar'))
+    }
+)
+
+test('option element value attribute is removed when bound value is null or undefined, falling back to text label',
+    html`
+        <div x-data="{ nullValue: null, undefinedValue: undefined }">
+            <select>
+                <option :value="nullValue" x-text="'Null Label'"></option>
+                <option :value="undefinedValue" x-text="'Undefined Label'"></option>
+            </select>
+        </div>
+    `,
+    ({ get }) => {
+        get('option:nth-of-type(1)').should(notHaveAttribute('value'))
+        get('option:nth-of-type(1)').should(haveValue('Null Label'))
+        get('option:nth-of-type(2)').should(notHaveAttribute('value'))
+        get('option:nth-of-type(2)').should(haveValue('Undefined Label'))
+    }
+)


### PR DESCRIPTION
# The Scenario

When using `x-bind:value` on an `<option>` element inside `x-for` and the bound value is an empty string, the rendered `<option>` is missing its `value` attribute. The option's `.value` property then reflects whatever text content `x-text` writes into it, so a form submission for the "empty" option sends the option's label instead of `""`.

```html
<select x-data="{
    options: [
        { value: '', label: 'Empty' },
        { value: 'foo', label: 'Foo' },
        { value: 'bar', label: 'Bar' },
    ]
}">
    <template x-for="option in options" :key="option.label">
        <option :value="option.value" x-text="option.label"></option>
    </template>
</select>
```

The first option ends up as `<option>Empty</option>` (no `value` attribute), and `optionEl.value === 'Empty'`, not `''`.

Adding any text inside the `<option>` template (e.g. `&nbsp;`) masks the bug, which was the clue in the original report.

# The Problem

`bindInputValue` in `packages/alpinejs/src/utils/bind.js` has an early-return optimisation:

```js
} else {
    if (el.value === value) return

    el.value = value === undefined ? '' : value
}
```

For most elements, `el.value` is anchored to the `value` attribute, so this short-circuit is safe. For `<option>` it isn't: per the HTML spec, when an `<option>` has no `value` attribute, its `.value` property reflects the element's **text content**.

Because `bind` runs before `text` in Alpine's directive order, the first pass sees an option with no text yet (`el.value === ''`), the bound value is also `''`, and the function returns early without setting the attribute. `x-text` then writes `"Empty"` into the option, and `el.value` silently becomes `"Empty"` because there's no `value` attribute holding it to `""`.

# The Solution

Special-case `<option>` in `bindInputValue` so the `value` attribute is written or removed deterministically:

```js
} else if (el.tagName === 'OPTION') {
    if (value === null || value === undefined || value === false) {
        if (el.hasAttribute('value')) el.removeAttribute('value')
    } else {
        setIfChanged(el, 'value', value)
    }
}
```

For non-nullish values, the attribute is set explicitly via `setIfChanged`. This anchors `.value` so it can't drift when sibling directives write text.

For `null`/`undefined`/`false`, the attribute is removed, matching the convention `bindAttribute` already uses for other attributes. This preserves the DOM's text-as-value fallback, so `:value="someUndefinedKey"` opts back into label-as-value behaviour.

The change is scoped to `<option>` and leaves the text/checkbox/radio/select paths untouched.

Fixes #4830