### PR TITLE
fix(persist): don't persist undefined values

### DIFF
--- a/packages/persist/src/index.js
+++ b/packages/persist/src/index.js
@@ -77,5 +77,15 @@ function storageGet(key, storage) {
 }
 
 function storageSet(key, value, storage) {
+    // Avoid persisting "undefined" values. JSON.stringify(undefined) returns
+    // undefined, which the storage API coerces into the string "undefined".
+    // On the next page load, JSON.parse("undefined") would throw and break
+    // the component that initialized that persisted value.
+    if (value === undefined) {
+        storage.removeItem?.(key)
+
+        return
+    }
+
     storage.setItem(key, JSON.stringify(value))
 }

--- a/tests/cypress/integration/plugins/persist.spec.js
+++ b/tests/cypress/integration/plugins/persist.spec.js
@@ -91,6 +91,52 @@ test('can persist boolean',
     },
 )
 
+test('does not persist undefined values',
+    [html`
+        <div x-data="{ foo: $persist('bar').as('no-undefined') }">
+            <button @click="foo = undefined"></button>
+            <span x-text="foo === undefined ? 'undefined' : foo"></span>
+        </div>
+    `],
+    ({ get, window }, reload) => {
+        get('span').should(haveText('bar'))
+        get('button').click()
+        get('span').should(haveText('undefined'))
+        window().then((win) => {
+            expect(win.localStorage.getItem('no-undefined')).to.equal(null)
+        })
+        reload()
+        get('span').should(haveText('bar'))
+    },
+)
+
+test('does not write undefined values to custom storage without removeItem',
+    [html`
+        <div x-data="{ foo: $persist('bar').as('custom-undefined').using(window.customStorage) }">
+            <button @click="foo = undefined"></button>
+            <span x-text="foo === undefined ? 'undefined' : foo"></span>
+        </div>
+    `, `
+        window.customStorage = {
+            values: {},
+            writes: {},
+            getItem(key) { return this.values[key] ?? null },
+            setItem(key, value) { this.values[key] = value; this.writes[key] = (this.writes[key] || 0) + 1 },
+        }
+    `],
+    ({ get, window }) => {
+        get('span').should(haveText('bar'))
+        window().then((win) => {
+            win.customStorage.writes['custom-undefined'] = 0
+        })
+        get('button').click()
+        get('span').should(haveText('undefined'))
+        window().then((win) => {
+            expect(win.customStorage.writes['custom-undefined']).to.equal(0)
+        })
+    },
+)
+
 test('can persist multiple components using the same property',
     [html`
         <div x-data="{ duplicate: $persist('foo') }">


### PR DESCRIPTION
## Problem

Fixes #4877

Setting a persisted value to `undefined` (via `delete foo` or `foo = undefined`) permanently breaks the component on the next page load:

1. `JSON.stringify(undefined)` returns JS `undefined` (not a string).
2. The Web Storage API coerces it into the literal string `"undefined"` before storing.
3. On the next load, `storageHas` sees the key exists and `storageGet` calls `JSON.parse("undefined")`, which throws a `SyntaxError`.
4. Component initialization aborts, and the poisoned key can only be recovered by manually clearing `localStorage`.

The read side was recently guarded against `undefined` (`c38a45f3`, `f96e3c8b`) but the write side was not.

## Fix

In `storageSet`, when the value is `undefined`, remove the key instead of writing it. `storage.removeItem?.()` keeps custom storages that don't implement `removeItem` working (write is skipped there too).

## Tests

Added two Cypress tests:

- `does not persist undefined values` — sets a persisted value to `undefined`, asserts the storage key is removed, and that reloading falls back to the initial value without crashing.
- `does not write undefined values to custom storage without removeItem` — covers storages without a `removeItem` implementation.

All 18 persist tests pass locally.