### PR TITLE
Upgrade `@vue/reactivity` to Vue 3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,17 +2149,19 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
+            "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+            "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.1.5"
+                "@vue/shared": "3.5.40"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA=="
+            "version": "3.5.40",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
+            "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+            "license": "MIT"
         },
         "node_modules/abab": {
             "version": "2.0.6",
@@ -10282,7 +10284,7 @@
             "version": "3.15.12",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "~3.1.1"
+                "@vue/reactivity": "~3.5.40"
             }
         },
         "packages/anchor": {
@@ -10303,7 +10305,7 @@
             "version": "3.15.12",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "~3.1.1"
+                "@vue/reactivity": "~3.5.40"
             }
         },
         "packages/docs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,18 +2149,18 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.40",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.40.tgz",
-            "integrity": "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+            "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.40"
+                "@vue/shared": "3.5.41"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.40",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",
-            "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
+            "version": "3.5.41",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+            "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
             "license": "MIT"
         },
         "node_modules/abab": {

--- a/packages/alpinejs/package.json
+++ b/packages/alpinejs/package.json
@@ -14,6 +14,6 @@
     "module": "dist/module.esm.js",
     "unpkg": "dist/cdn.min.js",
     "dependencies": {
-        "@vue/reactivity": "~3.1.1"
+        "@vue/reactivity": "~3.5.40"
     }
 }

--- a/packages/alpinejs/src/index.js
+++ b/packages/alpinejs/src/index.js
@@ -48,8 +48,8 @@ Alpine.setReactivityEngine({
 
         runner = effect(callback, {
             scheduler: () => {
-                // A self-triggering effect can notify before `runner` is
-                // assigned; Vue 3.1 silently dropped those, so we do too.
+                // Defensively preserve Vue 3.1's behavior if an engine ever
+                // schedules during its initial run, before returning a runner.
                 if (! runner) return
 
                 options.scheduler ? options.scheduler(runner) : runner()

--- a/packages/alpinejs/src/index.js
+++ b/packages/alpinejs/src/index.js
@@ -44,7 +44,9 @@ Alpine.setReactivityEngine({
     // Since Vue 3.2, the scheduler is called with no arguments, so we wrap
     // the effect to hand Alpine's scheduler the runner it expects to queue.
     effect: (callback, options = {}) => {
-        let runner = effect(callback, {
+        let runner
+
+        runner = effect(callback, {
             scheduler: () => {
                 // A self-triggering effect can notify before `runner` is
                 // assigned; Vue 3.1 silently dropped those, so we do too.

--- a/packages/alpinejs/src/index.js
+++ b/packages/alpinejs/src/index.js
@@ -39,7 +39,26 @@ Alpine.setRawEvaluator(normalRawEvaluator)
  */
 import { reactive, effect, stop, toRaw } from '@vue/reactivity'
 
-Alpine.setReactivityEngine({ reactive, effect, release: stop, raw: toRaw })
+Alpine.setReactivityEngine({
+    reactive,
+    // Since Vue 3.2, the scheduler is called with no arguments, so we wrap
+    // the effect to hand Alpine's scheduler the runner it expects to queue.
+    effect: (callback, options = {}) => {
+        let runner = effect(callback, {
+            scheduler: () => {
+                // A self-triggering effect can notify before `runner` is
+                // assigned; Vue 3.1 silently dropped those, so we do too.
+                if (! runner) return
+
+                options.scheduler ? options.scheduler(runner) : runner()
+            },
+        })
+
+        return runner
+    },
+    release: stop,
+    raw: toRaw,
+})
 
 /**
  * _______________________________________________________

--- a/packages/csp/package.json
+++ b/packages/csp/package.json
@@ -12,6 +12,6 @@
     "main": "dist/module.cjs.js",
     "module": "dist/module.esm.js",
     "dependencies": {
-        "@vue/reactivity": "~3.1.1"
+        "@vue/reactivity": "~3.5.40"
     }
 }

--- a/packages/csp/src/index.js
+++ b/packages/csp/src/index.js
@@ -34,7 +34,9 @@ Alpine.setReactivityEngine({
     // Since Vue 3.2, the scheduler is called with no arguments, so we wrap
     // the effect to hand Alpine's scheduler the runner it expects to queue.
     effect: (callback, options = {}) => {
-        let runner = effect(callback, {
+        let runner
+
+        runner = effect(callback, {
             scheduler: () => {
                 // A self-triggering effect can notify before `runner` is
                 // assigned; Vue 3.1 silently dropped those, so we do too.

--- a/packages/csp/src/index.js
+++ b/packages/csp/src/index.js
@@ -29,7 +29,26 @@ Alpine.setRawEvaluator(cspRawEvaluator)
  */
 import { reactive, effect, stop, toRaw } from '@vue/reactivity'
 
-Alpine.setReactivityEngine({ reactive, effect, release: stop, raw: toRaw })
+Alpine.setReactivityEngine({
+    reactive,
+    // Since Vue 3.2, the scheduler is called with no arguments, so we wrap
+    // the effect to hand Alpine's scheduler the runner it expects to queue.
+    effect: (callback, options = {}) => {
+        let runner = effect(callback, {
+            scheduler: () => {
+                // A self-triggering effect can notify before `runner` is
+                // assigned; Vue 3.1 silently dropped those, so we do too.
+                if (! runner) return
+
+                options.scheduler ? options.scheduler(runner) : runner()
+            },
+        })
+
+        return runner
+    },
+    release: stop,
+    raw: toRaw,
+})
 
 import 'alpinejs/src/magics/index'
 import 'alpinejs/src/directives/index'

--- a/packages/csp/src/index.js
+++ b/packages/csp/src/index.js
@@ -38,8 +38,8 @@ Alpine.setReactivityEngine({
 
         runner = effect(callback, {
             scheduler: () => {
-                // A self-triggering effect can notify before `runner` is
-                // assigned; Vue 3.1 silently dropped those, so we do too.
+                // Defensively preserve Vue 3.1's behavior if an engine ever
+                // schedules during its initial run, before returning a runner.
                 if (! runner) return
 
                 options.scheduler ? options.scheduler(runner) : runner()

--- a/tests/cypress/integration/reactivity-csp.spec.js
+++ b/tests/cypress/integration/reactivity-csp.spec.js
@@ -1,0 +1,70 @@
+import { haveText, html, notExist, test } from '../utils'
+
+test.csp('CSP Alpine.effect batches synchronous updates and Alpine.release stops it',
+    [html`
+        <span id="count"></span>
+        <span id="runs"></span>
+    `,
+    `
+        let state = Alpine.reactive({ count: 0 })
+        let runs = 0
+
+        let runner = Alpine.effect(() => {
+            document.querySelector('#count').textContent = state.count
+            document.querySelector('#runs').textContent = ++runs
+        })
+
+        window.reactivityTestState = state
+        window.releaseReactivityTestEffect = () => Alpine.release(runner)
+    `],
+    ({ get }, reload, window) => {
+        get('#count').should(haveText('0'))
+        get('#runs').should(haveText('1')).then(() => {
+            window.reactivityTestState.count++
+            window.reactivityTestState.count++
+            window.reactivityTestState.count++
+        })
+
+        get('#count').should(haveText('3'))
+        get('#runs').should(haveText('2')).then(() => {
+            window.releaseReactivityTestEffect()
+            window.reactivityTestState.count++
+        })
+
+        get('#count').should(haveText('3'))
+        get('#runs').should(haveText('2'))
+    },
+)
+
+test.csp('CSP element cleanup dequeues the exact pending effect runner',
+    [html`
+        <div x-data="{ show: true }">
+            <template x-if="show">
+                <span x-audit-effect></span>
+            </template>
+        </div>
+    `,
+    `
+        window.cspReactivityState = Alpine.reactive({ count: 0 })
+        window.cspReactivityRuns = 0
+
+        Alpine.directive('audit-effect', (el, value, { effect }) => {
+            effect(() => {
+                window.cspReactivityState.count
+                window.cspReactivityRuns++
+            })
+        })
+    `],
+    ({ get }, reload, window, document) => {
+        get('span').then(() => {
+            expect(window.cspReactivityRuns).to.equal(1)
+
+            document.querySelector('[x-data]')._x_dataStack[0].show = false
+            window.cspReactivityState.count++
+        })
+
+        get('span').should(notExist()).then(() => {
+            expect(window.cspReactivityRuns).to.equal(1)
+        })
+    },
+)

--- a/tests/cypress/integration/reactivity.spec.js
+++ b/tests/cypress/integration/reactivity.spec.js
@@ -1,0 +1,62 @@
+import { haveText, html, notExist, test } from '../utils'
+
+test('Alpine.effect batches synchronous updates and Alpine.release stops it',
+    [html`
+        <span id="count"></span>
+        <span id="runs"></span>
+    `,
+    `
+        let state = Alpine.reactive({ count: 0 })
+        let runs = 0
+
+        let runner = Alpine.effect(() => {
+            document.querySelector('#count').textContent = state.count
+            document.querySelector('#runs').textContent = ++runs
+        })
+
+        window.reactivityTestState = state
+        window.releaseReactivityTestEffect = () => Alpine.release(runner)
+    `],
+    ({ get }, reload, window) => {
+        get('#count').should(haveText('0'))
+        get('#runs').should(haveText('1')).then(() => {
+            window.reactivityTestState.count++
+            window.reactivityTestState.count++
+            window.reactivityTestState.count++
+        })
+
+        get('#count').should(haveText('3'))
+        get('#runs').should(haveText('2')).then(() => {
+            window.releaseReactivityTestEffect()
+            window.reactivityTestState.count++
+        })
+
+        get('#count').should(haveText('3'))
+        get('#runs').should(haveText('2'))
+    }
+)
+
+test('element cleanup dequeues the exact pending effect runner',
+    [html`
+        <div x-data="{ count: 0, show: true }">
+            <button @click="show = false; count++">Remove</button>
+
+            <template x-if="show">
+                <span x-effect="count; window.reactivityTestRuns++"></span>
+            </template>
+        </div>
+    `,
+    `
+        window.reactivityTestRuns = 0
+    `],
+    ({ get }, reload, window) => {
+        get('span').then(() => {
+            expect(window.reactivityTestRuns).to.equal(1)
+        })
+
+        get('button').click()
+        get('span').should(notExist()).then(() => {
+            expect(window.reactivityTestRuns).to.equal(1)
+        })
+    }
+)


### PR DESCRIPTION
## What

Upgrade the default Alpine and CSP reactivity engines from the Vue 3.1 line (2021) to Vue 3.5. The package constraint is `~3.5.40` and the lockfile now resolves the current 3.5.41 patch.

This also adapts Alpine to Vue's modern effect scheduler contract without changing Alpine's public API.

## Why upgrade

The 3.1 line is nearly five years old. Vue 3.4 and 3.5 substantially refactored dependency tracking and reactive arrays, and later 3.5 patches include fixes for dependency cleanup, failed writes, stale computed values, reactive Maps/Sets, arrays, and memory leaks.

The most concrete Alpine benefit is array-heavy `x-for` work. This upgrade also establishes the scheduler contract required for a later Vue 3.6 upgrade.

- [Vue 3.4 reactivity improvements](https://blog.vuejs.org/posts/vue-3-4#more-efficient-reactivity-system)
- [Vue 3.5 reactivity improvements](https://blog.vuejs.org/posts/vue-3-5#reactivity-system-optimizations)

## Scheduler compatibility

Vue 3.1 invoked an effect scheduler with the effect runner:

```js
scheduler(runner)
```

Modern Vue invokes it without arguments:

```js
scheduler()
```

A dependency-only bump would therefore make Alpine queue `undefined`. Alpine needs the exact callable runner for:

- scheduler queue deduplication
- structural priority metadata
- `dequeueJob()` and pending-job removal
- element `_x_effects` cleanup
- `Alpine.release()` / Vue's `stop(runner)`

The default and CSP adapters now close over the runner returned by Vue and hand that same object to Alpine's scheduler:

```js
effect: (callback, options = {}) => {
    let runner

    runner = effect(callback, {
        scheduler: () => {
            if (! runner) return

            options.scheduler ? options.scheduler(runner) : runner()
        },
    })

    return runner
}
```

Passing Vue's scheduler through directly loses the runner. Queuing a new closure such as `() => runner()` breaks runner identity, deduplication, and pending-job cleanup. The adapter is the narrowest compatibility shim and leaves custom `setReactivityEngine` implementations unchanged.

The pre-assignment guard defensively preserves Vue 3.1 behavior if an engine ever schedules during its synchronous initial run. Vue 3.5 currently suppresses self-notification while an effect is running, so this is a defensive boundary rather than an active Vue 3.5 path.

The `mergeProxies` setter workaround in `scope.js` remains necessary: the `target === toRaw(receiver)` guard in Vue's set trap is unchanged through 3.6.

## Compatibility and safety audit

There is no intended Alpine public API change. Upstream bug fixes and reduced redundant triggering are observable correctness improvements, so this is not literally a behavior-free dependency change.

The upgrade was tested on the PR branch and after merging it with current `main`, including Alpine's structural-priority scheduler.

### Differential randomized testing

An independent property harness ran Vue 3.1.5 and Vue 3.5.40/41 against the same plain-JavaScript oracle:

- 250 deterministic seeds
- 25,000 mutation batches
- 112,061 randomized operations
- 2,500 create → queue → dequeue → release lifecycle probes
- primitives and conditional dependencies
- nested objects and dependency replacement
- array push/pop/shift/unshift/splice/reverse/sort/length and iteration methods
- object-key iteration
- reactive Maps and Sets
- self-triggering effects
- scheduler deduplication, release, and pending-job cleanup

Every Vue 3.1 and Vue 3.5 result matched each other and the independent oracle. Mutation controls verified that the harness fails if the runner is dropped or replaced with a fresh closure.

### Browser and repository suites

- production build passes
- Vitest: 172 passed, 1 skipped on the exact PR branch
- normal scheduler/cleanup integration tests: 2/2
- equivalent CSP scheduler/cleanup integration tests: 2/2
- current-main structural stress oracle: 800 seeded transitions across nested keyed ranges, `x-if`, `x-html`, teleport, transactions, and ordinary scheduling
- complete Cypress suite passed during the current-main integration audit
- the final exact-branch Cypress rerun hit only the repository's existing retry-marked popover focus test; its isolated rerun passed
- production dependency audit: zero known vulnerabilities

Vue 3.5.41's reactivity runtime is identical to 3.5.40 apart from its version banner. The only relevant `@vue/shared` source delta is an unrelated boolean-HTML-attribute table change, which is not used by Alpine's reactivity bundle.

## Independently measured performance

Median Alpine-shaped Node measurements; lower is better:

| Scenario | Vue 3.1.5 | Vue 3.5.40 | Delta |
|---|---:|---:|---:|
| create and stop 30k effects | 10.50ms | 8.56ms | **−18.5%** |
| 1k effects × 100 triggers | 32.07ms | 19.43ms | **−39.4%** |
| iterate a 10k reactive array × 200 | 308.86ms | 47.13ms | **−84.7%** |
| deep `JSON.stringify` × 250 | 464.07ms | 508.35ms | **+9.5%** |
| heap for 100k active effects | 57.58 MiB | 55.85 MiB | **−3.0%** |

The array-tracking improvement is the headline Alpine win. Ordinary effect triggering is also materially faster. Deep JSON-based watching was modestly slower in this harness, and Alpine-shaped active-effect memory did not reproduce Vue's headline 56% reduction, so those are documented as tradeoffs rather than hidden by the faster cases.

Earlier end-to-end headless-Chrome measurements using an `x-for` table also showed:

| Operation | Vue 3.1.5 | Vue 3.5.40 | Delta |
|---|---:|---:|---:|
| create 10k rows | 1338ms | 1232ms | −8% |
| append 1k rows to 1k | 154ms | 125ms | −19% |
| update every 10th of 10k | 184ms | 173ms | −6% |
| clear 10k rows | 253ms | 210ms | −17% |
| initialize 2,000 components | 210ms | 186ms | −11% |

## Bundle-size cost

This is the material cost of the upgrade and should be accepted explicitly:

| Build | Before | After | Delta |
|---|---:|---:|---:|
| Alpine CDN, raw | 48,325 B | 54,454 B | +12.7% |
| Alpine CDN, gzip | 17,265 B | 19,424 B | **+2,159 B / +12.5%** |
| CSP CDN, raw | 63,499 B | 69,632 B | +9.7% |
| CSP CDN, gzip | 20,940 B | 23,020 B | **+2,080 B / +9.9%** |

The upgrade trades roughly 2.1 KiB gzip for a maintained engine line, years of correctness fixes, substantially faster tracked arrays, faster ordinary effect triggering, and a clean path to Vue 3.6.

## Follow-up

Vue 3.6's reactivity rewrite keeps the same adapter contract. Once 3.6 is stable, it can be evaluated as a version-only follow-up with the same differential and browser stress harnesses.
