### PR TITLE
Fix Unicode escapes in CSP string literals

### DIFF
--- a/packages/csp/src/parser.js
+++ b/packages/csp/src/parser.js
@@ -139,6 +139,18 @@ class Tokenizer {
                     case 'r': value += '\r'; break;
                     case '\\': value += '\\'; break;
                     case quote: value += quote; break;
+                    case 'u': {
+                        const codeUnit = this.input.slice(this.position + 1, this.position + 5);
+
+                        if (/^[0-9a-fA-F]{4}$/.test(codeUnit)) {
+                            value += String.fromCharCode(parseInt(codeUnit, 16));
+                            this.position += 4;
+                        } else {
+                            value += char;
+                        }
+
+                        break;
+                    }
                     default: value += char;
                 }
                 escaped = false;

--- a/tests/vitest/csp-parser.spec.js
+++ b/tests/vitest/csp-parser.spec.js
@@ -16,6 +16,7 @@ describe('CSP Parser', () => {
             expect(generateRuntimeFunction("'world'")()).toBe('world');
             expect(generateRuntimeFunction('"escaped \\"quotes\\""')()).toBe('escaped "quotes"');
             expect(generateRuntimeFunction("'mixed \"quotes\"'")()).toBe('mixed "quotes"');
+            expect(generateRuntimeFunction("'tes\\u0027t'")()).toBe("tes't");
         });
 
         it('should parse booleans', () => {


### PR DESCRIPTION
Fixes #4879.

The CSP tokenizer now decodes four-digit Unicode escapes inside string literals. This makes escaped values such as `tes\\u0027t` match the regular Alpine build while preserving the existing handling for other escapes.

Added a parser regression assertion for the escaped apostrophe case reported in the issue.

Testing:

- `npx vitest run tests/vitest/csp-parser.spec.js` (100 tests passed)
- `node --check packages/csp/src/parser.js`
