### PR TITLE
Fix `x-mask` attribute changes on `x-model` inputs

### DIFF
--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -3,8 +3,12 @@ export default function (Alpine) {
     Alpine.directive('mask', (el, { value, expression }, { effect, evaluateLater, cleanup }) => {
         let templateFn = () => expression
         let lastInputValue = ''
+        let undoModelUpdate = () => {}
+        let cleanedUp = false
 
         queueMicrotask(() => {
+            if (cleanedUp) return
+
             if (['function', 'dynamic'].includes(value)) {
                 // This is an x-mask:function directive.
 
@@ -51,7 +55,7 @@ export default function (Alpine) {
                 }
 
                 let updater = el._x_forceModelUpdate
-                el._x_forceModelUpdate = (value) => {
+                let update = (value) => {
                     // If the model value was cleared (e.g. the parent object was
                     // removed), just clear the input — don't format and write back
                     // as that would resurrect the model path with an empty value.
@@ -69,13 +73,23 @@ export default function (Alpine) {
                     updater(value)
                     el._x_model.set(value)
                 }
+
+                el._x_forceModelUpdate = update
+
+                undoModelUpdate = () => {
+                    if (el._x_forceModelUpdate === update) {
+                        el._x_forceModelUpdate = updater
+                    }
+                }
             }
         })
 
         const controller = new AbortController()
 
         cleanup(() => {
+            cleanedUp = true
             controller.abort()
+            undoModelUpdate()
         })
 
         el.addEventListener('input', () => processInputValue(el), {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -4,11 +4,8 @@ export default function (Alpine) {
         let templateFn = () => expression
         let lastInputValue = ''
         let undoModelUpdate = () => {}
-        let cleanedUp = false
 
         queueMicrotask(() => {
-            if (cleanedUp) return
-
             if (['function', 'dynamic'].includes(value)) {
                 // This is an x-mask:function directive.
 
@@ -87,7 +84,6 @@ export default function (Alpine) {
         const controller = new AbortController()
 
         cleanup(() => {
-            cleanedUp = true
             controller.abort()
             undoModelUpdate()
         })

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -294,6 +294,26 @@ test('x-mask masks programmatic x-model updates',
     }
 )
 
+test('x-mask can change with x-model without reusing previous masks',
+    [html`
+        <div x-data="{ value: '12345' }">
+            <input x-ref="input" x-model="value" x-mask="99999">
+            <button id="short" @click="$refs.input.setAttribute('x-mask', '9999'); value = '1234'">Short</button>
+            <button id="long" @click="$refs.input.setAttribute('x-mask', '99999'); value = '12345'">Long</button>
+        </div>
+    `],
+    ({ get }) => {
+        get('input').should(haveValue('12345'))
+
+        get('#short').click()
+        get('input').should(haveValue('1234'))
+
+        get('#long').click()
+        get('input').should(haveValue('12345'))
+        get('div').should(haveData('value', '12345'))
+    }
+)
+
 test('x-mask with x-model initializes missing object key',
     [html`
         <div x-data="{ form: {} }">


### PR DESCRIPTION
# The Scenario

When Livewire morphs an input that uses both `wire:model` and `x-mask`, changing the server-rendered `x-mask` attribute can leave the input using a previous mask.

In this example, the input starts with a five-digit French postal code mask, changes to a four-digit Belgian mask, then changes back to the five-digit French mask. The `x-mask` attribute updates, but the input remains limited by the older four-digit mask.

```php
use Livewire\Attributes\Computed;
use Livewire\Component;

new class extends Component {
    public string $country = 'FR';
    public string $postalCode = '12345';

    #[Computed]
    public function mask()
    {
        return $this->country === 'FR' ? '99999' : '9999';
    }
};
```

```blade
<form>
    <select wire:model.live="country">
        <option value="FR">France</option>
        <option value="BE">Belgium</option>
    </select>

    <input wire:model="postalCode" x-mask="{{ $this->mask }}">
</form>
```

# The Problem

The mask directive wraps `el._x_forceModelUpdate` so programmatic model updates are formatted before they are applied to the input.

When an existing `x-mask` attribute changes, Alpine treats that as directive cleanup followed by directive initialisation. The cleanup aborts the directive's event listeners, but it does not restore `el._x_forceModelUpdate`.

That means every reinitialised mask wraps the updater currently on the element. Previous masks stay in the update chain, so an older four-digit mask can still trim a value after the element has changed back to a five-digit mask.

# The Solution

The solution is to let the mask directive unregister the model updater wrapper it installs.

The directive now keeps a reference to its wrapper and restores the previous updater during cleanup, but only when the element is still using that exact wrapper. This avoids removing a newer wrapper that may have been installed after another directive initialisation.

Fixes livewire/livewire#10377
