### PR TITLE
Add x-data to $dispatch documentation example

### DIFF
--- a/packages/docs/src/en/essentials/events.md
+++ b/packages/docs/src/en/essentials/events.md
@@ -71,7 +71,7 @@ In addition to listening for browser events, you can dispatch them as well. This
 Alpine exposes a magic helper called `$dispatch` for this:
 
 ```alpine
-<div @foo="console.log('foo was dispatched')">
+<div x-data @foo="console.log('foo was dispatched')">
     <button @click="$dispatch('foo')"></button>
 </div>
 ```


### PR DESCRIPTION
The $dispatch example can be confusing when copied directly because Alpine directives and magic helpers require an Alpine component scope.

Without x-data, the example may not work as expected in a standalone setup.

This PR adds x-data to the example to make it function correctly when copied from the documentation.
Documentation link: https://alpinejs.dev/essentials/events#dispatching-custom-events