### PR TITLE
Fix fallback storage returning undefined for missing keys

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -12,7 +12,7 @@ export default function (Alpine) {
             let dummy = new Map();
 
             storage = {
-                getItem: dummy.get.bind(dummy),
+                getItem: key => dummy.has(key) ? dummy.get(key) : null,
                 setItem: dummy.set.bind(dummy)
             }
         }
@@ -61,7 +61,9 @@ export default function (Alpine) {
 }
 
 function storageHas(key, storage) {
-    return storage.getItem(key) !== null
+    let value = storage.getItem(key)
+
+    return value !== null && value !== undefined
 }
 
 function storageGet(key, storage) {


### PR DESCRIPTION
Fixes #4866

### What was the issue?
When `localStorage` is unavailable or throws an exception, `$persist` falls back to an in-memory `Map` storage (`dummy`).

When checking if a persisted key exists, `storageHas()` ran `storage.getItem(key) !== null`. Because `Map.prototype.get()` returns `undefined` (unlike `localStorage.getItem()` which returns `null`), `storageHas()` returned `true` for keys that were never set. This caused Alpine to attempt reading the value, receiving `undefined`, and overwriting the initial value passed to `$persist()`.

### Changes made
1. Updated the fallback `dummy` storage `getItem` handler to return `null` when a key is missing from the map, bringing it in line with the standard `Storage.getItem()` specification.
2. Updated `storageHas()` to check that the returned value is neither `null` nor `undefined`.

### Verification
- Tested normal `localStorage` functionality — remains unchanged.
- Tested fallback memory storage — initial values are now preserved correctly when `localStorage` throws or is absent.