### PR TITLE
Add dwell timing to the intersect plugin

### DIFF
--- a/packages/docs/src/en/plugins/intersect.md
+++ b/packages/docs/src/en/plugins/intersect.md
@@ -110,6 +110,35 @@ Sometimes it's useful to evaluate an expression only the first time an element e
 <div x-intersect.once="shown = true">...</div>
 ```
 
+<a name="dwell"></a>
+### .dwell
+
+Sometimes an element should remain in view for a short period before the expression evaluates. The `.dwell` modifier waits for 250 milliseconds of continuous intersection by default:
+
+```alpine
+<div x-intersect.dwell="viewed = true">...</div>
+```
+
+Append a duration to customize the wait:
+
+```alpine
+<div x-intersect.half.dwell.500ms="viewed = true">...</div>
+```
+
+Here the expression evaluates only after at least half of the element remains visible for 500 milliseconds. Leaving that threshold or hiding the page cancels the pending wait. The full duration must elapse again after the threshold is restored or the page becomes visible.
+
+With `x-intersect:leave`, the duration instead begins when visibility falls below the configured threshold:
+
+```alpine
+<div x-intersect:leave.half.dwell.500ms="viewed = false">...</div>
+```
+
+Combine `.dwell` with `.once` when the expression should evaluate only after the first completed interval:
+
+```alpine
+<div x-intersect.half.dwell.500ms.once="viewed = true">...</div>
+```
+
 <a name="half"></a>
 ### .half
 

--- a/packages/intersect/src/index.js
+++ b/packages/intersect/src/index.js
@@ -1,11 +1,18 @@
 export default function (Alpine) {
     Alpine.directive('intersect', Alpine.skipDuringClone((el, { value, expression, modifiers }, { evaluateLater, cleanup }) => {
         let evaluate = evaluateLater(expression)
+        let threshold = getThreshold(modifiers)
 
         let options = {
             rootMargin: getRootMargin(modifiers),
-            threshold: getThreshold(modifiers),
+            threshold,
             root: modifiers.includes('parent') ? el.parentElement : null
+        }
+
+        if (modifiers.includes('dwell')) {
+            observeForDwell(el, value, modifiers, evaluate, cleanup, options, threshold)
+
+            return
         }
 
         let observer = new IntersectionObserver(entries => {
@@ -25,6 +32,132 @@ export default function (Alpine) {
             observer.disconnect()
         })
     }))
+}
+
+function observeForDwell(el, value, modifiers, evaluate, cleanup, options, threshold) {
+    let dwellTimeout
+    let lastEntry
+    let hasEvaluated = false
+    let isConfirmingDwell = false
+    let duration = getDwellDuration(modifiers)
+    let observer
+
+    let clearDwellTimeout = () => {
+        clearTimeout(dwellTimeout)
+        dwellTimeout = undefined
+    }
+
+    let completeDwell = () => {
+        isConfirmingDwell = false
+
+        if (! lastEntry || document.hidden || ! meetsDwellThreshold(lastEntry, value, threshold)) return
+
+        hasEvaluated = true
+
+        evaluate()
+
+        if (modifiers.includes('once')) {
+            observer.disconnect()
+            document.removeEventListener('visibilitychange', handleVisibilityChange)
+        }
+    }
+
+    let observe = () => {
+        observer && observer.disconnect()
+
+        observer = new IntersectionObserver(handleEntries, options)
+        observer.observe(el)
+    }
+
+    let confirmDwell = () => {
+        dwellTimeout = undefined
+
+        if (document.hidden) return
+
+        let pendingEntries = observer.takeRecords()
+
+        if (pendingEntries.some(entry => ! meetsDwellThreshold(entry, value, threshold))) {
+            handleEntries(pendingEntries)
+
+            return
+        }
+
+        isConfirmingDwell = true
+        lastEntry = undefined
+
+        observe()
+    }
+
+    let beginDwell = () => {
+        if (dwellTimeout !== undefined || hasEvaluated || document.hidden || ! lastEntry) return
+        if (! meetsDwellThreshold(lastEntry, value, threshold)) return
+
+        dwellTimeout = setTimeout(confirmDwell, duration)
+    }
+
+    let handleEntries = entries => {
+        entries.forEach(entry => {
+            lastEntry = entry
+
+            if (! meetsDwellThreshold(entry, value, threshold)) {
+                clearDwellTimeout()
+
+                hasEvaluated = false
+                isConfirmingDwell = false
+
+                return
+            }
+
+            if (isConfirmingDwell) {
+                completeDwell()
+
+                return
+            }
+
+            beginDwell()
+        })
+    }
+
+    let handleVisibilityChange = () => {
+        if (document.hidden) {
+            clearDwellTimeout()
+
+            lastEntry = undefined
+            hasEvaluated = false
+            isConfirmingDwell = false
+
+            observer.disconnect()
+
+            return
+        }
+
+        observe()
+    }
+
+    observe()
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    cleanup(() => {
+        clearDwellTimeout()
+        observer.disconnect()
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+    })
+}
+
+function meetsDwellThreshold(entry, value, threshold) {
+    let meetsThreshold = threshold === 0
+        ? entry.isIntersecting
+        : entry.isIntersecting && entry.intersectionRatio >= threshold
+
+    return value === 'leave' ? ! meetsThreshold : meetsThreshold
+}
+
+function getDwellDuration(modifiers) {
+    let rawDuration = modifiers[modifiers.indexOf('dwell') + 1] || ''
+    let match = rawDuration.match(/^([0-9]+)(ms)?$/)
+
+    return match ? Number(match[1]) : 250
 }
 
 function getThreshold(modifiers) {

--- a/tests/cypress/integration/plugins/intersect.spec.js
+++ b/tests/cypress/integration/plugins/intersect.spec.js
@@ -1,5 +1,50 @@
 import { haveText, test, html } from '../../utils'
 
+let controllableIntersectionObserver = `
+    window.intersectionEntry = { isIntersecting: true, intersectionRatio: 0.5 }
+    window.intersectionObservers = []
+
+    window.IntersectionObserver = class {
+        constructor(callback) {
+            this.callback = callback
+            this.connected = false
+            this.records = []
+
+            window.intersectionObservers.push(this)
+        }
+
+        observe() {
+            this.connected = true
+
+            queueMicrotask(() => {
+                if (this.connected) this.callback([window.intersectionEntry])
+            })
+        }
+
+        disconnect() {
+            this.connected = false
+        }
+
+        takeRecords() {
+            let records = this.records
+
+            this.records = []
+
+            return records
+        }
+
+        notify(entry) {
+            window.intersectionEntry = entry
+            this.callback([entry])
+        }
+
+        queue(entry) {
+            window.intersectionEntry = entry
+            this.records.push(entry)
+        }
+    }
+`
+
 test('can intersect',
     [html`
     <div x-data="{ count: 0 }">
@@ -197,5 +242,159 @@ test('.parent observes the element relative to its parent, not the viewport',
         // container itself is well below the browser's viewport.
         get('#container').scrollTo(0, 250, {duration: 100})
         get('span').should(haveText('1'))
+    },
+)
+
+test('.dwell evaluates after the threshold remains continuously satisfied',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div id="container" style="height: 200px; overflow-y: scroll;">
+            <div style="height: 200px;">spacer</div>
+            <div style="height: 200px" x-intersect.half.dwell.100ms="count++">content</div>
+        </div>
+    </div>
+    `],
+    ({ get }) => {
+        get('#container').scrollTo(0, 100, {duration: 0})
+        get('#container').wait(50).scrollTo(0, 0, {duration: 0})
+        get('span').wait(100).should(haveText('0'))
+        get('#container').scrollTo(0, 100, {duration: 0})
+        get('span').wait(150).should(haveText('1'))
+    },
+)
+
+test('.dwell waits for 250 milliseconds by default',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+        <div x-intersect.dwell="count++">content</div>
+    </div>
+    `, controllableIntersectionObserver],
+    ({ get }) => {
+        get('span').wait(200).should(haveText('0'))
+        get('span').wait(100).should(haveText('1'))
+    },
+)
+
+test('.dwell reconciles queued threshold changes before evaluating',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+        <div x-intersect.half.dwell.200ms="count++">content</div>
+    </div>
+    `, controllableIntersectionObserver],
+    ({ get }, reload, window) => {
+        get('span').wait(100).then(() => {
+            window.intersectionObservers[0].queue({ isIntersecting: true, intersectionRatio: 0.49 })
+        })
+        get('span').wait(150).should(haveText('0'))
+    },
+)
+
+test('.dwell evaluates again after leaving and re-entering',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div id="container" style="height: 200px; overflow-y: scroll;">
+            <div style="height: 200px;">spacer</div>
+            <div style="height: 200px" x-intersect.half.dwell.100ms="count++">content</div>
+        </div>
+    </div>
+    `],
+    ({ get }) => {
+        get('#container').scrollTo(0, 100, {duration: 0})
+        get('span').wait(150).should(haveText('1'))
+        get('#container').scrollTo(0, 0, {duration: 0})
+        get('#container').wait(50).scrollTo(0, 100, {duration: 0})
+        get('span').wait(150).should(haveText('2'))
+    },
+)
+
+test('.dwell and .once evaluate only once',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div id="container" style="height: 200px; overflow-y: scroll;">
+            <div style="height: 200px;">spacer</div>
+            <div style="height: 200px" x-intersect.half.dwell.100ms.once="count++">content</div>
+        </div>
+    </div>
+    `],
+    ({ get }) => {
+        get('#container').scrollTo(0, 100, {duration: 0})
+        get('span').wait(150).should(haveText('1'))
+        get('#container').scrollTo(0, 0, {duration: 0})
+        get('#container').wait(50).scrollTo(0, 100, {duration: 0})
+        get('span').wait(150).should(haveText('1'))
+    },
+)
+
+test(':leave.dwell uses the configured threshold',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div id="container" style="height: 200px; overflow-y: scroll;">
+            <div style="height: 200px" x-intersect:leave.half.dwell.100ms="count++">content</div>
+            <div style="height: 200px;">spacer</div>
+        </div>
+    </div>
+    `],
+    ({ get }) => {
+        get('span').should(haveText('0'))
+        get('#container').scrollTo(0, 110, {duration: 0})
+        get('span').wait(150).should(haveText('1'))
+    },
+)
+
+test('.dwell restarts when the page becomes visible',
+    [html`
+    <div x-data="{ count: 0 }">
+        <span x-text="count"></span>
+
+        <div x-intersect.half.dwell.100ms="count++">content</div>
+    </div>
+    `, controllableIntersectionObserver],
+    ({ get }, reload, window, document) => {
+        get('span').wait(50).then(() => {
+            Object.defineProperty(document, 'hidden', { configurable: true, value: true })
+            document.dispatchEvent(new Event('visibilitychange'))
+
+            window.intersectionEntry = { isIntersecting: true, intersectionRatio: 0.49 }
+
+            Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+            document.dispatchEvent(new Event('visibilitychange'))
+        })
+        get('span').wait(150).should(haveText('0'))
+        get('span').then(() => {
+            window.intersectionObservers[window.intersectionObservers.length - 1]
+                .notify({ isIntersecting: true, intersectionRatio: 0.5 })
+        })
+        get('span').wait(150).should(haveText('1'))
+    },
+)
+
+test('.dwell cancels when the element is removed',
+    [html`
+    <div x-data="{ count: 0, show: true }">
+        <span x-text="count"></span>
+        <button id="remove" @click="show = false">remove</button>
+
+        <div id="container" style="height: 200px; overflow-y: scroll;">
+            <div style="height: 200px;">spacer</div>
+            <template x-if="show">
+                <div style="height: 200px" x-intersect.half.dwell.100ms="count++">content</div>
+            </template>
+        </div>
+    </div>
+    `],
+    ({ get }) => {
+        get('#container').scrollTo(0, 100, {duration: 0})
+        get('#remove').wait(50).click()
+        get('span').wait(100).should(haveText('0'))
     },
 )


### PR DESCRIPTION
## Problem

`x-intersect` evaluates as soon as an element crosses its configured threshold. View qualification and similar interactions sometimes need the threshold state to remain continuous for a short interval, which currently requires each application to maintain its own observer, timer, page-visibility, and cleanup logic.

## Approach

Add a `.dwell` modifier to the intersect plugin:

```html
<div x-intersect.half.dwell.500ms.once="trackView()"></div>
```

- waits 250 milliseconds by default and accepts an adjacent millisecond duration
- composes with `.half`, `.full`, custom thresholds, margins, `.parent`, and `.once`
- treats `:leave` as continuously below the configured threshold
- cancels pending dwell when the threshold breaks or the page becomes hidden
- reconciles queued observations and requires a fresh observation before evaluating, so stale entries cannot complete a dwell
- leaves the existing non-dwell path unchanged

## Validation

- focused intersect Cypress spec: 17 passed
- complete Cypress suite passed in Chromium 151
- Vitest: 185 passed, 1 skipped
- production build passed
- standalone intersect CDN bundle: +1,058 minified bytes / +365 Brotli bytes
