### PR TITLE
Fix stale effects after `x-data` replacement

### DIFF
--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -119,7 +119,7 @@ export function getElementBoundUtilities(el) {
         evaluate: evaluate.bind(evaluate, el),
     }
 
-    let doCleanup = () => cleanups.forEach(i => i())
+    let doCleanup = (...args) => cleanups.forEach(i => i(...args))
 
     return [utilities, doCleanup]
 }

--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -10,6 +10,8 @@ import { evaluate } from '../evaluator'
 
 addRootSelector(() => `[${prefix('data')}]`)
 
+let dataToReconcile = new WeakMap
+
 directive('data', ((el, { expression }, { cleanup }) => {
     if (shouldSkipRegisteringDataDuringClone(el)) return
 
@@ -27,18 +29,46 @@ directive('data', ((el, { expression }, { cleanup }) => {
 
     injectMagics(data, el)
 
-    let reactiveData = reactive(data)
+    let reactiveData = dataToReconcile.get(el)
 
-    initInterceptors(reactiveData)
+    dataToReconcile.delete(el)
+
+    if (reactiveData) {
+        Object.keys(data).forEach(key => {
+            let descriptor = Object.getOwnPropertyDescriptor(data, key)
+            let existingDescriptor = Object.getOwnPropertyDescriptor(reactiveData, key)
+
+            if (descriptor.get || descriptor.set || existingDescriptor?.get || existingDescriptor?.set) {
+                if (existingDescriptor) delete reactiveData[key]
+                if (! existingDescriptor) reactiveData[key] = undefined
+
+                descriptor.get || descriptor.set
+                    ? Object.defineProperty(reactiveData, key, descriptor)
+                    : reactiveData[key] = data[key]
+            } else {
+                reactiveData[key] = data[key]
+            }
+        })
+
+        Object.keys(reactiveData)
+            .filter(key => ! Object.prototype.hasOwnProperty.call(data, key))
+            .forEach(key => delete reactiveData[key])
+    } else {
+        reactiveData = reactive(data)
+    }
+
+    initInterceptors(reactiveData, cleanup)
 
     let undo = addScopeToNode(el, reactiveData)
 
     reactiveData['init'] && evaluate(el, reactiveData['init'])
 
-    cleanup(() => {
+    cleanup((isReplaced) => {
         reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])
 
         undo()
+
+        if (isReplaced) dataToReconcile.set(el, reactiveData)
     })
 }))
 

--- a/packages/alpinejs/src/interceptor.js
+++ b/packages/alpinejs/src/interceptor.js
@@ -1,7 +1,7 @@
 // Warning: The concept of "interceptors" in Alpine is not public API and is subject to change
 // without tagging a major release.
 
-export function initInterceptors(data) {
+export function initInterceptors(data, cleanup = () => {}) {
     let isObject = val => typeof val === 'object' && !Array.isArray(val) && val !== null
 
     let recurse = (obj, basePath = '') => {
@@ -13,7 +13,7 @@ export function initInterceptors(data) {
             let path = basePath === '' ? key : `${basePath}.${key}`
 
             if (typeof value === 'object' && value !== null && value._x_interceptor) {
-                obj[key] = value.initialize(data, path, key)
+                obj[key] = value.initialize(data, path, key, cleanup)
             } else {
                 if (isObject(value) && value !== obj && ! (value instanceof Element)) {
                     recurse(value, path)
@@ -31,8 +31,8 @@ export function interceptor(callback, mutateObj = () => {}) {
 
         _x_interceptor: true,
 
-        initialize(data, path, key) {
-            return callback(this.initialValue, () => get(data, path), (value) => set(data, path, value), path, key)
+        initialize(data, path, key, cleanup) {
+            return callback(this.initialValue, () => get(data, path), (value) => set(data, path, value), path, key, cleanup)
         }
     }
 
@@ -43,12 +43,12 @@ export function interceptor(callback, mutateObj = () => {}) {
             // Support nesting interceptors.
             let initialize = obj.initialize.bind(obj)
 
-            obj.initialize = (data, path, key) => {
-                let innerValue = initialValue.initialize(data, path, key)
+            obj.initialize = (data, path, key, cleanup) => {
+                let innerValue = initialValue.initialize(data, path, key, cleanup)
 
                 obj.initialValue = innerValue
 
-                return initialize(data, path, key)
+                return initialize(data, path, key, cleanup)
             }
         } else {
             obj.initialValue = initialValue

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -28,12 +28,12 @@ export function onAttributeRemoved(el, name, callback) {
     el._x_attributeCleanups[name].push(callback)
 }
 
-export function cleanupAttributes(el, names) {
+export function cleanupAttributes(el, names, replacements = []) {
     if (! el._x_attributeCleanups) return
 
     Object.entries(el._x_attributeCleanups).forEach(([name, value]) => {
         if (names === undefined || names.includes(name)) {
-            value.forEach(i => i())
+            value.forEach(i => i(replacements.includes(name)))
 
             delete el._x_attributeCleanups[name]
         }
@@ -160,12 +160,14 @@ function onMutate(mutations) {
 
             let add = () => {
                 if (! addedAttributes.has(el)) addedAttributes.set(el, [])
+                if (addedAttributes.get(el).some(attr => attr.name === name)) return
 
                 addedAttributes.get(el).push({ name,  value: el.getAttribute(name) })
             }
 
             let remove = () => {
                 if (! removedAttributes.has(el)) removedAttributes.set(el, [])
+                if (removedAttributes.get(el).includes(name)) return
 
                 removedAttributes.get(el).push(name)
             }
@@ -185,7 +187,9 @@ function onMutate(mutations) {
     }
 
     removedAttributes.forEach((attrs, el) => {
-        cleanupAttributes(el, attrs)
+        let replacements = addedAttributes.get(el)?.map(attr => attr.name) || []
+
+        cleanupAttributes(el, attrs, replacements)
     })
 
     addedAttributes.forEach((attrs, el) => {

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -17,7 +17,7 @@ export default function (Alpine) {
             }
         }
 
-        return Alpine.interceptor((initialValue, getter, setter, path, key) => {
+        return Alpine.interceptor((initialValue, getter, setter, path, key, cleanup) => {
             let lookup = alias || `_x_${path}`
 
             let initial = storageHas(lookup, storage)
@@ -26,13 +26,15 @@ export default function (Alpine) {
 
             setter(initial)
 
-            Alpine.effect(() => {
+            let effect = Alpine.effect(() => {
                 let value = getter()
 
                 storageSet(lookup, value, storage)
 
                 setter(value)
             })
+
+            cleanup(() => Alpine.release(effect))
 
             return initial
         }, func => {

--- a/tests/cypress/integration/directives/x-data.spec.js
+++ b/tests/cypress/integration/directives/x-data.spec.js
@@ -124,3 +124,141 @@ test('x-data getters have access to parent scope',
     `,
     ({ get }) => get('h1').should(haveText('bar'))
 )
+
+test('updating an x-data expression keeps descendant effects bound to the current scope',
+    [html`
+        <div id="component" x-data="{
+            version: 1,
+            value: null,
+        }">
+            <span x-text="value ?? 'No value'"></span>
+        </div>
+    `],
+    ({ get }, reload, window) => {
+        // Give the original scope a value that will reveal a stale effect later.
+        get('#component').then(([el]) => {
+            window.Alpine.$data(el).value = 'Hello'
+        })
+
+        get('span').should(haveText('Hello'))
+
+        // Simulate a server-rendered x-data expression changing while preserving the element.
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', `{
+                version: 2,
+                value: null,
+            }`)
+        })
+
+        // Wait for Alpine's mutation observer to install the replacement scope.
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).value).to.equal(null)
+        })
+
+        // Update the replacement scope to verify descendant effects are bound to it.
+        get('#component').then(([el]) => {
+            window.Alpine.$data(el).value = 'Goodbye'
+        })
+
+        get('span').should(haveText('Goodbye'))
+    },
+)
+
+test('replacing x-data removes old properties and updates nested state',
+    html`
+        <div id="component" x-data="{
+            oldValue: 'old',
+            nested: { value: 'one' },
+            get label() { return this.nested.value },
+        }">
+            <span x-text="label"></span>
+        </div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', `{
+                newValue: 'new',
+                nested: { value: 'two' },
+                get label() { return this.nested.value },
+            }`)
+        })
+
+        get('#component').should(([el]) => {
+            let data = window.Alpine.$data(el)
+
+            expect('oldValue' in data).to.equal(false)
+            expect(data.newValue).to.equal('new')
+        })
+
+        get('span').should(haveText('two'))
+
+        get('#component').then(([el]) => {
+            window.Alpine.$data(el).nested.value = 'three'
+        })
+
+        get('span').should(haveText('three'))
+    }
+)
+
+test('multiple synchronous x-data replacements only initialize the final scope once',
+    html`
+        <div id="component" x-data="{
+            version: 1,
+            init() { window.xDataInitCount = (window.xDataInitCount || 0) + 1 },
+        }"></div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            window.originalScope = el._x_dataStack[0]
+
+            el.setAttribute('x-data', `{
+                version: 2,
+                init() { window.xDataInitCount++ },
+            }`)
+            el.setAttribute('x-data', `{
+                version: 3,
+                init() { window.xDataInitCount++ },
+            }`)
+        })
+
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).version).to.equal(3)
+            expect(el._x_dataStack).to.have.length(1)
+            expect(el._x_dataStack[0]).to.equal(window.originalScope)
+            expect(window.xDataInitCount).to.equal(2)
+        })
+    }
+)
+
+test('replacing x-data transitions between accessors and ordinary properties',
+    html`
+        <div id="component" x-data="{
+            value: 'one',
+            get label() { return this.value },
+        }">
+            <span x-text="label"></span>
+        </div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', "{ label: 'two' }")
+        })
+
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).label).to.equal('two')
+        })
+        get('span').should(haveText('two'))
+
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', `{
+                value: 'three',
+                get label() { return this.value },
+            }`)
+        })
+
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).label).to.equal('three')
+        })
+        get('span').should(haveText('three'))
+    }
+)

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -271,3 +271,125 @@ test('multiple aliases work when using global Alpine.$persist',
         get('p').should(haveText('Doe'))
     },
 )
+
+test('x-data replacement initializes persisted values and newly introduced interceptors',
+    [html`
+        <div id="component" x-data="{
+            count: $persist(1).as('count').using(window.persistStorage),
+        }">
+            <span x-text="count"></span>
+        </div>
+    `, `
+        window.persistStorage = {
+            values: {},
+            getItem(key) { return this.values[key] ?? null },
+            setItem(key, value) { this.values[key] = value },
+        }
+    `],
+    ({ get }, reload, window) => {
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).count).to.equal(1)
+            expect(window.Alpine.$data(el).count?._x_interceptor).to.equal(undefined)
+        })
+
+        get('#component').then(([el]) => {
+            window.Alpine.$data(el).count = 2
+        })
+
+        get('span').should(haveText('2'))
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', `{
+                count: $persist(0).as('count').using(window.persistStorage),
+                message: $persist('hello').as('message').using(window.persistStorage),
+            }`)
+        })
+
+        get('#component').should(([el]) => {
+            let data = window.Alpine.$data(el)
+
+            expect(data.count).to.equal(2)
+            expect(data.message).to.equal('hello')
+            expect(data.count?._x_interceptor).to.equal(undefined)
+            expect(data.message?._x_interceptor).to.equal(undefined)
+        })
+
+        get('#component').then(([el]) => {
+            let data = window.Alpine.$data(el)
+
+            data.count = 3
+            data.message = 'goodbye'
+        })
+
+        get('span').should(haveText('3'))
+        get('#component').should(() => {
+            expect(window.persistStorage.values.count).to.equal(JSON.stringify(3))
+            expect(window.persistStorage.values.message).to.equal(JSON.stringify('goodbye'))
+        })
+    },
+)
+
+test('x-data replacement does not accumulate persistence effects',
+    [html`
+        <div id="component" x-data="{
+            count: $persist(1).as('count').using(window.persistStorage),
+        }">
+            <span x-text="count"></span>
+        </div>
+    `, `
+        window.persistStorage = {
+            values: {},
+            writes: {},
+            getItem(key) { return this.values[key] ?? null },
+            setItem(key, value) {
+                this.values[key] = value
+                this.writes[key] = (this.writes[key] || 0) + 1
+            },
+        }
+    `],
+    ({ get }, reload, window) => {
+        let replacePersistedCount = initialValue => {
+            get('#component').then(([el]) => {
+                el.setAttribute('x-data', `{
+                    version: ${initialValue},
+                    count: $persist(${initialValue}).as('count').using(window.persistStorage),
+                }`)
+            })
+            get('#component').should(([el]) => {
+                let data = window.Alpine.$data(el)
+
+                expect(data.version).to.equal(initialValue)
+                expect(data.count?._x_interceptor).to.equal(undefined)
+            })
+        }
+
+        replacePersistedCount(2)
+        replacePersistedCount(3)
+
+        get('#component').then(([el]) => {
+            window.persistStorage.writes.count = 0
+            window.Alpine.$data(el).count = 4
+        })
+
+        get('span').should(haveText('4'))
+        get('#component').should(() => {
+            expect(window.persistStorage.writes.count).to.equal(1)
+        })
+
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', '{ count: 5 }')
+        })
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).count).to.equal(5)
+        })
+
+        get('#component').then(([el]) => {
+            window.persistStorage.writes.count = 0
+            window.Alpine.$data(el).count = 6
+        })
+
+        get('span').should(haveText('6'))
+        get('#component').should(() => {
+            expect(window.persistStorage.writes.count).to.equal(0)
+        })
+    },
+)


### PR DESCRIPTION
# The Scenario

When a Livewire update changes values rendered into a keyed Alpine component's `x-data` expression, the component state resets correctly but a descendant `x-text` binding can continue displaying its previous value.

In this example, selecting the first option displays `One`. Replacing the available options causes Livewire to morph the existing element with a new `x-data` expression. Although `selectedValue` resets to `null`, the label can remain stuck on `One` and ignore subsequent changes to the current scope.

```blade
<?php

use Livewire\Component;

new class extends Component {
    public array $options = ['One', 'Two'];

    public function replaceOptions(): void
    {
        $this->options = ['Three', 'Four'];
    }
};

?>

<div>
    <button wire:click="replaceOptions">
        Replace options
    </button>

    <div
        wire:key="options"
        x-data="{
            options: {{ Js::from($options) }},
            selectedValue: null,
        }"
    >
        <button
            type="button"
            x-on:click="selectedValue = options[0]"
        >
            Select first option
        </button>

        <span x-text="selectedValue ?? 'No option selected'"></span>
    </div>
</div>
```

# The Problem

When Alpine observes a changed `x-data` attribute, it cleans up the existing directive and initialises the replacement.

The cleanup removes the original reactive object from the component's data stack. The replacement expression is then wrapped in a new reactive object.

Descendant directives are not reinitialised because their elements and attributes have not changed. Their evaluators still reference the original reactive object, while `Alpine.$data()` returns the replacement. Effects therefore remain registered but no longer react to writes made through the component's current scope.

Repeated attribute changes can also initialise the final expression more than once, producing duplicate scope entries.

# The Solution

The solution is to update the existing reactive `x-data` object instead of replacing it with a new one.

This keeps descendant bindings connected to the same object they were originally watching. Alpine applies values from the new `x-data` expression to that object and removes properties that are no longer present.

Getters and setters are copied without converting them into plain values.

Alpine now distinguishes between replacing an `x-data` attribute and removing it entirely. Replacements preserve the reactive object, while removals continue to destroy and release the component normally.

Multiple changes to the same attribute in one mutation batch are combined so the final expression is only initialised once.

Effects created by `$persist` are released when their owning `x-data` expression is replaced. This prevents old persistence effects from accumulating.

PR #4759 previously explored updating the existing reactive object in place. This implementation was developed independently and differs in several important ways.

It only retains the reactive object during a confirmed attribute replacement. Removing `x-data` does not leave the old component data attached to the element.

It also preserves getters and setters, removes obsolete lifecycle properties, prevents duplicate scopes during repeated mutations, and cleans up interceptor effects created by `$persist`.

Related to PR #4759
Fixes #4864
