### PR TITLE
Use Node 24 for release workflows

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - run: npm install -g npm@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - run: npm install -g npm@latest
 


### PR DESCRIPTION
Fixes the Draft Release failure from run 31396299507.

`npm@latest` now installs npm 12, which requires Node 22.22.2+ or Node 24.15+. Both the draft and publish workflows now use Node 24 so the second workflow does not fail for the same reason after a draft is published.

Validation:
- both workflow YAML files parse successfully
- `git diff --check` passes