### PR TITLE
Add `.parent` modifier for `x-intersect`

### DIFF
--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -174,8 +174,10 @@ get a pixel value.
 <a name="parent"></a>
 ### .parent
 
-Allows for the underlying `IntersectionObserver` to use the viewport of the parent element, rather than the default, which is the browser.
+By default, `x-intersect` observes the element against the browser's viewport. The `.parent` modifier sets the `root` of the underlying `IntersectionObserver` to the element's parent instead, so the expression evaluates based on whether the element is visible within its parent rather than the whole page.
+
+This is handy when the element lives inside a scrollable container, or any time you care about visibility relative to the parent and not the viewport.
 
 ```alpine
-<div x-intersect.parent="shown = true">...</div> // Mark as shown when element is moves inside it's parents viewport.
+<div x-intersect.parent="shown = true">...</div> // Mark as shown when the element scrolls into view within its parent
 ```

--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -170,3 +170,12 @@ get a pixel value.
 ```alpine
 <div x-intersect.margin.-100px="visible = true">...</div> // Mark as visible when element is more than 100 pixels into the viewport.
 ```
+
+<a name="parent"></a>
+### .parent
+
+Allows for the underlying `IntersectionObserver` to use the viewport of the parent element, rather than the default, which is the browser.
+
+```alpine
+<div x-intersect.parent="shown = true">...</div> // Mark as shown when element is moves inside it's parents viewport.
+```

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -5,6 +5,7 @@ export default function (Alpine) {
         let options = {
             rootMargin: getRootMargin(modifiers),
             threshold: getThreshold(modifiers),
+            root: modifiers.includes('parent') ? el.parentElement : null
         }
 
         let observer = new IntersectionObserver(entries => {

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -168,3 +168,31 @@ test('.threshold',
         get('span').should(haveText('1'))
     },
 )
+
+test('.parent observes the element relative to its parent, not the viewport',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <!-- Push the scroll container far below the viewport so a window-rooted
+             observer would never fire. Only a parent-rooted one should. -->
+        <div style="height: 200vh;"></div>
+
+        <div id="container" style="height: 200px; overflow-y: scroll;">
+            <div style="height: 250px;">spacer</div>
+            <div style="height: 200px" x-intersect.parent="count++">content</div>
+        </div>
+    </div>
+    `],
+    ({ get }) => {
+        // The content starts below the container's scrolled viewport, so it
+        // hasn't intersected yet.
+        get('span').should(haveText('0'))
+
+        // Scrolling *within the container* (the observer's root) brings the
+        // content into view and triggers the intersection — even though the
+        // container itself is well below the browser's viewport.
+        get('#container').scrollTo(0, 250, {duration: 100})
+        get('span').should(haveText('1'))
+    },
+)


### PR DESCRIPTION
This pull request adds support for using a parent element as the viewport for `x-intersect` in Alpine.js, instead of the default browser viewport. This allows elements to be observed relative to their parent container, which is useful for more complex layouts. Documentation has also been updated to explain the new `.parent` modifier.

**Feature: Support for parent viewport in IntersectionObserver**

* [`packages/intersect/src/index.js`](diffhunk://#diff-a17b7753c98862d6434d541a096eaea3cf4879c09ff7556c2cc486d7e5d55eceR8): Added logic to set the `root` option to the parent element when the `parent` modifier is present, enabling intersection observation relative to the parent container.

**Documentation update**

* [`packages/docs/src/en/plugins/intersect.md`](diffhunk://#diff-181afc6ce848f24b52ba39229e56225fcaed2c5dae7fa1d3927e782c94441b76R173-R181): Added documentation for the new `.parent` modifier, explaining its usage and providing an example.