### PR TITLE
Add `.display` modifier to `x-mask`

### DIFF
--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -257,6 +257,10 @@ function getInputValue(el, modifiers, event, currentValue) {
                 newValue = event.target.value
             }
 
+            if (el._x_modelValueTransformer) {
+                newValue = el._x_modelValueTransformer(newValue)
+            }
+
             if (modifiers.includes('number')) {
                 return safeParseNumber(newValue)
             } else if (modifiers.includes('boolean')) {

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -257,10 +257,6 @@ function getInputValue(el, modifiers, event, currentValue) {
                 newValue = event.target.value
             }
 
-            if ('_x_modelValue' in event.target) {
-                newValue = event.target._x_modelValue
-            }
-
             if (modifiers.includes('number')) {
                 return safeParseNumber(newValue)
             } else if (modifiers.includes('boolean')) {

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -257,6 +257,10 @@ function getInputValue(el, modifiers, event, currentValue) {
                 newValue = event.target.value
             }
 
+            if ('_x_modelValue' in event.target) {
+                newValue = event.target._x_modelValue
+            }
+
             if (modifiers.includes('number')) {
                 return safeParseNumber(newValue)
             } else if (modifiers.includes('boolean')) {

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -247,6 +247,7 @@ function getInputValue(el, modifiers, event, currentValue) {
         } else {
             let newValue
 
+            // Allow plugins to override the value x-model reads from the element.
             if ('_x_modelValue' in event.target) {
                 newValue = event.target._x_modelValue
             } else if (isRadio(el)) {

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -257,8 +257,8 @@ function getInputValue(el, modifiers, event, currentValue) {
                 newValue = event.target.value
             }
 
-            if (el._x_modelValueTransformer) {
-                newValue = el._x_modelValueTransformer(newValue)
+            if ('_x_modelValue' in event.target) {
+                newValue = event.target._x_modelValue
             }
 
             if (modifiers.includes('number')) {

--- a/packages/alpinejs/src/directives/x-model.js
+++ b/packages/alpinejs/src/directives/x-model.js
@@ -247,7 +247,9 @@ function getInputValue(el, modifiers, event, currentValue) {
         } else {
             let newValue
 
-            if (isRadio(el)) {
+            if ('_x_modelValue' in event.target) {
+                newValue = event.target._x_modelValue
+            } else if (isRadio(el)) {
                 if (event.target.checked) {
                     newValue = event.target.value
                 } else {
@@ -255,10 +257,6 @@ function getInputValue(el, modifiers, event, currentValue) {
                 }
             } else {
                 newValue = event.target.value
-            }
-
-            if ('_x_modelValue' in event.target) {
-                newValue = event.target._x_modelValue
             }
 
             if (modifiers.includes('number')) {

--- a/packages/docs/src/en/plugins/mask.md
+++ b/packages/docs/src/en/plugins/mask.md
@@ -184,3 +184,29 @@ You can also override the default precision of 2 digits by using any desired num
     <input type="text" x-mask:dynamic="$money($input, '.', ',', 4)"  placeholder="0.0001">
 </div>
 <!-- END_VERBATIM -->
+
+<a name="display-only-masks"></a>
+
+## Display-only Masks
+
+By default, any formatting applied by `x-mask` is included in the value stored by `x-model`.
+
+If you only want the mask to affect what is displayed in the input, use the `.display` modifier. The input will display the masked value, while the bound property stores the unmasked value.
+
+```alpine
+<div x-data="{ amount: '1000' }">
+    <input x-mask:dynamic.display="$money($input)" x-model="amount">
+
+    <p>Model value: <span x-text="amount"></span></p>
+</div>
+```
+
+<!-- START_VERBATIM -->
+<div class="demo" x-data="{ amount: '1000' }">
+    <input x-mask:dynamic.display="$money($input)" x-model="amount">
+
+    <div class="pt-4">Model value: <span x-text="amount"></span></div>
+</div>
+<!-- END_VERBATIM -->
+
+In the above example, the input displays `1,000`, while `amount` remains `1000`. If `amount` is changed programmatically, the input will display the newly formatted value.

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -42,14 +42,12 @@ export default function (Alpine) {
 
             // Override x-model's initial value...
             if (el._x_model) {
-                if (! isDisplayOnly) {
-                    // If the x-model value is the same, don't override it as that will trigger updates...
-                    if (el._x_model.get() !== el.value) {
-                        // If the x-model value is `null` and the input value is an empty
-                        // string, don't override it as that will trigger updates...
-                        if (!(el._x_model.get() === null && el.value === '')) {
-                            el._x_model.set(el.value)
-                        }
+                // If the x-model value is the same, don't override it as that will trigger updates...
+                if (! isDisplayOnly && el._x_model.get() !== el.value) {
+                    // If the x-model value is `null` and the input value is an empty
+                    // string, don't override it as that will trigger updates...
+                    if (!(el._x_model.get() === null && el.value === '')) {
+                        el._x_model.set(el.value)
                     }
                 }
 
@@ -71,7 +69,10 @@ export default function (Alpine) {
                     }
                     lastInputValue = value
                     updater(value)
-                    if (! isDisplayOnly) el._x_model.set(value)
+
+                    if (! isDisplayOnly) {
+                        el._x_model.set(value)
+                    }
                 }
             }
         })
@@ -103,6 +104,7 @@ export default function (Alpine) {
             // If a template value is `falsy`, then don't process the input value
             if(!template || template === 'false') {
                 removeUnmaskedModelValue()
+
                 return false
             }
 
@@ -132,11 +134,15 @@ export default function (Alpine) {
         }
 
         function setUnmaskedModelValue(value) {
-            if (isDisplayOnly) el._x_modelValue = value
+            if (! isDisplayOnly) return
+
+            el._x_modelValue = value
         }
 
         function removeUnmaskedModelValue() {
-            if (isDisplayOnly) delete el._x_modelValue
+            if (! isDisplayOnly) return
+
+            delete el._x_modelValue
         }
     }).before('model')
 }

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -3,19 +3,14 @@ export default function (Alpine) {
     Alpine.directive('mask', (el, { value, expression, modifiers }, { effect, evaluateLater, cleanup }) => {
         let templateFn = () => expression
         let lastInputValue = ''
-        let lastTemplate = null
         let isDisplayOnly = modifiers.includes('display')
 
-        let transformModelValue = value => {
-            let template = lastTemplate || templateFn(value)
-
-            return template && template !== 'false'
-                ? unmaskInput(template, value)
-                : value
+        let setModelValue = value => {
+            if (isDisplayOnly) el._x_modelValue = value
         }
 
-        if (isDisplayOnly) {
-            el._x_modelValueTransformer = transformModelValue
+        let clearModelValue = () => {
+            if (isDisplayOnly) delete el._x_modelValue
         }
 
         queueMicrotask(() => {
@@ -73,18 +68,21 @@ export default function (Alpine) {
                     // as that would resurrect the model path with an empty value.
                     if (value === undefined) {
                         lastInputValue = ''
+                        clearModelValue()
                         return updater(value)
                     }
 
                     value = String(value)
+                    let modelValue = value
                     let template = templateFn(value)
                     if (template && template !== 'false') {
-                        lastTemplate = template
-                        value = formatInput(template, value)
-                    } else {
-                        lastTemplate = null
+                        let formatted = formatInputValues(template, value)
+
+                        value = formatted.masked
+                        modelValue = formatted.unmasked
                     }
                     lastInputValue = value
+                    setModelValue(modelValue)
                     updater(value)
                     if (! isDisplayOnly) el._x_model.set(value)
                 }
@@ -96,9 +94,7 @@ export default function (Alpine) {
         cleanup(() => {
             controller.abort()
 
-            if (el._x_modelValueTransformer === transformModelValue) {
-                delete el._x_modelValueTransformer
-            }
+            clearModelValue()
         })
 
         el.addEventListener('input', () => processInputValue(el), {
@@ -119,11 +115,13 @@ export default function (Alpine) {
 
             // If a template value is `falsy`, then don't process the input value
             if(!template || template === 'false') {
-                lastTemplate = null
+                clearModelValue()
                 return false
             }
 
-            lastTemplate = template
+            let formatted = formatInputValues(template, input)
+
+            setModelValue(formatted.unmasked)
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
@@ -131,7 +129,7 @@ export default function (Alpine) {
             }
 
             let setInput = () => {
-                lastInputValue = el.value = formatInput(template,input)
+                lastInputValue = el.value = formatted.masked
             }
 
             if (shouldRestoreCursor) {
@@ -170,9 +168,14 @@ let regexes = {
 }
 
 export function formatInput(template, input) {
+    return formatInputValues(template, input).masked
+}
+
+function formatInputValues(template, input) {
     let templateMark = 0
     let inputMark = 0
-    let output = ''
+    let masked = ''
+    let unmasked = ''
 
     // Walk the template and input chars simultaneously one by one...
     while (templateMark < template.length && inputMark < input.length) {
@@ -183,14 +186,15 @@ export function formatInput(template, input) {
         if (templateChar in regexes) {
             // If the input is "allowed" based on the placeholder...
             if (regexes[templateChar].test(inputChar)) {
-                output += inputChar
+                masked += inputChar
+                unmasked += inputChar
 
                 templateMark++
             }
 
             inputMark++
         } else { // We've encountered a template literal...
-            output += templateChar
+            masked += templateChar
 
             templateMark++
 
@@ -198,34 +202,7 @@ export function formatInput(template, input) {
         }
     }
 
-    return output
-}
-
-export function unmaskInput(template, input) {
-    let templateMark = 0
-    let inputMark = 0
-    let output = ''
-
-    while (templateMark < template.length && inputMark < input.length) {
-        let templateChar = template[templateMark]
-        let inputChar = input[inputMark]
-
-        if (templateChar in regexes) {
-            if (regexes[templateChar].test(inputChar)) {
-                output += inputChar
-
-                templateMark++
-            }
-
-            inputMark++
-        } else {
-            templateMark++
-
-            if (templateChar === input[inputMark]) inputMark++
-        }
-    }
-
-    return output
+    return { masked, unmasked }
 }
 
 export function formatMoney(input, delimiter = '.', thousands, precision = 2) {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -5,14 +5,6 @@ export default function (Alpine) {
         let lastInputValue = ''
         let isDisplayOnly = modifiers.includes('display')
 
-        let setModelValue = value => {
-            if (isDisplayOnly) el._x_modelValue = value
-        }
-
-        let clearModelValue = () => {
-            if (isDisplayOnly) delete el._x_modelValue
-        }
-
         queueMicrotask(() => {
             if (['function', 'dynamic'].includes(value)) {
                 // This is an x-mask:function directive.
@@ -68,7 +60,7 @@ export default function (Alpine) {
                     // as that would resurrect the model path with an empty value.
                     if (value === undefined) {
                         lastInputValue = ''
-                        clearModelValue()
+                        removeUnmaskedModelValue()
                         return updater(value)
                     }
 
@@ -89,7 +81,7 @@ export default function (Alpine) {
         cleanup(() => {
             controller.abort()
 
-            clearModelValue()
+            removeUnmaskedModelValue()
         })
 
         el.addEventListener('input', () => processInputValue(el), {
@@ -110,13 +102,13 @@ export default function (Alpine) {
 
             // If a template value is `falsy`, then don't process the input value
             if(!template || template === 'false') {
-                clearModelValue()
+                removeUnmaskedModelValue()
                 return false
             }
 
             let formatted = formatInputValues(template, input)
 
-            setModelValue(formatted.unmasked)
+            setUnmaskedModelValue(formatted.unmasked)
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
@@ -137,6 +129,14 @@ export default function (Alpine) {
             } else {
                 setInput()
             }
+        }
+
+        function setUnmaskedModelValue(value) {
+            if (isDisplayOnly) el._x_modelValue = value
+        }
+
+        function removeUnmaskedModelValue() {
+            if (isDisplayOnly) delete el._x_modelValue
         }
     }).before('model')
 }

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -68,9 +68,7 @@ export default function (Alpine) {
                     value = String(value)
                     let template = templateFn(value)
                     if (template && template !== 'false') {
-                        let formatted = formatInputValues(template, value)
-
-                        value = formatted.masked
+                        value = formatInput(template, value)
                     }
                     lastInputValue = value
                     updater(value)

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -3,7 +3,7 @@ export default function (Alpine) {
     Alpine.directive('mask', (el, { value, expression, modifiers }, { effect, evaluateLater, cleanup }) => {
         let templateFn = () => expression
         let lastInputValue = ''
-        let isDisplayOnly = modifiers.includes('display')
+        let modelValue = createModelValueHandler(el, modifiers.includes('display'))
 
         queueMicrotask(() => {
             if (['function', 'dynamic'].includes(value)) {
@@ -42,14 +42,7 @@ export default function (Alpine) {
 
             // Override x-model's initial value...
             if (el._x_model) {
-                // If the x-model value is the same, don't override it as that will trigger updates...
-                if (! isDisplayOnly && el._x_model.get() !== el.value) {
-                    // If the x-model value is `null` and the input value is an empty
-                    // string, don't override it as that will trigger updates...
-                    if (!(el._x_model.get() === null && el.value === '')) {
-                        el._x_model.set(el.value)
-                    }
-                }
+                modelValue.initialize()
 
                 let updater = el._x_forceModelUpdate
                 el._x_forceModelUpdate = (value) => {
@@ -58,21 +51,22 @@ export default function (Alpine) {
                     // as that would resurrect the model path with an empty value.
                     if (value === undefined) {
                         lastInputValue = ''
-                        removeUnmaskedModelValue()
+                        modelValue.remove()
+
                         return updater(value)
                     }
 
                     value = String(value)
                     let template = templateFn(value)
-                    if (template && template !== 'false') {
-                        value = formatInput(template, value)
-                    }
-                    lastInputValue = value
-                    updater(value)
+                    let formatted = { masked: value, unmasked: value }
 
-                    if (! isDisplayOnly) {
-                        el._x_model.set(value)
+                    if (template && template !== 'false') {
+                        formatted = formatInputValues(template, value)
                     }
+
+                    lastInputValue = formatted.masked
+                    updater(formatted.masked)
+                    modelValue.onProgrammaticUpdate(formatted)
                 }
             }
         })
@@ -82,7 +76,7 @@ export default function (Alpine) {
         cleanup(() => {
             controller.abort()
 
-            removeUnmaskedModelValue()
+            modelValue.remove()
         })
 
         el.addEventListener('input', () => processInputValue(el), {
@@ -103,14 +97,14 @@ export default function (Alpine) {
 
             // If a template value is `falsy`, then don't process the input value
             if(!template || template === 'false') {
-                removeUnmaskedModelValue()
+                modelValue.remove()
 
                 return false
             }
 
             let formatted = formatInputValues(template, input)
 
-            setUnmaskedModelValue(formatted.unmasked)
+            modelValue.onInput(formatted)
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
@@ -132,19 +126,44 @@ export default function (Alpine) {
                 setInput()
             }
         }
-
-        function setUnmaskedModelValue(value) {
-            if (! isDisplayOnly) return
-
-            el._x_modelValue = value
-        }
-
-        function removeUnmaskedModelValue() {
-            if (! isDisplayOnly) return
-
-            delete el._x_modelValue
-        }
     }).before('model')
+}
+
+function createModelValueHandler(el, isDisplayOnly) {
+    if (isDisplayOnly) {
+        return {
+            initialize() {},
+            onInput({ unmasked }) {
+                el._x_modelValue = unmasked
+            },
+            onProgrammaticUpdate({ unmasked }) {
+                el._x_modelValue = unmasked
+            },
+            remove() {
+                delete el._x_modelValue
+            },
+        }
+    }
+
+    return {
+        initialize() {
+            let value = el._x_model.get()
+
+            // If the x-model value is the same, don't override it as that will trigger updates...
+            if (value === el.value) return
+
+            // If the x-model value is `null` and the input value is an empty
+            // string, don't override it as that will trigger updates...
+            if (value === null && el.value === '') return
+
+            el._x_model.set(el.value)
+        },
+        onInput() {},
+        onProgrammaticUpdate({ masked }) {
+            el._x_model.set(masked)
+        },
+        remove() {},
+    }
 }
 
 export function restoreCursorPosition(el, template, callback) {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -108,7 +108,7 @@ export default function (Alpine) {
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
-                return lastInputValue = input
+                return lastInputValue = el.value
             }
 
             let setInput = () => {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -3,9 +3,15 @@ export default function (Alpine) {
     Alpine.directive('mask', (el, { value, expression, modifiers }, { effect, evaluateLater, cleanup }) => {
         let templateFn = () => expression
         let lastInputValue = ''
-        let lastModelValue = ''
         let isDisplayOnly = modifiers.includes('display')
-        let restoreValueGetter = () => {}
+
+        let setModelValue = value => {
+            if (isDisplayOnly) el._x_modelValue = value
+        }
+
+        let clearModelValue = () => {
+            if (isDisplayOnly) delete el._x_modelValue
+        }
 
         queueMicrotask(() => {
             if (['function', 'dynamic'].includes(value)) {
@@ -36,10 +42,10 @@ export default function (Alpine) {
                     // - Initializing the mask on the input if it has an initial value.
                     // - Running the template function to set up reactivity, so that
                     //   when a dependency inside it changes, the input re-masks.
-                    processInputValue(el, false, false)
+                    processInputValue(el, false)
                 })
             } else {
-                processInputValue(el, false, false)
+                processInputValue(el, false)
             }
 
             // Override x-model's initial value...
@@ -62,6 +68,7 @@ export default function (Alpine) {
                     // as that would resurrect the model path with an empty value.
                     if (value === undefined) {
                         lastInputValue = ''
+                        clearModelValue()
                         return updater(value)
                     }
 
@@ -82,7 +89,7 @@ export default function (Alpine) {
         cleanup(() => {
             controller.abort()
 
-            restoreValueGetter()
+            clearModelValue()
         })
 
         el.addEventListener('input', () => processInputValue(el), {
@@ -94,36 +101,25 @@ export default function (Alpine) {
 
         // Don't "restoreCursorPosition" on "blur", because Safari
         // will re-focus the input and cause a focus trap.
-        el.addEventListener('blur', () => processInputValue(el, false), { signal: controller.signal, capture: true })
-        el.addEventListener('change', () => processInputValue(el, false), { signal: controller.signal, capture: true })
-        el.addEventListener('keydown', event => {
-            if (event.key !== 'Enter') return
+        el.addEventListener('blur', () => processInputValue(el, false), { signal: controller.signal })
 
-            exposeModelValue(lastModelValue, true)
-        }, { signal: controller.signal, capture: true })
-
-        function processInputValue (el, shouldRestoreCursor = true, shouldExposeModelValue = true) {
-            restoreValueGetter()
-
+        function processInputValue (el, shouldRestoreCursor = true) {
             let input = el.value
 
             let template = templateFn(input)
 
             // If a template value is `falsy`, then don't process the input value
             if(!template || template === 'false') {
-                lastModelValue = input
-                exposeModelValue(input, shouldExposeModelValue)
+                clearModelValue()
                 return false
             }
 
             let formatted = formatInputValues(template, input)
 
-            lastModelValue = formatted.unmasked
+            setModelValue(formatted.unmasked)
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
-                exposeModelValue(formatted.unmasked, shouldExposeModelValue)
-
                 return lastInputValue = input
             }
 
@@ -141,77 +137,8 @@ export default function (Alpine) {
             } else {
                 setInput()
             }
-
-            exposeModelValue(formatted.unmasked, shouldExposeModelValue)
-        }
-
-        function exposeModelValue(value, shouldExposeModelValue) {
-            if (! isDisplayOnly || ! shouldExposeModelValue) return
-
-            restoreValueGetter()
-
-            let descriptor = Object.getOwnPropertyDescriptor(el, 'value')
-            let nativeDescriptor = getNativeValueDescriptor(el)
-
-            let restore = () => {
-                if (restoreValueGetter !== restore) return
-
-                if (descriptor) {
-                    Object.defineProperty(el, 'value', descriptor)
-                } else {
-                    delete el.value
-                }
-
-                restoreValueGetter = () => {}
-            }
-
-            restoreValueGetter = restore
-
-            Object.defineProperty(el, 'value', {
-                configurable: true,
-                get() {
-                    return value
-                },
-                set(value) {
-                    nativeDescriptor.set.call(el, value)
-                },
-            })
-
-            setTimeout(restore, getModelValueExposureDuration(el))
         }
     }).before('model')
-}
-
-function getNativeValueDescriptor(el) {
-    let prototype = Object.getPrototypeOf(el)
-
-    while (prototype) {
-        let descriptor = Object.getOwnPropertyDescriptor(prototype, 'value')
-
-        if (descriptor) return descriptor
-
-        prototype = Object.getPrototypeOf(prototype)
-    }
-}
-
-function getModelValueExposureDuration(el) {
-    let modifiers = getModelModifiers(el)
-    let debounce = modifiers.indexOf('debounce')
-
-    if (debounce === -1) return 0
-
-    let duration = modifiers[debounce + 1] || 'invalid-wait'
-    let milliseconds = Number(duration.split('ms')[0])
-
-    return (isNaN(milliseconds) ? 250 : milliseconds) + 25
-}
-
-function getModelModifiers(el) {
-    let modelAttribute = Array.from(el.attributes).find(attribute => {
-        return attribute.name === 'x-model' || attribute.name.startsWith('x-model.')
-    })
-
-    return modelAttribute ? modelAttribute.name.split('.').slice(1) : []
 }
 
 export function restoreCursorPosition(el, template, callback) {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -1,8 +1,22 @@
 
 export default function (Alpine) {
-    Alpine.directive('mask', (el, { value, expression }, { effect, evaluateLater, cleanup }) => {
+    Alpine.directive('mask', (el, { value, expression, modifiers }, { effect, evaluateLater, cleanup }) => {
         let templateFn = () => expression
         let lastInputValue = ''
+        let lastTemplate = null
+        let isDisplayOnly = modifiers.includes('display')
+
+        let transformModelValue = value => {
+            let template = lastTemplate || templateFn(value)
+
+            return template && template !== 'false'
+                ? unmaskInput(template, value)
+                : value
+        }
+
+        if (isDisplayOnly) {
+            el._x_modelValueTransformer = transformModelValue
+        }
 
         queueMicrotask(() => {
             if (['function', 'dynamic'].includes(value)) {
@@ -41,12 +55,14 @@ export default function (Alpine) {
 
             // Override x-model's initial value...
             if (el._x_model) {
-                // If the x-model value is the same, don't override it as that will trigger updates...
-                if (el._x_model.get() !== el.value) {
-                    // If the x-model value is `null` and the input value is an empty
-                    // string, don't override it as that will trigger updates...
-                    if (!(el._x_model.get() === null && el.value === '')) {
-                        el._x_model.set(el.value)
+                if (! isDisplayOnly) {
+                    // If the x-model value is the same, don't override it as that will trigger updates...
+                    if (el._x_model.get() !== el.value) {
+                        // If the x-model value is `null` and the input value is an empty
+                        // string, don't override it as that will trigger updates...
+                        if (!(el._x_model.get() === null && el.value === '')) {
+                            el._x_model.set(el.value)
+                        }
                     }
                 }
 
@@ -63,11 +79,14 @@ export default function (Alpine) {
                     value = String(value)
                     let template = templateFn(value)
                     if (template && template !== 'false') {
+                        lastTemplate = template
                         value = formatInput(template, value)
+                    } else {
+                        lastTemplate = null
                     }
                     lastInputValue = value
                     updater(value)
-                    el._x_model.set(value)
+                    if (! isDisplayOnly) el._x_model.set(value)
                 }
             }
         })
@@ -76,6 +95,10 @@ export default function (Alpine) {
 
         cleanup(() => {
             controller.abort()
+
+            if (el._x_modelValueTransformer === transformModelValue) {
+                delete el._x_modelValueTransformer
+            }
         })
 
         el.addEventListener('input', () => processInputValue(el), {
@@ -95,7 +118,12 @@ export default function (Alpine) {
             let template = templateFn(input)
 
             // If a template value is `falsy`, then don't process the input value
-            if(!template || template === 'false') return false
+            if(!template || template === 'false') {
+                lastTemplate = null
+                return false
+            }
+
+            lastTemplate = template
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
@@ -164,6 +192,33 @@ export function formatInput(template, input) {
         } else { // We've encountered a template literal...
             output += templateChar
 
+            templateMark++
+
+            if (templateChar === input[inputMark]) inputMark++
+        }
+    }
+
+    return output
+}
+
+export function unmaskInput(template, input) {
+    let templateMark = 0
+    let inputMark = 0
+    let output = ''
+
+    while (templateMark < template.length && inputMark < input.length) {
+        let templateChar = template[templateMark]
+        let inputChar = input[inputMark]
+
+        if (templateChar in regexes) {
+            if (regexes[templateChar].test(inputChar)) {
+                output += inputChar
+
+                templateMark++
+            }
+
+            inputMark++
+        } else {
             templateMark++
 
             if (templateChar === input[inputMark]) inputMark++

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -3,15 +3,9 @@ export default function (Alpine) {
     Alpine.directive('mask', (el, { value, expression, modifiers }, { effect, evaluateLater, cleanup }) => {
         let templateFn = () => expression
         let lastInputValue = ''
+        let lastModelValue = ''
         let isDisplayOnly = modifiers.includes('display')
-
-        let setModelValue = value => {
-            if (isDisplayOnly) el._x_modelValue = value
-        }
-
-        let clearModelValue = () => {
-            if (isDisplayOnly) delete el._x_modelValue
-        }
+        let restoreValueGetter = () => {}
 
         queueMicrotask(() => {
             if (['function', 'dynamic'].includes(value)) {
@@ -42,10 +36,10 @@ export default function (Alpine) {
                     // - Initializing the mask on the input if it has an initial value.
                     // - Running the template function to set up reactivity, so that
                     //   when a dependency inside it changes, the input re-masks.
-                    processInputValue(el, false)
+                    processInputValue(el, false, false)
                 })
             } else {
-                processInputValue(el, false)
+                processInputValue(el, false, false)
             }
 
             // Override x-model's initial value...
@@ -68,21 +62,17 @@ export default function (Alpine) {
                     // as that would resurrect the model path with an empty value.
                     if (value === undefined) {
                         lastInputValue = ''
-                        clearModelValue()
                         return updater(value)
                     }
 
                     value = String(value)
-                    let modelValue = value
                     let template = templateFn(value)
                     if (template && template !== 'false') {
                         let formatted = formatInputValues(template, value)
 
                         value = formatted.masked
-                        modelValue = formatted.unmasked
                     }
                     lastInputValue = value
-                    setModelValue(modelValue)
                     updater(value)
                     if (! isDisplayOnly) el._x_model.set(value)
                 }
@@ -94,7 +84,7 @@ export default function (Alpine) {
         cleanup(() => {
             controller.abort()
 
-            clearModelValue()
+            restoreValueGetter()
         })
 
         el.addEventListener('input', () => processInputValue(el), {
@@ -106,26 +96,37 @@ export default function (Alpine) {
 
         // Don't "restoreCursorPosition" on "blur", because Safari
         // will re-focus the input and cause a focus trap.
-        el.addEventListener('blur', () => processInputValue(el, false), { signal: controller.signal })
+        el.addEventListener('blur', () => processInputValue(el, false), { signal: controller.signal, capture: true })
+        el.addEventListener('change', () => processInputValue(el, false), { signal: controller.signal, capture: true })
+        el.addEventListener('keydown', event => {
+            if (event.key !== 'Enter') return
 
-        function processInputValue (el, shouldRestoreCursor = true) {
+            exposeModelValue(lastModelValue, true)
+        }, { signal: controller.signal, capture: true })
+
+        function processInputValue (el, shouldRestoreCursor = true, shouldExposeModelValue = true) {
+            restoreValueGetter()
+
             let input = el.value
 
             let template = templateFn(input)
 
             // If a template value is `falsy`, then don't process the input value
             if(!template || template === 'false') {
-                clearModelValue()
+                lastModelValue = input
+                exposeModelValue(input, shouldExposeModelValue)
                 return false
             }
 
             let formatted = formatInputValues(template, input)
 
-            setModelValue(formatted.unmasked)
+            lastModelValue = formatted.unmasked
 
             // If they hit backspace, don't process input.
             if (lastInputValue.length - el.value.length === 1) {
-                return lastInputValue = el.value
+                exposeModelValue(formatted.unmasked, shouldExposeModelValue)
+
+                return lastInputValue = input
             }
 
             let setInput = () => {
@@ -142,8 +143,77 @@ export default function (Alpine) {
             } else {
                 setInput()
             }
+
+            exposeModelValue(formatted.unmasked, shouldExposeModelValue)
+        }
+
+        function exposeModelValue(value, shouldExposeModelValue) {
+            if (! isDisplayOnly || ! shouldExposeModelValue) return
+
+            restoreValueGetter()
+
+            let descriptor = Object.getOwnPropertyDescriptor(el, 'value')
+            let nativeDescriptor = getNativeValueDescriptor(el)
+
+            let restore = () => {
+                if (restoreValueGetter !== restore) return
+
+                if (descriptor) {
+                    Object.defineProperty(el, 'value', descriptor)
+                } else {
+                    delete el.value
+                }
+
+                restoreValueGetter = () => {}
+            }
+
+            restoreValueGetter = restore
+
+            Object.defineProperty(el, 'value', {
+                configurable: true,
+                get() {
+                    return value
+                },
+                set(value) {
+                    nativeDescriptor.set.call(el, value)
+                },
+            })
+
+            setTimeout(restore, getModelValueExposureDuration(el))
         }
     }).before('model')
+}
+
+function getNativeValueDescriptor(el) {
+    let prototype = Object.getPrototypeOf(el)
+
+    while (prototype) {
+        let descriptor = Object.getOwnPropertyDescriptor(prototype, 'value')
+
+        if (descriptor) return descriptor
+
+        prototype = Object.getPrototypeOf(prototype)
+    }
+}
+
+function getModelValueExposureDuration(el) {
+    let modifiers = getModelModifiers(el)
+    let debounce = modifiers.indexOf('debounce')
+
+    if (debounce === -1) return 0
+
+    let duration = modifiers[debounce + 1] || 'invalid-wait'
+    let milliseconds = Number(duration.split('ms')[0])
+
+    return (isNaN(milliseconds) ? 250 : milliseconds) + 25
+}
+
+function getModelModifiers(el) {
+    let modelAttribute = Array.from(el.attributes).find(attribute => {
+        return attribute.name === 'x-model' || attribute.name.startsWith('x-model.')
+    })
+
+    return modelAttribute ? modelAttribute.name.split('.').slice(1) : []
 }
 
 export function restoreCursorPosition(el, template, callback) {

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -65,7 +65,9 @@ export default function (Alpine) {
                     }
 
                     lastInputValue = formatted.masked
-                    updater(formatted.masked)
+                    if (modelValue.shouldUpdateInput(formatted)) {
+                        updater(formatted.masked)
+                    }
                     modelValue.onProgrammaticUpdate(formatted)
                 }
             }
@@ -131,10 +133,16 @@ export default function (Alpine) {
 
 function createModelValueHandler(el, isDisplayOnly) {
     if (isDisplayOnly) {
+        let inputValue
+
         return {
             initialize() {},
             onInput({ unmasked }) {
+                inputValue = unmasked
                 el._x_modelValue = unmasked
+            },
+            shouldUpdateInput({ unmasked }) {
+                return document.activeElement !== el || inputValue !== unmasked
             },
             onProgrammaticUpdate({ unmasked }) {
                 el._x_modelValue = unmasked
@@ -159,6 +167,9 @@ function createModelValueHandler(el, isDisplayOnly) {
             el._x_model.set(el.value)
         },
         onInput() {},
+        shouldUpdateInput() {
+            return true
+        },
         onProgrammaticUpdate({ masked }) {
             el._x_model.set(masked)
         },

--- a/packages/mask/src/index.js
+++ b/packages/mask/src/index.js
@@ -109,7 +109,7 @@ export default function (Alpine) {
             modelValue.onInput(formatted)
 
             // If they hit backspace, don't process input.
-            if (lastInputValue.length - el.value.length === 1) {
+            if (lastInputValue.length - el.value.length === 1 && formatted.masked.length >= el.value.length) {
                 return lastInputValue = el.value
             }
 

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -163,6 +163,34 @@ test('x-mask.display masks programmatic x-model updates without masking the mode
     },
 )
 
+test('x-mask.display preserves x-model number modifier',
+    [html`
+        <div x-data="{ value: '' }">
+            <input x-mask.display="9,999" x-model.number="value" id="1">
+            <span id="2" x-text="typeof value + ':' + value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#2').should(haveText('number:1234'))
+    },
+)
+
+test('x-mask.display preserves x-model blur modifier',
+    [html`
+        <div x-data="{ value: '' }">
+            <input x-mask.display="9,999" x-model.blur="value" id="1">
+            <span id="2" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#2').should(haveText(''))
+        get('#1').blur()
+        get('#2').should(haveText('1234'))
+    },
+)
+
 test('x-mask with x-model if initial value is null it should remain null',
     [html`
         <div x-data="{ value: null }">

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -163,6 +163,25 @@ test('x-mask.display masks programmatic x-model updates without masking the mode
     },
 )
 
+test('x-mask.display refreshes unmasked model value after programmatic x-model updates',
+    [html`
+        <div x-data="{ value: '1000' }">
+            <input x-mask.display="9,999" x-model.enter="value" id="1">
+            <span id="2" x-text="value"></span>
+            <button @click="value = '2345'">Change</button>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveValue('1,000'))
+        get('#2').should(haveText('1000'))
+        get('button').click()
+        get('#1').should(haveValue('2,345'))
+        get('#2').should(haveText('2345'))
+        get('#1').type('{enter}')
+        get('#2').should(haveText('2345'))
+    },
+)
+
 test('x-mask.display preserves x-model number modifier',
     [html`
         <div x-data="{ value: '' }">

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -191,6 +191,49 @@ test('x-mask.display preserves x-model blur modifier',
     },
 )
 
+test('x-mask.display preserves x-model change modifier',
+    [html`
+        <div x-data="{ value: '' }">
+            <input x-mask.display="9,999" x-model.change="value" id="1">
+            <span id="2" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#2').should(haveText(''))
+        get('#1').blur()
+        get('#2').should(haveText('1234'))
+    },
+)
+
+test('x-mask.display preserves x-model debounce modifier',
+    [html`
+        <div x-data="{ value: '' }">
+            <input x-mask.display="9,999" x-model.debounce.50ms="value" id="1">
+            <span id="2" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#2').should(haveText('1234'))
+    },
+)
+
+test('x-mask.display preserves x-model enter modifier',
+    [html`
+        <div x-data="{ value: '' }">
+            <input x-mask.display="9,999" x-model.enter="value" id="1">
+            <span id="2" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#2').should(haveText(''))
+        get('#1').type('{enter}')
+        get('#2').should(haveText('1234'))
+    },
+)
+
 test('x-mask with x-model if initial value is null it should remain null',
     [html`
         <div x-data="{ value: null }">

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -113,6 +113,56 @@ test('x-mask with x-model with initial value',
     },
 )
 
+test('x-mask.display with x-model keeps initial model value unmasked',
+    [html`
+        <div x-data="{ value: '1000' }">
+            <input x-mask.display="9,999" x-model="value" id="1">
+            <input x-model="value" id="2">
+            <span id="3" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveValue('1,000'))
+        get('#2').should(haveValue('1000'))
+        get('#3').should(haveText('1000'))
+    },
+)
+
+test('x-mask.display with x-model stores user input unmasked',
+    [html`
+        <div x-data="{ value: '' }">
+            <input x-mask.display="9,999" x-model="value" id="1">
+            <input x-model="value" id="2">
+            <span id="3" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').type('1234').should(haveValue('1,234'))
+        get('#2').should(haveValue('1234'))
+        get('#3').should(haveText('1234'))
+    },
+)
+
+test('x-mask.display masks programmatic x-model updates without masking the model value',
+    [html`
+        <div x-data="{ value: '1000' }">
+            <input x-mask.display="9,999" x-model="value" id="1">
+            <input x-model="value" id="2">
+            <span id="3" x-text="value"></span>
+            <button @click="value = '2345'">Change</button>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveValue('1,000'))
+        get('#2').should(haveValue('1000'))
+        get('#3').should(haveText('1000'))
+        get('button').click()
+        get('#1').should(haveValue('2,345'))
+        get('#2').should(haveValue('2345'))
+        get('#3').should(haveText('2345'))
+    },
+)
+
 test('x-mask with x-model if initial value is null it should remain null',
     [html`
         <div x-data="{ value: null }">

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -157,6 +157,23 @@ test('x-mask.display preserves the cursor after deleting from a dynamic mask',
     },
 )
 
+test('x-mask.display reformats a dynamic mask after deleting a separator-adjacent digit',
+    [html`
+        <div x-data="{ value: 1500 }">
+            <input x-mask:dynamic.display="$money($input, '.', ',', 0)" x-model.number="value" id="1">
+            <span id="2" x-text="typeof value + ':' + value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveValue('1,500'))
+        get('#1').type('{leftArrow}{leftArrow}{backspace}').should(haveValue('100'))
+        get('#1').should(($input) => {
+            expect($input[0].selectionStart).to.equal(1)
+        })
+        get('#2').should(haveText('number:100'))
+    },
+)
+
 test('x-mask.display masks programmatic x-model updates without masking the model value',
     [html`
         <div x-data="{ value: '1000' }">

--- a/tests/cypress/integration/plugins/mask.spec.js
+++ b/tests/cypress/integration/plugins/mask.spec.js
@@ -143,6 +143,20 @@ test('x-mask.display with x-model stores user input unmasked',
     },
 )
 
+test('x-mask.display preserves the cursor after deleting from a dynamic mask',
+    [html`
+        <div x-data="{ value: '1000' }">
+            <input x-mask:dynamic.display="$money($input, '.', ',', 0)" x-model="value" id="1">
+            <span id="2" x-text="value"></span>
+        </div>
+    `],
+    ({ get }) => {
+        get('#1').should(haveValue('1,000'))
+        get('#1').type('{leftArrow}{leftArrow}{backspace}5').should(haveValue('1,500'))
+        get('#2').should(haveText('1500'))
+    },
+)
+
 test('x-mask.display masks programmatic x-model updates without masking the model value',
     [html`
         <div x-data="{ value: '1000' }">


### PR DESCRIPTION
# The Scenario

A masked input may need to display a formatted value while keeping an unformatted value in application state.

For example, this Livewire property should remain the integer `1000`, while the input displays `1,000`. Instead, Livewire receives the formatted string `"1,000"` for the integer `$quantity` property, causing a property type error.

<img width="800" height="593" alt="CleanShot 2026-07-13 at 18 04 33" src="https://github.com/user-attachments/assets/e8a2a0e6-6e26-4b65-ad05-da7781ec7d41" />


```blade
<?php

use Livewire\Component;

new class extends Component {
    public int $quantity = 1000;

    public function updating(): void
    {
        usleep(500_000);
    }

    public function setQuantity(): void
    {
        $this->quantity = 2000;
    }
};
?>

<div>
    <flux:input
        label="Quantity"
        type="text"
        x-mask:dynamic="$money($input)"
        wire:model.live="quantity"
    />

    <flux:button wire:click="setQuantity">Set to 2000</flux:button>

    <div>
        <flux:label>Livewire value</flux:label>
        <flux:text>{{ $quantity }}</flux:text>
    </div>
</div>
```

# The Problem

`x-mask` does not distinguish between the value displayed in the input and the value stored in the model.

When `1000` is masked to `1,000`, the formatted value replaces the input’s value. It is then picked up by `x-model` and sent to Livewire, which attempts to store the string `"1,000"` instead of the integer `1000`, triggering the property type error.

# The Solution

This PR adds a new `.display` modifier to `x-mask`.

The modifier separates the value displayed in the input from the value stored in the model. The masked value is assigned to the input, while `x-model` receives the unmasked value.

This PR also adds `_x_modelValue` support to `x-model`. Display masks use it to expose the unmasked value. When present, `x-model` uses this value instead of the input's `value`.

In the example above, adding `.display` makes the input display `1,000` while `$quantity` remains the integer `1000`:

```blade
<flux:input
    label="Quantity"
    type="text"
    x-mask:dynamic.display="$money($input)"
    wire:model.live="quantity"
/>
```

<img width="800" height="593" alt="CleanShot 2026-07-13 at 18 06 37" src="https://github.com/user-attachments/assets/b642cf54-b9cf-4565-be57-58739a6f18e7" />

Dynamic masks now remove obsolete separators after backspacing.

Without `.display`, `x-mask` continues to store the formatted value in the model.

Fixes livewire/flux#2666
