### PR TITLE
Split draft and npm release workflows

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,106 @@
+name: Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 3.15.12 or v3.15.12)'
+        required: true
+        type: string
+      previous_tag:
+        description: 'Previous tag for generated release notes (e.g. v3.15.11)'
+        required: false
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: draft-release
+  cancel-in-progress: false
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm install -g npm@latest
+
+      - name: Normalize and validate release inputs
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PREVIOUS_TAG: ${{ inputs.previous_tag }}
+        run: |
+          version="${INPUT_VERSION#v}"
+
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: ${version} (expected X.Y.Z)"
+            exit 1
+          fi
+
+          echo "VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=v${version}" >> "$GITHUB_ENV"
+
+          if [[ -n "${INPUT_PREVIOUS_TAG}" ]]; then
+            previous_tag="v${INPUT_PREVIOUS_TAG#v}"
+
+            if [[ ! "${previous_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid previous tag format: ${previous_tag} (expected vX.Y.Z)"
+              exit 1
+            fi
+
+            echo "PREVIOUS_TAG=${previous_tag}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify tag does not exist
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${RELEASE_TAG} already exists"
+            exit 1
+          fi
+
+      - run: npm ci
+
+      - name: Bump versions in all packages
+        run: node scripts/prep-release.js "$VERSION"
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Commit version bumps
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Bump version to ${VERSION}"
+          git push origin HEAD:main
+          echo "RELEASE_TARGET=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Create draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          args=(
+            "${RELEASE_TAG}"
+            --draft
+            --target "${RELEASE_TARGET}"
+            --title "${RELEASE_TAG}"
+            --generate-notes
+          )
+
+          if [[ -n "${PREVIOUS_TAG}" ]]; then
+            args+=(--notes-start-tag "${PREVIOUS_TAG}")
+          fi
+
+          gh release create "${args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,15 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g. 3.15.12 or v3.15.12)'
-        required: true
-        type: string
+  release:
+    types: [published]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -17,11 +17,11 @@ jobs:
     environment: release
     permissions:
       id-token: write
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.release.tag_name }}
 
       - uses: actions/setup-node@v4
         with:
@@ -29,70 +29,43 @@ jobs:
 
       - run: npm install -g npm@latest
 
-      # ── Normalize version ──────────────────────────────────────────
-      - name: Normalize version
-        id: version
+      - name: Verify release version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          RAW="${{ github.event.inputs.version }}"
-          VERSION="${RAW#v}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version format: $VERSION (expected X.Y.Z)"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          version="${RELEASE_TAG#v}"
 
-      # ── Verify tag doesn't already exist ───────────────────────────
-      - name: Verify tag doesn't exist
-        run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.tag }}$"; then
-            echo "::error::Tag ${{ steps.version.outputs.tag }} already exists"
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: ${RELEASE_TAG} (expected vX.Y.Z)"
             exit 1
           fi
 
-      # ── Install dependencies ───────────────────────────────────────
+          package_version=$(node -p "require('./packages/alpinejs/package.json').version")
+
+          if [[ "${package_version}" != "${version}" ]]; then
+            echo "::error::Release tag ${RELEASE_TAG} does not match package version ${package_version}"
+            exit 1
+          fi
+
       - run: npm ci
 
-      # ── Bump versions ──────────────────────────────────────────────
-      - name: Bump versions in all packages
-        run: node scripts/prep-release.js ${{ steps.version.outputs.version }}
+      - name: Build packages
+        run: npm run build
 
-      # ── Commit and push version bumps ──────────────────────────────
-      - name: Commit version bumps
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "Bump version to ${{ steps.version.outputs.version }}"
-          git push
-
-      # ── Build ──────────────────────────────────────────────────────
-      - run: npm run build
-
-      # ── Create GitHub release ──────────────────────────────────────
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --target main \
-            --title "${{ steps.version.outputs.tag }}" \
-            --generate-notes
-
-      # ── Publish all packages to npm ────────────────────────────────
       - name: Publish all packages to npm
         run: |
-          FAILED=""
+          failed=""
+
           for pkg in alpinejs csp intersect collapse persist resize anchor morph focus sort mask ui docs; do
-            echo "Publishing $pkg..."
-            cd packages/$pkg
-            if ! npm publish --access public --provenance 2>&1; then
-              echo "::warning::Failed to publish $pkg"
-              FAILED="$FAILED $pkg"
+            echo "Publishing ${pkg}..."
+
+            if ! (cd "packages/${pkg}" && npm publish --access public --provenance); then
+              echo "::warning::Failed to publish ${pkg}"
+              failed="${failed} ${pkg}"
             fi
-            cd ../..
           done
-          if [ -n "$FAILED" ]; then
-            echo "::error::Failed to publish:$FAILED"
+
+          if [[ -n "${failed}" ]]; then
+            echo "::error::Failed to publish:${failed}"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- add a manual `Draft Release` workflow that bumps versions, builds packages, commits the version bump, and creates a draft GitHub release
- run the existing `Release` workflow only when that draft is published
- verify the published tag matches the package version before rebuilding and publishing packages to npm

## Why

This introduces an explicit review boundary so release notes and the prepared version can be checked before a tag is created or packages are published to npm.

## Validation

- `actionlint` on both workflows
- `git diff --check`
- clean `npm ci`
- full `npm run build`
