### PR TITLE
Add a deferred tree initialization primitive

### DIFF
--- a/packages/alpinejs/src/alpine.js
+++ b/packages/alpinejs/src/alpine.js
@@ -1,6 +1,6 @@
 import { setReactivityEngine, disableEffectScheduling, reactive, effect, release, raw, watch, transaction } from './reactivity'
 import { mapAttributes, directive, setPrefix as prefix, prefix as prefixed } from './directives'
-import { start, addRootSelector, addInitSelector, closestRoot, findClosest, initTree, destroyTree, interceptInit } from './lifecycle'
+import { start, addRootSelector, addInitSelector, closestRoot, findClosest, initTree, destroyTree, interceptInit, deferInit } from './lifecycle'
 import { onElRemoved, onAttributeRemoved, onAttributesAdded, mutateDom, deferMutations, flushAndStopDeferringMutations, startObservingMutations, stopObservingMutations } from './mutation'
 import { mergeProxies, closestDataStack, addScopeToNode, scope as $data } from './scope'
 import { setEvaluator, setRawEvaluator, evaluate, evaluateLater, dontAutoEvaluateFunctions, evaluateRaw } from './evaluator'
@@ -48,6 +48,7 @@ let Alpine = {
     mapAttributes,
     evaluateLater,
     interceptInit,
+    deferInit,
     initInterceptors,
     injectMagics,
     setEvaluator,

--- a/packages/alpinejs/src/clone.js
+++ b/packages/alpinejs/src/clone.js
@@ -1,5 +1,5 @@
 import { effect, release, overrideEffect } from "./reactivity"
-import { initTree, isRoot } from "./lifecycle"
+import { initTree, isDeferringInit, isRoot } from "./lifecycle"
 import { walk } from "./utils/walk"
 
 export let isCloning = false
@@ -20,6 +20,8 @@ export function interceptClone(callback) {
 
 export function cloneNode(from, to)
 {
+    if (isDeferringInit(from)) return
+
     interceptors.forEach(i => i(from, to))
 
     isCloning = true
@@ -42,6 +44,8 @@ export let isCloningLegacy = false
 
 /** deprecated */
 export function clone(oldEl, newEl) {
+    if (isDeferringInit(oldEl)) return
+
     if (! newEl._x_dataStack) newEl._x_dataStack = oldEl._x_dataStack
 
     isCloning = true

--- a/packages/alpinejs/src/deferred-init.js
+++ b/packages/alpinejs/src/deferred-init.js
@@ -1,0 +1,17 @@
+let deferredInits = new WeakMap()
+
+export function getDeferredInit(el) {
+    return deferredInits.get(el)
+}
+
+export function hasDeferredInit(el) {
+    return deferredInits.has(el)
+}
+
+export function setDeferredInit(el, deferred) {
+    deferredInits.set(el, deferred)
+}
+
+export function deleteDeferredInit(el) {
+    deferredInits.delete(el)
+}

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -3,6 +3,8 @@ import { deferHandlingDirectives, directiveExists, directives } from "./directiv
 import { dispatch } from './utils/dispatch'
 import { walk } from "./utils/walk"
 import { warn } from './utils/warn'
+import { handleError } from './utils/error'
+import { deleteDeferredInit, getDeferredInit, hasDeferredInit, setDeferredInit } from './deferred-init'
 
 let started = false
 
@@ -22,6 +24,8 @@ export function start() {
     onElRemoved(el => destroyTree(el))
 
     onAttributesAdded((el, attrs) => {
+        if (queueDeferredAttributes(el, attrs)) return
+
         directives(el, attrs).forEach(handle => handle())
     })
 
@@ -85,20 +89,90 @@ let initInterceptors = []
 
 export function interceptInit(callback) { initInterceptors.push(callback) }
 
+let currentInitContext
+
+export function deferInit(el, promise) {
+    if (currentInitContext?.el === el) {
+        currentInitContext.promises.push(Promise.resolve(promise))
+
+        return
+    }
+
+    let deferred = getDeferredInit(el)
+
+    if (! deferred) {
+        deferred = createDeferredInit(el)
+
+        setDeferredInit(el, deferred)
+    }
+
+    addDeferredPromise(deferred, promise)
+}
+
+export function isDeferringInit(el) {
+    return !! findDeferredInit(el)
+}
+
 let markerDispenser = 1
 
-export function initTree(el, walker = walk, intercept = () => {}) {
+export function initTree(el, walker = walk, intercept = () => {}, resuming = null) {
     // Don't init a tree within a parent that is being ignored...
     if (findClosest(el, i => i._x_ignore)) return
+    if (isDeferringInit(el)) return
+
+    let root = el
 
     deferHandlingDirectives(() => {
         walker(el, (el, skip) => {
+            let resume = el === root ? resuming : null
+
             // If the element has a marker, it's already been initialized...
-            if (el._x_marker) return
+            if (el._x_marker) {
+                initializeDeferredAttributes(el, resuming)
 
-            intercept(el, skip)
+                return
+            }
 
-            initInterceptors.forEach(i => i(el, skip))
+            if (hasDeferredInit(el)) return skip()
+
+            let interceptors = resume?.interceptors || [intercept, ...initInterceptors]
+            let interceptorIndex = resume?.interceptorIndex || 0
+            let skipDescendants = resume?.skipDescendants || false
+
+            let skipAndRemember = () => {
+                skipDescendants = true
+
+                skip()
+            }
+
+            for (; interceptorIndex < interceptors.length; interceptorIndex++) {
+                let context = { el, promises: [] }
+                let previousContext = currentInitContext
+
+                currentInitContext = context
+
+                try {
+                    interceptors[interceptorIndex](el, skipAndRemember)
+                } finally {
+                    currentInitContext = previousContext
+                }
+
+                if (context.promises.length) {
+                    let deferred = createDeferredInit(el, {
+                        walker,
+                        intercept,
+                        interceptors,
+                        interceptorIndex: interceptorIndex + 1,
+                        skipDescendants,
+                    })
+
+                    setDeferredInit(el, deferred)
+                    context.promises.forEach(promise => addDeferredPromise(deferred, promise))
+                    skip()
+
+                    return
+                }
+            }
 
             directives(el, el.attributes).forEach(handle => handle())
 
@@ -107,13 +181,86 @@ export function initTree(el, walker = walk, intercept = () => {}) {
             // elements that are moved around on the page.
             if (!el._x_ignore) el._x_marker = markerDispenser++
 
-            el._x_ignore && skip()
+            if (el._x_ignore || skipDescendants) skip()
         })
     })
 }
 
+function createDeferredInit(el, resume = {}) {
+    return {
+        el,
+        pending: 0,
+        attributes: new Map(),
+        walker: resume.walker || walk,
+        intercept: resume.intercept || (() => {}),
+        interceptors: resume.interceptors,
+        interceptorIndex: resume.interceptorIndex,
+        skipDescendants: resume.skipDescendants,
+    }
+}
+
+function addDeferredPromise(deferred, promise) {
+    deferred.pending++
+
+    Promise.resolve(promise).then(
+        () => settleDeferredInit(deferred),
+        error => {
+            try {
+                handleError(error, deferred.el)
+            } finally {
+                settleDeferredInit(deferred)
+            }
+        },
+    )
+}
+
+function settleDeferredInit(deferred) {
+    deferred.pending--
+
+    if (deferred.pending > 0) return
+    if (getDeferredInit(deferred.el) !== deferred) return
+
+    deleteDeferredInit(deferred.el)
+
+    if (! deferred.el.isConnected) return
+
+    initTree(deferred.el, deferred.walker, deferred.intercept, deferred)
+}
+
+function findDeferredInit(el) {
+    let root = findClosest(el, element => hasDeferredInit(element))
+
+    return root ? getDeferredInit(root) : undefined
+}
+
+function queueDeferredAttributes(el, attrs) {
+    let deferred = findDeferredInit(el)
+
+    if (! deferred) return false
+
+    let attributes = deferred.attributes.get(el) || new Set()
+
+    attrs.forEach(attribute => attributes.add(attribute.name))
+    deferred.attributes.set(el, attributes)
+
+    return true
+}
+
+function initializeDeferredAttributes(el, deferred) {
+    let attributeNames = deferred?.attributes.get(el)
+
+    if (! attributeNames) return
+
+    let attributes = Array.from(attributeNames)
+        .filter(name => el.hasAttribute(name))
+        .map(name => ({ name, value: el.getAttribute(name) }))
+
+    directives(el, attributes).forEach(handle => handle())
+}
+
 export function destroyTree(root, walker = walk) {
     walker(root, el => {
+        deleteDeferredInit(el)
         cleanupElement(el)
         cleanupAttributes(el)
         delete el._x_marker

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -1,4 +1,5 @@
 import { dequeueJob } from "./scheduler";
+import { hasDeferredInit } from './deferred-init'
 let onAttributeAddeds = []
 let onElRemoveds = []
 let onElAddeds = []
@@ -131,7 +132,7 @@ function onMutate(mutations) {
                 if (node.nodeType !== 1) return
 
                 // No need to process removed nodes that haven't been initialized by Alpine...
-                if (! node._x_marker) return
+                if (! node._x_marker && ! hasDeferredInit(node)) return
 
                 removedNodes.add(node)
             })

--- a/packages/docs/src/en/advanced/extending.md
+++ b/packages/docs/src/en/advanced/extending.md
@@ -61,6 +61,23 @@ window.Alpine = Alpine
 window.Alpine.start()
 ```
 
+<a name="deferring-initialization"></a>
+### Deferring initialization
+
+An extension that needs to load something before Alpine initializes a tree can defer that tree from an initialization interceptor:
+
+```js
+Alpine.interceptInit((el) => {
+    if (! el.hasAttribute('x-needs-library')) return
+
+    Alpine.deferInit(el, import('./library.js'))
+})
+```
+
+`Alpine.deferInit()` must be called synchronously from the interceptor. Alpine will leave the element and its descendants uninitialized until every deferred promise settles, then continue from the next interceptor without re-running earlier ones. Rejected promises are passed to Alpine's error handler before initialization continues.
+
+Other trees continue initializing normally, and the global `alpine:initialized` event remains synchronous: it may fire before a deferred tree has resumed.
+
 Now that we know where to use these extension APIs, let's look more closely at how to use each one:
 
 <a name="custom-directives"></a>

--- a/tests/cypress/integration/deferred-init.spec.js
+++ b/tests/cypress/integration/deferred-init.spec.js
@@ -1,0 +1,256 @@
+import { haveText, html, test } from '../utils'
+
+test('can defer initialization and resume without running the interceptor twice',
+    [html`
+        <button id="resolve" x-data @click="window.resolveInit()">Resolve</button>
+
+        <div id="target" x-data="{ count: 0 }" x-init="count++">
+            <button id="increment" @click="count++">Increment</button>
+            <span x-text="count"></span>
+        </div>
+    `,
+    `
+        window.initRuns = 0
+        window.initPromise = new Promise(resolve => window.resolveInit = resolve)
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            window.initRuns++
+            Alpine.deferInit(el, window.initPromise)
+        })
+    `],
+    ({ get }) => {
+        get('#target span').should(haveText(''))
+        get('#resolve').click()
+        get('#target span').should(haveText('1'))
+        get('#increment').click()
+        get('#target span').should(haveText('2'))
+        cy.window().its('initRuns').should('equal', 1)
+    }
+)
+
+test('resumes each deferred interceptor in order',
+    [html`
+        <button id="resolve-one" x-data @click="window.resolveOne()">Resolve one</button>
+        <button id="resolve-two" x-data @click="window.resolveTwo()">Resolve two</button>
+
+        <div id="target" x-data x-init="window.initSteps.push('directive')"></div>
+    `,
+    `
+        window.initSteps = []
+        window.promiseOne = new Promise(resolve => window.resolveOne = resolve)
+        window.promiseTwo = new Promise(resolve => window.resolveTwo = resolve)
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            window.initSteps.push('one')
+            Alpine.deferInit(el, window.promiseOne)
+        })
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            window.initSteps.push('two')
+            Alpine.deferInit(el, window.promiseTwo)
+        })
+    `],
+    ({ get }) => {
+        cy.window().its('initSteps').should('deep.equal', ['one'])
+        get('#resolve-one').click()
+        cy.window().its('initSteps').should('deep.equal', ['one', 'two'])
+        get('#resolve-two').click()
+        cy.window().its('initSteps').should('deep.equal', ['one', 'two', 'directive'])
+    }
+)
+
+test('waits for every promise deferred by one interceptor',
+    [html`
+        <button id="resolve-one" x-data @click="window.resolveOne()">Resolve one</button>
+        <button id="resolve-two" x-data @click="window.resolveTwo()">Resolve two</button>
+
+        <div id="target" x-data="{ status: 'ready' }">
+            <span x-text="status"></span>
+        </div>
+    `,
+    `
+        window.promiseOne = new Promise(resolve => window.resolveOne = resolve)
+        window.promiseTwo = new Promise(resolve => window.resolveTwo = resolve)
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            Alpine.deferInit(el, window.promiseOne)
+            Alpine.deferInit(el, window.promiseTwo)
+        })
+    `],
+    ({ get }) => {
+        get('#target span').should(haveText(''))
+        get('#resolve-one').click()
+        get('#target span').should(haveText(''))
+        get('#resolve-two').click()
+        get('#target span').should(haveText('ready'))
+    }
+)
+
+test('a nested deferred tree does not block its parent or siblings',
+    [html`
+        <button id="resolve-child" x-data @click="window.resolveChild()">Resolve child</button>
+
+        <div id="parent" x-data="{ message: 'ready' }">
+            <span id="sibling" x-text="message"></span>
+            <span id="child" x-data x-init="window.childInitialized = true">Waiting</span>
+        </div>
+    `,
+    `
+        window.childInitialized = false
+        window.childPromise = new Promise(resolve => window.resolveChild = resolve)
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'child') return
+
+            Alpine.deferInit(el, window.childPromise)
+        })
+    `],
+    ({ get }) => {
+        get('#sibling').should(haveText('ready'))
+        cy.window().its('childInitialized').should('equal', false)
+        get('#resolve-child').click()
+        cy.window().its('childInitialized').should('equal', true)
+    }
+)
+
+test('queues directive and element initialization inside an existing deferred tree',
+    html`
+        <div id="target" x-data="{ message: 'loaded' }">
+            <span id="changed"></span>
+            <div id="children"></div>
+        </div>
+    `,
+    ({ get }, reload, window, document) => {
+        window.existingInitPromise = new Promise(resolve => window.resolveExistingInit = resolve)
+        window.Alpine.deferInit(document.querySelector('#target'), window.existingInitPromise)
+
+        document.querySelector('#changed').setAttribute('x-text', 'message')
+
+        let added = document.createElement('span')
+        added.id = 'added'
+        added.setAttribute('x-text', 'message')
+        document.querySelector('#children').appendChild(added)
+
+        get('#changed').should(haveText(''))
+        get('#added').should(haveText(''))
+
+        cy.then(() => window.resolveExistingInit())
+
+        get('#changed').should(haveText('loaded'))
+        get('#added').should(haveText('loaded'))
+    }
+)
+
+test('does not clone a tree while its source is deferred',
+    [html`
+        <div id="target" x-data x-init="window.cloneInitRuns++"></div>
+    `,
+    `
+        window.cloneInitRuns = 0
+        window.cloneInterceptorRuns = []
+
+        Alpine.interceptClone((from, to) => window.cloneInterceptorRuns.push(to.id))
+    `],
+    ({ get }, reload, window, document) => {
+        window.clonePromise = new Promise(resolve => window.resolveClone = resolve)
+
+        let target = document.querySelector('#target')
+        let clone = target.cloneNode(true)
+        let legacyClone = target.cloneNode(true)
+
+        clone.id = 'clone'
+        legacyClone.id = 'legacy-clone'
+        window.cloneInterceptorRuns = []
+        window.Alpine.deferInit(target, window.clonePromise)
+        window.Alpine.cloneNode(target, clone)
+        window.Alpine.clone(target, legacyClone)
+
+        cy.window().its('cloneInitRuns').should('equal', 1)
+        cy.window().its('cloneInterceptorRuns').should('deep.equal', [])
+        cy.then(() => {
+            expect(clone).not.to.have.property('_x_marker')
+            expect(legacyClone).not.to.have.property('_x_marker')
+        })
+        cy.then(() => window.resolveClone())
+        cy.window().its('cloneInitRuns').should('equal', 1)
+    }
+)
+
+test('reports a rejected deferral and still releases initialization',
+    [html`
+        <button id="reject" x-data @click="window.rejectInit(new Error('failed to load'))">Reject</button>
+
+        <div id="target" x-data="{ status: 'ready' }">
+            <span x-text="status"></span>
+        </div>
+    `,
+    `
+        window.rejectedInitPromise = new Promise((resolve, reject) => window.rejectInit = reject)
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            Alpine.deferInit(el, window.rejectedInitPromise)
+        })
+    `],
+    ({ get }) => {
+        get('#target span').should(haveText(''))
+        get('#reject').click()
+        get('#target span').should(haveText('ready'))
+    },
+    true,
+)
+
+test('does not initialize a deferred tree removed before settlement',
+    [html`
+        <div id="target" x-data x-init="window.detachedInitRuns++"></div>
+    `,
+    `
+        window.detachedInitRuns = 0
+        window.detachedInitPromise = new Promise(resolve => window.resolveDetachedInit = resolve)
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            Alpine.deferInit(el, window.detachedInitPromise)
+        })
+    `],
+    ({ get }, reload, window, document) => {
+        document.querySelector('#target').remove()
+        window.resolveDetachedInit()
+
+        cy.window().its('detachedInitRuns').should('equal', 0)
+    }
+)
+
+test('alpine:initialized remains synchronous while a tree is deferred',
+    [html`
+        <div id="target" x-data x-init="window.initSteps.push('directive')"></div>
+    `,
+    `
+        window.initSteps = []
+        window.initializedPromise = new Promise(resolve => window.resolveInitialized = resolve)
+
+        document.addEventListener('alpine:initialized', () => window.initSteps.push('initialized'))
+
+        Alpine.interceptInit((el) => {
+            if (el.id !== 'target') return
+
+            window.initSteps.push('interceptor')
+            Alpine.deferInit(el, window.initializedPromise)
+        })
+    `],
+    ({ get }) => {
+        cy.window().its('initSteps').should('deep.equal', ['interceptor', 'initialized'])
+        cy.window().then(window => window.resolveInitialized())
+        cy.window().its('initSteps').should('deep.equal', ['interceptor', 'initialized', 'directive'])
+    }
+)


### PR DESCRIPTION
## Problem

- **What users experience:** Framework extensions that load component-scoped JavaScript asynchronously can lose a race with Alpine. Alpine initializes the component tree first, so directives fail because the data, magics, or actions supplied by that JavaScript do not exist yet.
- **What users expected:** A component tree should initialize only after its declared prerequisite is ready, while unrelated Alpine trees continue normally.
- **Why reality differs:** Alpine initialization is synchronous and currently has no supported per-tree suspension point. Integrations therefore have to manipulate private ignore/marker state and manually re-run initialization, which can double-initialize directives or miss DOM lifecycle cases.

## Solution

- [Level 1: deferred initialization primitive](https://github.com/alpinejs/alpine/commit/4f31253a) — adds `Alpine.deferInit(el, promise)` and resumes from the exact interceptor continuation instead of restarting `initTree()`.
- [Level 2: DOM lifecycle hardening](https://github.com/alpinejs/alpine/commit/ede8db83) — handles multiple/nested boundaries, deferred mutations, cloning, removal, rejection, and synchronous global lifecycle timing with browser coverage.
- [Level 3: documented contract](https://github.com/alpinejs/alpine/commit/ea7c770b) — documents synchronous registration, settlement/rejection behavior, tree isolation, and `alpine:initialized` timing.

The public contract stays deliberately small: an init interceptor synchronously registers one or more promises for an element. Alpine pauses only that tree, reports rejected promises through its error handler, and continues initialization after every promise settles.

## Verification

- `npm run build`
- Focused Cypress coverage: deferred initialization, clone, mutation, and `x-ignore` (27 passing)
- The Level 1 commit also builds independently.
