### PR TITLE
Pass cleanup callback to direct store interceptors

### DIFF
--- a/packages/alpinejs/src/store.js
+++ b/packages/alpinejs/src/store.js
@@ -15,7 +15,7 @@ export function store(name, value) {
 
     // Initialize the interceptor directly when it is the store value itself.
     if (typeof value === 'object' && value !== null && value._x_interceptor) {
-        stores[name] = value.initialize(stores, name, name)
+        stores[name] = value.initialize(stores, name, name, () => {})
     } else {
         initInterceptors(stores[name])
     }


### PR DESCRIPTION
Fixes the persisted direct-store regression introduced in #4859.

Direct store interceptors now receive the same no-op cleanup callback used by the generic interceptor initialization path.

Validation:
- `npm run build`
- `npx cypress run --browser chrome --headless --spec tests/cypress/integration/plugins/persist.spec.js` (16 passing)