### PR TITLE
Fix persisted single-value stores

### DIFF
--- a/packages/alpinejs/src/store.js
+++ b/packages/alpinejs/src/store.js
@@ -13,7 +13,12 @@ export function store(name, value) {
 
     stores[name] = value
 
-    initInterceptors(stores[name])
+    // Initialize the interceptor directly when it is the store value itself.
+    if (typeof value === 'object' && value !== null && value._x_interceptor) {
+        stores[name] = value.initialize(stores, name, name)
+    } else {
+        initInterceptors(stores[name])
+    }
 
     if (typeof value === 'object' && value !== null && value.hasOwnProperty('init') && typeof value.init === 'function') {
         stores[name].init()

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -227,6 +227,25 @@ test('can persist using global Alpine.$persist within Alpine.store',
     },
 )
 
+test('can persist a primitive as a direct Alpine store',
+    [html`
+        <div x-data>
+            <button @click="$store.language = $store.language === 'EN' ? 'IT' : 'EN'"></button>
+            <span x-text="$store.language"></span>
+        </div>
+    `, `
+        Alpine.store('language', Alpine.$persist('EN').as('direct-store-language'))
+    `],
+    ({ get, window }, reload) => {
+        get('span').should(haveText('EN'))
+        get('button').click()
+        get('span').should(haveText('IT'))
+        window().its('localStorage.direct-store-language').should(beEqualTo(JSON.stringify('IT')))
+        reload()
+        get('span').should(haveText('IT'))
+    },
+)
+
 test('persist in Stores is available in init call',
     [html`
         <div x-data>


### PR DESCRIPTION
# The Scenario

When `Alpine.$persist()` is used as the direct value of a single-value store, the store initially renders `[object Object]` instead of its persisted value.

```js
Alpine.store('language', Alpine.$persist('EN').as('language'))
```

```html
<button
    x-data
    x-on:click="$store.language = $store.language === 'EN' ? 'IT' : 'EN'"
    x-text="$store.language"
></button>
```

# The Problem

`Alpine.$persist()` wraps the initial value until Alpine sets up persistence.

Alpine currently initialises wrapped values found inside a store object, but skips the wrapper when it is the entire store.

The wrapper is therefore exposed through `$store.language`, causing it to display `[object Object]`. Changes to the store are also not saved.

# The Solution

The solution is to check whether the store value itself needs to be initialised.

When it does, Alpine replaces it with the real persisted value and watches that store for future changes. Object stores continue using the existing logic for persisted properties.

Fixes #4855
