### PR TITLE
Fix stale keyed `x-for` range scopes

### DIFF
--- a/packages/alpinejs/src/scheduler.js
+++ b/packages/alpinejs/src/scheduler.js
@@ -17,7 +17,7 @@ export function commitTransaction() {
 }
 
 function queueJob(job) {
-    if (! queue.includes(job)) queue.push(job)
+    if (! queue.includes(job, lastFlushedIndex + 1)) queue.push(job)
 
     queueFlush()
 }

--- a/packages/alpinejs/src/scheduler.js
+++ b/packages/alpinejs/src/scheduler.js
@@ -1,8 +1,9 @@
 
 let flushPending = false
 let flushing = false
-let queue = []
-let lastFlushedIndex = -1
+let pendingJobs = new Set
+let completedJobs = new WeakSet
+let repeatedJobs = new WeakSet
 let transactionActive = false
 
 export function scheduler (callback) { queueJob(callback) }
@@ -17,14 +18,41 @@ export function commitTransaction() {
 }
 
 function queueJob(job) {
-    if (! queue.includes(job, lastFlushedIndex + 1)) queue.push(job)
+    if (jobCanBeQueued(job)) {
+        // During a flush, the data a job depends on can change after it runs, so allow it back into the queue to react to that change. Allowing it back only once prevents the scheduler from getting stuck in a loop.
+        if (jobHasPreviouslyRun(job)) recordJobAsRepeated(job)
+
+        pendingJobs.add(job)
+    }
 
     queueFlush()
 }
-export function dequeueJob(job) {
-    let index = queue.indexOf(job)
 
-    if (index !== -1 && index > lastFlushedIndex) queue.splice(index, 1)
+export function dequeueJob(job) {
+    pendingJobs.delete(job)
+}
+
+function jobCanBeQueued(job) {
+    if (jobIsPending(job)) return false
+    if (jobHasBeenRepeated(job)) return false
+
+    return true
+}
+
+function jobIsPending(job) {
+    return pendingJobs.has(job)
+}
+
+function jobHasPreviouslyRun(job) {
+    return completedJobs.has(job)
+}
+
+function jobHasBeenRepeated(job) {
+    return repeatedJobs.has(job)
+}
+
+function recordJobAsRepeated(job) {
+    repeatedJobs.add(job)
 }
 
 function queueFlush() {
@@ -41,13 +69,15 @@ export function flushJobs() {
     flushPending = false
     flushing = true
 
-    for (let i = 0; i < queue.length; i++) {
-        queue[i]()
-        lastFlushedIndex = i
+    for (let job of pendingJobs) {
+        job()
+
+        pendingJobs.delete(job)
+        completedJobs.add(job)
     }
 
-    queue.length = 0
-    lastFlushedIndex = -1
+    completedJobs = new WeakSet
+    repeatedJobs = new WeakSet
 
     flushing = false
 }

--- a/tests/cypress/integration/directives/x-effect.spec.js
+++ b/tests/cypress/integration/directives/x-effect.spec.js
@@ -1,0 +1,19 @@
+import { html, test } from '../../utils'
+
+test('effects that trigger each other do not requeue endlessly in the same flush',
+    [html`
+        <div x-data="{ a: 0, b: 0 }">
+            <button @click="window.__allowCircularEffects = true; a++">start</button>
+
+            <span x-effect="a; if (window.__allowCircularEffects) { if (++window.__circularEffectRuns > 4) throw new Error('Circular effects requeued endlessly'); b++ }"></span>
+            <span x-effect="b; if (window.__allowCircularEffects) { if (++window.__circularEffectRuns > 4) throw new Error('Circular effects requeued endlessly'); a++ }"></span>
+        </div>
+    `,
+    `
+        window.__allowCircularEffects = false
+        window.__circularEffectRuns = 0
+    `],
+    ({ get }) => {
+        get('button').click()
+    }
+)

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -412,6 +412,32 @@ test('x-for over range using i in property syntax',
     ({ get }) => get('span').should(haveLength('10'))
 )
 
+test('keyed range loops refresh reused item scopes before child effects run',
+    html`
+        <div x-data="{ start: 0, end: 25 }">
+            <button id="shrink" @click="end = 15">shrink</button>
+            <button id="shift" @click="start = 12; end = 30">shift</button>
+
+            <template x-for="i in end - start" :key="start + i">
+                <span x-text="start + i"></span>
+            </template>
+        </div>
+    `,
+    ({ get }) => {
+        let haveTexts = texts => els => {
+            expect(Array.from(els, el => el.textContent)).to.deep.equal(texts)
+        }
+
+        get('span').should(haveTexts(Array.from({ length: 25 }, (_, i) => String(i + 1))))
+
+        get('#shrink').click()
+        get('span').should(haveTexts(Array.from({ length: 15 }, (_, i) => String(i + 1))))
+
+        get('#shift').click()
+        get('span').should(haveTexts(Array.from({ length: 18 }, (_, i) => String(i + 13))))
+    }
+)
+
 test.retry(2)('x-for with an array of numbers',
     `
         <div x-data="{ items: [] }">


### PR DESCRIPTION
# The Scenario

A keyed `x-for` range can render stale values when the key combines an outer reactive value with the range item.

For example, this pattern is useful for virtualised lists where `visible_start` changes as the user scrolls:

```html
<template x-for="i in visible_end - visible_start" :key="visible_start + i">
    <span x-text="visible_start + i"></span>
</template>
```

# The Problem

When `visible_start` changes, Alpine may reuse an existing keyed element for a different range item. Directives inside that element, such as the `x-text` on the `span` above, can run from the outer `visible_start` update before `x-for` refreshes the reused element's loop scope.

For example, after scrolling, an element that previously represented `i = 13` might be reused for the new key where `i` should now be `1`.

At that point, the parent scope has already updated `visible_start` to `12`, but the reused loop scope still contains the old `i = 13`. If the `x-text` effect runs in that moment, it evaluates `visible_start + i` as `12 + 13`, rendering `25` instead of `13`.

`x-for` then refreshes the reused element's loop scope from `i = 13` to `i = 1`. Updating `i` should schedule the `x-text` effect again so it can re-evaluate `visible_start + i` and render `13`.

The scheduler blocked that second run. It kept all jobs in the queue array until the current flush completed, including jobs that had already run. When the `i` update tried to schedule the `x-text` job again, the scheduler found the existing copy of that job in the queue and treated it as already pending.

At that point the job was not actually pending. It had already run with the mixed old/new state. Because it was not added back to the queue, the corrected loop scope never caused the `x-text` expression to run again during that flush.

# The Solution

The solution is to change scheduler deduping so it only checks jobs that have not run yet.

Before this change, the scheduler checked the whole queue when deciding whether to add a job. That prevented duplicate pending work, but it also treated already-run jobs as if they were still pending because they remained in the queue array until the flush completed.

Now the scheduler starts its duplicate check after `lastFlushedIndex`. Jobs that are still waiting to run are deduped as before. Jobs that already ran earlier in the same flush can be added again if another reactive update needs them to run with newer state.

In the keyed `x-for` case, this allows the `x-text` effect to run once with the mixed old/new state, then run again after `x-for` refreshes the reused loop scope. The final render uses the updated outer value and the updated `i` value.

Fixes #4843
