### PR TITLE
docs: clarify x-modelable value support

### DIFF
--- a/packages/docs/src/en/directives/modelable.md
+++ b/packages/docs/src/en/directives/modelable.md
@@ -5,7 +5,7 @@ title: modelable
 
 # x-modelable
 
-`x-modelable` allows you to expose any Alpine property as the target of the `x-model` directive.
+`x-modelable` allows you to expose Alpine state as the target of the `x-model` directive.
 
 Here's a simple example of using `x-modelable` to expose a variable for binding with `x-model`.
 
@@ -35,4 +35,26 @@ As you can see the outer scope property "number" is now bound to the inner scope
 
 Typically this feature would be used in conjunction with a backend templating framework like Laravel Blade. It's useful for abstracting away Alpine components into backend templates and exposing state to the outside through `x-model` as if it were a native input.
 
-> **Note:** `x-modelable` syncs values with a JSON clone (`JSON.parse(JSON.stringify(...))`). That only preserves JSON-serializable data: plain objects, arrays, strings, numbers, booleans, and `null`. Values such as `File`, `FileList`, `Map`, `Set`, `Date`, class instances, and DOM nodes are silently stripped or converted. For those, dispatch the value with [`$dispatch('input', value)`](/magics/dispatch#dispatching-to-x-model) instead — `x-model` picks up `event.detail` without cloning.
+## Supported values
+
+`x-modelable` keeps its inner and outer state independent by cloning values as JSON. It is therefore intended for JSON-compatible state such as strings, numbers, booleans, `null`, arrays, and plain objects containing those values.
+
+Browser objects and other state that cannot be represented as JSON won't cross this boundary intact. For example, a `File` loses properties such as its name, size, and type. The same limitation applies to values such as `FileList`, `Map`, `Set`, `Date`, class instances, and DOM nodes.
+
+For a custom input that produces one of these values, omit `x-modelable` and [dispatch an `input` event](/magics/dispatch#dispatching-to-x-model) instead. `x-model` reads the value directly from the event without cloning it:
+
+```alpine
+<div x-data="{ files: [] }">
+    <div x-model="files">
+        <input
+            type="file"
+            multiple
+            @change="$dispatch('input', Array.from($event.target.files))"
+        >
+    </div>
+
+    <template x-for="file in files" :key="file.name">
+        <p x-text="file.name"></p>
+    </template>
+</div>
+```

--- a/packages/docs/src/en/directives/modelable.md
+++ b/packages/docs/src/en/directives/modelable.md
@@ -34,3 +34,5 @@ Here's a simple example of using `x-modelable` to expose a variable for binding 
 As you can see the outer scope property "number" is now bound to the inner scope property "count".
 
 Typically this feature would be used in conjunction with a backend templating framework like Laravel Blade. It's useful for abstracting away Alpine components into backend templates and exposing state to the outside through `x-model` as if it were a native input.
+
+> **Note:** `x-modelable` syncs values with a JSON clone (`JSON.parse(JSON.stringify(...))`). That only preserves JSON-serializable data: plain objects, arrays, strings, numbers, booleans, and `null`. Values such as `File`, `FileList`, `Map`, `Set`, `Date`, class instances, and DOM nodes are silently stripped or converted. For those, dispatch the value with [`$dispatch('input', value)`](/magics/dispatch#dispatching-to-x-model) instead — `x-model` picks up `event.detail` without cloning.


### PR DESCRIPTION
## What

Clarify that `x-modelable` is intended for JSON-compatible state and explain what happens when browser objects or other non-JSON values cross its cloning boundary.

Add a complete file-input example showing the supported alternative: omit `x-modelable`, keep plain `x-model` on the custom input's root, and dispatch a bubbling `input` event carrying the original value.

Related to #4873.

## Why

The previous docs described `x-modelable` as accepting any Alpine property, even though values such as `File`, `FileList`, `Map`, `Set`, and class instances do not survive its JSON clone intact.

Simply linking to `$dispatch('input', value)` was incomplete because `x-modelable` deliberately removes `x-model`'s normal input listener. The new example makes it explicit that the event-driven approach replaces `x-modelable` for these values.

## Test plan

- [x] Run `npm run build`
- [x] Run the focused `x-modelable` Cypress spec (8 passing)
- [x] Confirm the dispatch documentation link resolves to the `x-model` section
- [x] Confirm the example omits `x-modelable` and passes the original `File` objects through `event.detail`
