### PR TITLE
Preserve x-data scope when its expression changes

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -10,8 +10,16 @@ import { evaluate } from '../evaluator'
 
 addRootSelector(() => `[${prefix('data')}]`)
 
+let dataForReconciliation = Symbol()
+
 directive('data', ((el, { expression }, { cleanup }) => {
     if (shouldSkipRegisteringDataDuringClone(el)) return
+
+    let dataToReconcile = el[dataForReconciliation]
+
+    // Multiple changes to the same attribute are collapsed into one mutation
+    // batch. Only initialize the final expression once.
+    if (dataToReconcile?.expression === expression) return
 
     expression = expression === '' ? '{}' : expression
 
@@ -27,9 +35,25 @@ directive('data', ((el, { expression }, { cleanup }) => {
 
     injectMagics(data, el)
 
-    let reactiveData = reactive(data)
+    let reactiveData
 
-    initInterceptors(reactiveData)
+    if (dataToReconcile?.reactiveData) {
+        reactiveData = dataToReconcile.reactiveData
+        reconcileData(reactiveData, data)
+
+        let initialized = { expression }
+        el[dataForReconciliation] = initialized
+
+        queueMicrotask(() => {
+            if (el[dataForReconciliation] === initialized) {
+                delete el[dataForReconciliation]
+            }
+        })
+    } else {
+        reactiveData = reactive(data)
+    }
+
+    initInterceptors(reactiveData, cleanup)
 
     let undo = addScopeToNode(el, reactiveData)
 
@@ -39,8 +63,42 @@ directive('data', ((el, { expression }, { cleanup }) => {
         reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])
 
         undo()
+
+        // Attribute cleanup and re-initialization happen synchronously in the
+        // same mutation flush. Keep the data around just long enough for a
+        // replacement x-data directive to reuse it, but not a later addition.
+        let removed = { reactiveData }
+        el[dataForReconciliation] = removed
+
+        queueMicrotask(() => {
+            if (el[dataForReconciliation] === removed) {
+                delete el[dataForReconciliation]
+            }
+        })
     })
 }))
+
+function reconcileData(target, source) {
+    Object.keys(source).forEach(key => {
+        let descriptor = Object.getOwnPropertyDescriptor(source, key)
+        let existingDescriptor = Object.getOwnPropertyDescriptor(target, key)
+
+        if (descriptor.get || descriptor.set || existingDescriptor?.get || existingDescriptor?.set) {
+            if (existingDescriptor) delete target[key]
+            if (! existingDescriptor) target[key] = undefined
+
+            descriptor.get || descriptor.set
+                ? Object.defineProperty(target, key, descriptor)
+                : target[key] = source[key]
+        } else {
+            target[key] = source[key]
+        }
+    })
+
+    Object.keys(target)
+        .filter(key => ! Object.prototype.hasOwnProperty.call(source, key))
+        .forEach(key => delete target[key])
+}
 
 interceptClone((from, to) => {
     // Transfer over existing runtime Alpine state from

--- a/packages/alpinejs/src/interceptor.js
+++ b/packages/alpinejs/src/interceptor.js
@@ -1,7 +1,7 @@
 // Warning: The concept of "interceptors" in Alpine is not public API and is subject to change
 // without tagging a major release.
 
-export function initInterceptors(data) {
+export function initInterceptors(data, cleanup = () => {}) {
     let isObject = val => typeof val === 'object' && !Array.isArray(val) && val !== null
 
     let recurse = (obj, basePath = '') => {
@@ -13,7 +13,7 @@ export function initInterceptors(data) {
             let path = basePath === '' ? key : `${basePath}.${key}`
 
             if (typeof value === 'object' && value !== null && value._x_interceptor) {
-                obj[key] = value.initialize(data, path, key)
+                obj[key] = value.initialize(data, path, key, cleanup)
             } else {
                 if (isObject(value) && value !== obj && ! (value instanceof Element)) {
                     recurse(value, path)
@@ -31,8 +31,8 @@ export function interceptor(callback, mutateObj = () => {}) {
 
         _x_interceptor: true,
 
-        initialize(data, path, key) {
-            return callback(this.initialValue, () => get(data, path), (value) => set(data, path, value), path, key)
+        initialize(data, path, key, cleanup) {
+            return callback(this.initialValue, () => get(data, path), (value) => set(data, path, value), path, key, cleanup)
         }
     }
 
@@ -43,12 +43,12 @@ export function interceptor(callback, mutateObj = () => {}) {
             // Support nesting interceptors.
             let initialize = obj.initialize.bind(obj)
 
-            obj.initialize = (data, path, key) => {
-                let innerValue = initialValue.initialize(data, path, key)
+            obj.initialize = (data, path, key, cleanup) => {
+                let innerValue = initialValue.initialize(data, path, key, cleanup)
 
                 obj.initialValue = innerValue
 
-                return initialize(data, path, key)
+                return initialize(data, path, key, cleanup)
             }
         } else {
             obj.initialValue = initialValue

--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -17,7 +17,7 @@ export default function (Alpine) {
             }
         }
 
-        return Alpine.interceptor((initialValue, getter, setter, path, key) => {
+        return Alpine.interceptor((initialValue, getter, setter, path, key, cleanup) => {
             let lookup = alias || `_x_${path}`
 
             let initial = storageHas(lookup, storage)
@@ -26,13 +26,15 @@ export default function (Alpine) {
 
             setter(initial)
 
-            Alpine.effect(() => {
+            let effect = Alpine.effect(() => {
                 let value = getter()
 
                 storageSet(lookup, value, storage)
 
                 setter(value)
             })
+
+            cleanup(() => Alpine.release(effect))
 
             return initial
         }, func => {

--- a/tests/cypress/integration/directives/x-data.spec.js
+++ b/tests/cypress/integration/directives/x-data.spec.js
@@ -124,3 +124,116 @@ test('x-data getters have access to parent scope',
     `,
     ({ get }) => get('h1').should(haveText('bar'))
 )
+
+test('replacing x-data keeps descendant effects bound to the same reactive object',
+    html`
+        <div id="component" x-data="{ version: 1, value: 'one' }">
+            <span x-text="value"></span>
+        </div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            window.originalScope = el._x_dataStack[0]
+
+            el.setAttribute('x-data', "{ version: 2, value: 'two' }")
+        })
+
+        get('#component').should(([el]) => {
+            expect(el._x_dataStack).to.have.length(1)
+            expect(el._x_dataStack[0]).to.equal(window.originalScope)
+            expect(window.Alpine.$data(el).version).to.equal(2)
+        })
+
+        get('span').should(haveText('two'))
+
+        get('#component').then(([el]) => {
+            window.Alpine.$data(el).value = 'three'
+        })
+
+        get('span').should(haveText('three'))
+    },
+)
+
+test('replacing x-data removes old keys and preserves property descriptors',
+    html`
+        <div id="component" x-data="{
+            removed: true,
+            value: 'one',
+            get label() { return this.value },
+        }">
+            <span x-text="label"></span>
+        </div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', "{ label: 'two' }")
+        })
+
+        get('#component').should(([el]) => {
+            let data = window.Alpine.$data(el)
+
+            expect('removed' in data).to.equal(false)
+            expect(data.label).to.equal('two')
+        })
+
+        get('span').should(haveText('two'))
+
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', "{ value: 'three', get label() { return this.value } }")
+        })
+
+        get('span').should(haveText('three'))
+    },
+)
+
+test('multiple synchronous x-data replacements initialize only the final expression',
+    html`
+        <div id="component" x-data="{
+            version: 1,
+            init() { window.xDataInitCount = (window.xDataInitCount || 0) + 1 },
+        }"></div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            window.originalScope = el._x_dataStack[0]
+
+            el.setAttribute('x-data', "{ version: 2, init() { window.xDataInitCount++ } }")
+            el.setAttribute('x-data', "{ version: 3, init() { window.xDataInitCount++ } }")
+        })
+
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).version).to.equal(3)
+            expect(el._x_dataStack).to.have.length(1)
+            expect(el._x_dataStack[0]).to.equal(window.originalScope)
+            expect(window.xDataInitCount).to.equal(2)
+        })
+    },
+)
+
+test('removing and later re-adding x-data creates a new reactive object',
+    html`
+        <div id="component" x-data="{
+            version: 1,
+            destroy() { window.xDataDestroyCount = (window.xDataDestroyCount || 0) + 1 },
+        }"></div>
+    `,
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            window.originalScope = el._x_dataStack[0]
+            el.removeAttribute('x-data')
+        })
+
+        get('#component').should(() => {
+            expect(window.xDataDestroyCount).to.equal(1)
+        })
+
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', '{ version: 2 }')
+        })
+
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).version).to.equal(2)
+            expect(el._x_dataStack[0]).not.to.equal(window.originalScope)
+        })
+    },
+)

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -271,3 +271,116 @@ test('multiple aliases work when using global Alpine.$persist',
         get('p').should(haveText('Doe'))
     },
 )
+
+test('x-data replacement initializes new persisted properties',
+    [html`
+        <div id="component" x-data="{
+            count: $persist(1).as('count').using(window.persistStorage),
+        }">
+            <span x-text="count"></span>
+        </div>
+    `, `
+        window.persistStorage = {
+            values: {},
+            getItem(key) { return this.values[key] ?? null },
+            setItem(key, value) { this.values[key] = value },
+        }
+    `],
+    ({ get }, reload, window) => {
+        get('#component').then(([el]) => {
+            window.Alpine.$data(el).count = 2
+        })
+
+        get('span').should(haveText('2'))
+
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', `{
+                count: $persist(0).as('count').using(window.persistStorage),
+                message: $persist('hello').as('message').using(window.persistStorage),
+            }`)
+        })
+
+        get('#component').should(([el]) => {
+            let data = window.Alpine.$data(el)
+
+            expect(data.count).to.equal(2)
+            expect(data.message).to.equal('hello')
+        })
+
+        get('#component').then(([el]) => {
+            let data = window.Alpine.$data(el)
+
+            data.count = 3
+            data.message = 'goodbye'
+        })
+
+        get('#component').should(() => {
+            expect(window.persistStorage.values.count).to.equal(JSON.stringify(3))
+            expect(window.persistStorage.values.message).to.equal(JSON.stringify('goodbye'))
+        })
+    },
+)
+
+test('x-data replacement releases previous persistence effects',
+    [html`
+        <div id="component" x-data="{
+            count: $persist(1).as('count').using(window.persistStorage),
+        }">
+            <span x-text="count"></span>
+        </div>
+    `, `
+        window.persistStorage = {
+            values: {},
+            writes: {},
+            getItem(key) { return this.values[key] ?? null },
+            setItem(key, value) {
+                this.values[key] = value
+                this.writes[key] = (this.writes[key] || 0) + 1
+            },
+        }
+    `],
+    ({ get }, reload, window) => {
+        let replacePersistedCount = version => {
+            get('#component').then(([el]) => {
+                el.setAttribute('x-data', `{
+                    version: ${version},
+                    count: $persist(${version}).as('count').using(window.persistStorage),
+                }`)
+            })
+
+            get('#component').should(([el]) => {
+                expect(window.Alpine.$data(el).version).to.equal(version)
+            })
+        }
+
+        replacePersistedCount(2)
+        replacePersistedCount(3)
+
+        get('#component').then(([el]) => {
+            window.persistStorage.writes.count = 0
+            window.Alpine.$data(el).count = 4
+        })
+
+        get('#component').should(() => {
+            expect(window.persistStorage.writes.count).to.equal(1)
+        })
+
+        get('#component').then(([el]) => {
+            el.setAttribute('x-data', '{ count: 5 }')
+        })
+
+        get('#component').should(([el]) => {
+            expect(window.Alpine.$data(el).count).to.equal(5)
+        })
+
+        get('#component').then(([el]) => {
+            window.persistStorage.writes.count = 0
+            window.Alpine.$data(el).count = 6
+        })
+
+        get('span').should(haveText('6'))
+        get('#component').should(() => {
+            expect(window.persistStorage.writes.count).to.equal(0)
+        })
+    },
+)


### PR DESCRIPTION
When Livewire morphs an existing element and changes its `x-data` expression, Alpine cleans up and initializes the directive again. Today that creates a new reactive object. Descendant directives are unchanged, so their evaluators remain bound to the previous object while new scope lookups resolve the replacement.

## Approach

Preserve the root reactive object across an immediate `x-data` replacement and reconcile the newly evaluated top-level shape into it.

- `x-data` temporarily parks its reactive object on the element during cleanup. A synchronous re-initialization consumes it.
- A microtask clears the parked object when `x-data` was genuinely removed, so a later addition still creates a fresh scope.
- Multiple changes in one mutation batch initialize only the final expression.
- Reconciliation is intentionally shallow: the root proxy survives, while nested values are replaced normally. Accessors are preserved and keys missing from the new expression are removed.
- Interceptors receive directive cleanup so replaced `$persist` declarations release their old effects before the new expression is initialized.

This keeps replacement detection local to `x-data`. It does not change mutation observer bookkeeping, general directive cleanup, or descendant lifecycle behavior. Ordinary same-element scope composition (including Alpine UI's programmatic `x-data` bindings) remains unchanged.

## Why not reinitialize descendants?

Reinitializing the subtree would run unrelated directive lifecycles again and still would not update bespoke effects or other consumers holding the original root object. Preserving that reference addresses the split-scope failure directly.

## Verification

- Added browser coverage for preserved identity, descendant effects, removed keys, getter/data-property transitions, same-batch replacements, true remove/re-add behavior, and persisted values/effect cleanup.
- Ran the full Cypress suite, including Alpine UI integration specs.
- Ran Vitest: 172 passed, 1 skipped.
- Built Alpine and verified the original Livewire morph reproduction end-to-end.
- Minified CDN bundle delta: +629 bytes raw (the reported compressed Alpine size remains 15.0 KB).

This is a narrower alternative to #4865.

Fixes #4864
