### PR TITLE
Fix `:value` bindings not updating custom elements when bound object data mutates

### DIFF
--- a/packages/alpinejs/src/utils/bind.js
+++ b/packages/alpinejs/src/utils/bind.js
@@ -66,7 +66,12 @@ function bindInputValue(el, value) {
     } else if (el.tagName === 'OPTION') {
         bindAttribute(el, 'value', value)
     } else {
-        if (el.value === value) return
+        // For non-null objects, reference equality doesn't imply state
+        // equality: reactive proxies can mutate internally while the
+        // top-level reference stays the same. Without this guard, custom
+        // elements receiving an object value via x-bind:value or x-model
+        // would never see those nested updates.
+        if (el.value === value && (typeof value !== 'object' || value === null)) return
 
         el.value = value === undefined ? '' : value
     }

--- a/tests/cypress/integration/directives/x-bind.spec.js
+++ b/tests/cypress/integration/directives/x-bind.spec.js
@@ -580,3 +580,30 @@ test('option element value attribute is removed when bound value is null or unde
         get('option:nth-of-type(2)').should(haveValue('Undefined Label'))
     }
 )
+
+test(':value on a custom element re-syncs when bound object data mutates',
+    html`
+        <script>
+            if (! customElements.get('value-display')) {
+                customElements.define('value-display', class extends HTMLElement {
+                    get value() { return this._value }
+                    set value(v) {
+                        this._value = v
+                        this.textContent = JSON.stringify(v)
+                    }
+                })
+            }
+        </script>
+
+        <div x-data="{ data: [{ label: 'Mon', value: 100 }] }">
+            <value-display :value="data"></value-display>
+
+            <button @click="data[0].value = 999">Mutate</button>
+        </div>
+    `,
+    ({ get }) => {
+        get('value-display').should(haveText('[{"label":"Mon","value":100}]'))
+        get('button').click()
+        get('value-display').should(haveText('[{"label":"Mon","value":999}]'))
+    }
+)


### PR DESCRIPTION
# The Scenario

When `:value` (or `x-model`) binds an object to a custom element, mutations to nested properties don't propagate to the element:

```html
<script>
    customElements.define('value-display', class extends HTMLElement {
        get value() { return this._value }
        set value(v) {
            this._value = v
            this.textContent = JSON.stringify(v)
        }
    })
</script>

<div x-data="{ data: [{ label: 'Mon', value: 100 }] }">
    <value-display :value="data"></value-display>
    <button @click="data[0].value = 999">Mutate</button>
</div>
```

After clicking the button the display still shows `"value":100` instead of `999`.

# The Problem

`bindInputValue` short-circuits with a reference-equality check:

```js
if (el.value === value) return
```

The custom element's `value` getter returns the reactive proxy that was last set. When the proxy is the same reference between renders (its contents mutate but the top-level reference is preserved), the equality check is true and the setter is never re-invoked.

# The Solution

Skip the short-circuit when `value` is a non-null object:

```js
if (el.value === value && (typeof value !== 'object' || value === null)) return
```

Strings, numbers, booleans, and `null`/`undefined` still short-circuit as before.

Fixes livewire/flux#2414