### PR TITLE
Add Alpine.deferInit() — suspend a tree until an async prerequisite settles

### DIFF
--- a/packages/alpinejs/src/alpine.js
+++ b/packages/alpinejs/src/alpine.js
@@ -2,6 +2,7 @@ import { setReactivityEngine, disableEffectScheduling, reactive, effect, release
 import { mapAttributes, directive, setPrefix as prefix, prefix as prefixed } from './directives'
 import { start, addRootSelector, addInitSelector, closestRoot, findClosest, initTree, destroyTree, interceptInit } from './lifecycle'
 import { onElRemoved, onAttributeRemoved, onAttributesAdded, mutateDom, deferMutations, flushAndStopDeferringMutations, startObservingMutations, stopObservingMutations } from './mutation'
+import { deferInit } from './deferInit'
 import { mergeProxies, closestDataStack, addScopeToNode, scope as $data } from './scope'
 import { setEvaluator, setRawEvaluator, evaluate, evaluateLater, dontAutoEvaluateFunctions, evaluateRaw } from './evaluator'
 import { transition } from './directives/x-transition'
@@ -62,6 +63,7 @@ let Alpine = {
     transition, // INTERNAL
     setStyles, // INTERNAL
     mutateDom,
+    deferInit,
     directive,
     entangle,
     throttle,

--- a/packages/alpinejs/src/deferInit.js
+++ b/packages/alpinejs/src/deferInit.js
@@ -1,0 +1,154 @@
+import { findClosest, initTree } from './lifecycle'
+import { flushPendingMutations } from './mutation'
+import { handleError } from './utils/error'
+import { directives } from './directives'
+import { interceptClone } from './clone'
+
+// A tree can be suspended while an asynchronous prerequisite loads — a script
+// module that registers Alpine.data() providers, for example. While suspended,
+// nothing inside the tree initializes: directives don't evaluate, added nodes
+// wait, and attribute changes are held for later. When every registered
+// promise has settled, the tree initializes in place.
+let activeDefers = 0
+
+export function deferInit(el, promise) {
+    let record = el._x_deferInit
+
+    if (! record) {
+        record = el._x_deferInit = {
+            pending: 0,
+            ownsIgnore: ! el._x_ignore,
+            queuedAttributes: new Map,
+        }
+
+        // Suspension rides on the ignore flag so every existing guard — the
+        // walker, directive handlers, added-node initialization — already
+        // respects the boundary. If something else set the flag first, it
+        // owns the tree and we leave the flag alone when we're done...
+        if (record.ownsIgnore) el._x_ignore = true
+
+        activeDefers++
+    }
+
+    record.pending++
+
+    Promise.resolve(promise).catch(error => {
+        // A rejected prerequisite must not leave the tree suspended forever.
+        // Surface the error, then initialize anyway. The handler itself may
+        // throw (custom error handlers can) — rethrow out of band so the
+        // settle below still runs...
+        try {
+            handleError(error, el)
+        } catch (error) {
+            setTimeout(() => { throw error }, 0)
+        }
+    }).then(() => settle(el, record))
+}
+
+function settle(el, record) {
+    record.pending--
+
+    if (record.pending > 0) return
+
+    // Deliver any mutations the observer is still holding while the tree is
+    // still suspended, so pending attribute changes land in the queue below
+    // instead of firing against a half-ready tree...
+    flushPendingMutations()
+
+    // Handlers that ran during that flush may have registered a new
+    // prerequisite on this same element — its chain will settle later...
+    if (record.pending > 0) return
+
+    // ...and if the suspension was already torn down (or replaced) by the
+    // time this chain ran, there's nothing left for it to do...
+    if (el._x_deferInit !== record) return
+
+    delete el._x_deferInit
+
+    if (record.ownsIgnore) delete el._x_ignore
+
+    activeDefers--
+
+    // The element left the DOM while it was suspended. If it re-enters later,
+    // the mutation observer will initialize it like any other added node...
+    if (! el.isConnected) return
+
+    replayQueuedAttributes(record)
+
+    initTree(el)
+}
+
+// While a tree is suspended, Alpine's attributes-added handler routes the
+// mutation here instead of evaluating directives against a tree that isn't
+// ready. Everything queued is replayed when the tree resumes...
+export function queueAttributesForDeferredTree(el, attrs) {
+    if (activeDefers === 0) return false
+
+    let root = findClosest(el, i => i._x_deferInit)
+
+    if (! root) return false
+
+    queueInto(root._x_deferInit, el, attrs.map(({ name }) => name))
+
+    return true
+}
+
+function queueInto(record, el, names) {
+    let entry = record.queuedAttributes.get(el)
+
+    // The marker pins the entry to this incarnation of the element. If the
+    // element is destroyed and re-initialized before the replay (it moved out
+    // of the suspended tree, say), the fresh initialization already applied
+    // its attributes and a stale entry must not apply them again...
+    if (! entry || entry.marker !== el._x_marker) {
+        entry = { marker: el._x_marker, names: new Set }
+
+        record.queuedAttributes.set(el, entry)
+    }
+
+    names.forEach(name => entry.names.add(name))
+}
+
+function replayQueuedAttributes(record) {
+    record.queuedAttributes.forEach((entry, el) => {
+        if (! el.isConnected) return
+
+        // Elements without a marker are picked up by the tree walk that
+        // follows — replaying here would process their attributes twice...
+        if (! el._x_marker) return
+
+        // A different marker means the element was re-initialized since the
+        // attributes were queued, which already applied them...
+        if (el._x_marker !== entry.marker) return
+
+        // If an enclosing tree is still suspended, this isn't the moment to
+        // evaluate anything — hand the entry over so it replays when that
+        // tree resumes...
+        let suspendedAncestor = findClosest(el, i => i._x_deferInit)
+
+        if (suspendedAncestor) {
+            queueInto(suspendedAncestor._x_deferInit, el, Array.from(entry.names))
+
+            return
+        }
+
+        let attrs = Array.from(entry.names)
+            .filter(name => el.hasAttribute(name))
+            .map(name => ({ name, value: el.getAttribute(name) }))
+
+        if (attrs.length === 0) return
+
+        directives(el, attrs).forEach(handle => handle())
+    })
+}
+
+// Morphing evaluates directives on detached clones of live elements, where
+// the suspension flag on the live tree can't be seen. Carry it over so a
+// suspended tree stays suspended through a morph...
+interceptClone((from, to) => {
+    if (activeDefers === 0) return
+
+    if (! from || from.nodeType !== 1 || ! to || to.nodeType !== 1) return
+
+    if (findClosest(from, i => i._x_deferInit)) to._x_ignore = true
+})

--- a/packages/alpinejs/src/lifecycle.js
+++ b/packages/alpinejs/src/lifecycle.js
@@ -1,5 +1,6 @@
 import { startObservingMutations, onAttributesAdded, onElAdded, onElRemoved, cleanupAttributes, cleanupElement } from "./mutation"
 import { deferHandlingDirectives, directiveExists, directives } from "./directives"
+import { queueAttributesForDeferredTree } from "./deferInit"
 import { dispatch } from './utils/dispatch'
 import { walk } from "./utils/walk"
 import { warn } from './utils/warn'
@@ -22,6 +23,10 @@ export function start() {
     onElRemoved(el => destroyTree(el))
 
     onAttributesAdded((el, attrs) => {
+        // Attributes added inside a suspended tree are held and replayed
+        // when the tree resumes...
+        if (queueAttributesForDeferredTree(el, attrs)) return
+
         directives(el, attrs).forEach(handle => handle())
     })
 

--- a/packages/alpinejs/src/mutation.js
+++ b/packages/alpinejs/src/mutation.js
@@ -84,6 +84,17 @@ export function flushObserver() {
     })
 }
 
+export function flushPendingMutations() {
+    // Deliver everything synchronously: batches already queued by
+    // flushObserver, plus whatever the observer has seen but not
+    // yet handed over...
+    while (queuedMutations.length > 0) queuedMutations.shift()()
+
+    let records = observer.takeRecords()
+
+    if (records.length > 0) onMutate(records)
+}
+
 export function mutateDom(callback) {
     if (! currentlyObserving) return callback()
 

--- a/packages/docs/src/en/advanced/extending.md
+++ b/packages/docs/src/en/advanced/extending.md
@@ -376,3 +376,31 @@ export default function (Alpine) {
 You'll see that `Alpine.plugin` is incredibly simple. It accepts a callback and immediately invokes it while providing the `Alpine` global as a parameter for use inside of it.
 
 Then you can go about extending Alpine as you please.
+
+<a name="deferring-initialization"></a>
+## Deferring initialization
+
+Alpine initializes a tree of elements synchronously. Integrations that load JavaScript for a component asynchronously — a script module that registers an `Alpine.data()` provider, for example — can lose that race: Alpine evaluates `x-data="someComponent"` before the registration exists.
+
+`Alpine.deferInit(el, promise)` suspends initialization of one element's tree until a promise settles. Nothing inside the tree initializes while it's suspended: directives don't evaluate, nodes added inside it wait, and attribute changes are held and replayed when the tree resumes. The rest of the page initializes normally.
+
+```js
+Alpine.interceptInit(el => {
+    if (el.hasAttribute('data-widget') && ! widgetIsLoaded(el)) {
+        Alpine.deferInit(el, loadWidget(el))
+    }
+})
+```
+
+(`Alpine.interceptInit()` is Alpine's low-level integration hook — its callback runs for every element just before that element initializes.)
+
+A few things to know about the contract:
+
+- Registering must happen synchronously — from an `Alpine.interceptInit()` callback before the element initializes, or on an already-initialized element to suspend future activity in its tree (a morph that's about to bring in new markup, for example).
+- Calling `deferInit()` on the same element again before it resumes adds another prerequisite: the tree initializes after every registered promise settles.
+- A rejected promise is reported through Alpine's error handler, then the tree initializes anyway — a failed prerequisite never leaves a tree permanently suspended.
+- If the element has left the DOM by the time the promise settles, nothing happens. If it re-enters later, it initializes like any other added node.
+- When a suspended tree resumes, init interceptors run again for elements that hadn't initialized yet. Only defer while your prerequisite is still outstanding — like the `widgetIsLoaded()` check above — so the resume pass initializes normally instead of suspending again.
+- `[x-cloak]` attributes inside a suspended tree stay in place until it resumes, so the existing cloaking pattern hides not-yet-ready content.
+- `alpine:initialized` does not wait for suspended trees — it fires when the synchronous pass over the page completes.
+- The promise is expected to settle. A prerequisite that never settles leaves its tree suspended indefinitely — put timeouts on operations that need them before handing the promise to Alpine.

--- a/tests/cypress/integration/defer-init.spec.js
+++ b/tests/cypress/integration/defer-init.spec.js
@@ -1,0 +1,389 @@
+import { beEqualTo, haveAttribute, haveText, html, notHaveAttribute, test } from '../utils'
+
+// Registers an interceptor that suspends any [defer-me] element on
+// window.promise until window.resolveIt() is called. Mirrors real usage:
+// only defer while the prerequisite is still outstanding, so the resume
+// pass initializes normally...
+let suspendOnDeferMe = `
+    window.ready = false
+
+    window.promise = new Promise(resolve => window.resolveIt = () => {
+        window.ready = true
+
+        resolve()
+    })
+
+    Alpine.interceptInit(el => {
+        if (el.hasAttribute('defer-me') && ! window.ready) {
+            Alpine.deferInit(el, window.promise)
+        }
+    })
+`
+
+test('deferInit suspends a tree until the promise resolves',
+    [html`
+        <div id="deferred" defer-me x-data="lateData">
+            <span x-text="message"></span>
+        </div>
+
+        <button x-data @click="registerAndResolve()">resolve</button>
+    `,
+    suspendOnDeferMe + `
+        window.registerAndResolve = () => {
+            Alpine.data('lateData', () => ({ message: 'loaded' }))
+
+            window.resolveIt()
+        }
+    `],
+    ({ get }) => {
+        get('#deferred span').should(haveText(''))
+        get('button').click()
+        get('#deferred span').should(haveText('loaded'))
+    }
+)
+
+test('deferInit only suspends the affected tree',
+    [html`
+        <div id="deferred" defer-me x-data="{ message: 'deferred' }">
+            <span x-text="message"></span>
+        </div>
+
+        <div id="untouched" x-data="{ message: 'immediate' }">
+            <span x-text="message"></span>
+        </div>
+
+        <button x-data @click="resolveIt()">resolve</button>
+    `,
+    suspendOnDeferMe],
+    ({ get }) => {
+        get('#untouched span').should(haveText('immediate'))
+        get('#deferred span').should(haveText(''))
+        get('button').click()
+        get('#deferred span').should(haveText('deferred'))
+    }
+)
+
+test('deferInit waits for every registered promise',
+    [html`
+        <div id="deferred" defer-me x-data="{ message: 'both' }">
+            <span x-text="message"></span>
+        </div>
+
+        <button id="first" x-data @click="resolveFirst()">first</button>
+        <button id="second" x-data @click="resolveSecond()">second</button>
+    `,
+    `
+        window.firstDone = false
+        window.secondDone = false
+
+        let first = new Promise(resolve => window.resolveFirst = () => {
+            window.firstDone = true
+
+            resolve()
+        })
+
+        let second = new Promise(resolve => window.resolveSecond = () => {
+            window.secondDone = true
+
+            resolve()
+        })
+
+        Alpine.interceptInit(el => {
+            if (! el.hasAttribute('defer-me')) return
+
+            if (! window.firstDone) Alpine.deferInit(el, first)
+            if (! window.secondDone) Alpine.deferInit(el, second)
+        })
+    `],
+    ({ get }) => {
+        get('#first').click()
+        get('#deferred span').should(haveText(''))
+        get('#second').click()
+        get('#deferred span').should(haveText('both'))
+    }
+)
+
+test('a rejected promise surfaces the error and initializes the tree anyway',
+    [html`
+        <div id="deferred" defer-me x-data="{ message: 'recovered' }">
+            <span x-text="message"></span>
+        </div>
+
+        <button x-data @click="rejectIt()">reject</button>
+    `,
+    `
+        window.ready = false
+
+        window.promise = new Promise((resolve, reject) => window.rejectIt = () => {
+            window.ready = true
+
+            reject(new Error('failed to load'))
+        })
+
+        Alpine.interceptInit(el => {
+            if (el.hasAttribute('defer-me') && ! window.ready) {
+                Alpine.deferInit(el, window.promise)
+            }
+        })
+    `],
+    ({ get }) => {
+        get('#deferred span').should(haveText(''))
+        get('button').click()
+        get('#deferred span').should(haveText('recovered'))
+    },
+    true // The surfaced rejection is expected...
+)
+
+test('x-cloak is honored while a tree is suspended',
+    [html`
+        <div id="deferred" defer-me x-data x-cloak>
+            <span>hidden until ready</span>
+        </div>
+
+        <button x-data @click="resolveIt()">resolve</button>
+    `,
+    suspendOnDeferMe],
+    ({ get }) => {
+        get('#deferred').should(haveAttribute('x-cloak', ''))
+        get('button').click()
+        get('#deferred').should(notHaveAttribute('x-cloak'))
+    }
+)
+
+test('nodes added inside a suspended tree wait for it to resume',
+    [html`
+        <div id="deferred" defer-me x-data="{ message: 'ready' }">
+            <span x-text="message"></span>
+        </div>
+
+        <button id="add" x-data @click="addChild()">add</button>
+        <button id="resolve" x-data @click="resolveIt()">resolve</button>
+    `,
+    suspendOnDeferMe + `
+        window.addChild = () => {
+            let child = document.createElement('h1')
+
+            child.setAttribute('x-text', 'message')
+
+            document.querySelector('#deferred').appendChild(child)
+        }
+    `],
+    ({ get }) => {
+        get('#add').click()
+        get('#deferred h1').should(haveText(''))
+        get('#resolve').click()
+        get('#deferred h1').should(haveText('ready'))
+    }
+)
+
+test('attributes added to an initialized element inside a suspended tree are replayed on resume',
+    [html`
+        <div id="target" x-data="{ message: 'replayed' }">
+            <span>plain</span>
+        </div>
+
+        <button id="suspend" x-data @click="suspendIt()">suspend</button>
+        <button id="resolve" x-data @click="resolveIt()">resolve</button>
+    `,
+    `
+        window.promise = new Promise(resolve => window.resolveIt = resolve)
+
+        window.suspendIt = () => {
+            let el = document.querySelector('#target')
+
+            Alpine.deferInit(el, window.promise)
+
+            el.querySelector('span').setAttribute('x-text', 'message')
+        }
+    `],
+    ({ get }) => {
+        get('#suspend').click()
+        get('#target span').should(haveText('plain'))
+        get('#resolve').click()
+        get('#target span').should(haveText('replayed'))
+    }
+)
+
+test('suspended trees compose when nested',
+    [html`
+        <div id="outer" defer-outer x-data="{ outer: 'outer-ready' }">
+            <span x-text="outer"></span>
+
+            <div id="inner" defer-inner x-data="{ inner: 'inner-ready' }">
+                <span x-text="inner"></span>
+            </div>
+        </div>
+
+        <button id="resolve-outer" x-data @click="resolveOuter()">outer</button>
+        <button id="resolve-inner" x-data @click="resolveInner()">inner</button>
+    `,
+    `
+        window.outerDone = false
+        window.innerDone = false
+
+        let outerPromise = new Promise(resolve => window.resolveOuter = () => {
+            window.outerDone = true
+
+            resolve()
+        })
+
+        let innerPromise = new Promise(resolve => window.resolveInner = () => {
+            window.innerDone = true
+
+            resolve()
+        })
+
+        Alpine.interceptInit(el => {
+            if (el.hasAttribute('defer-outer') && ! window.outerDone) {
+                Alpine.deferInit(el, outerPromise)
+            }
+
+            if (el.hasAttribute('defer-inner') && ! window.innerDone) {
+                Alpine.deferInit(el, innerPromise)
+            }
+        })
+    `],
+    ({ get }) => {
+        get('#outer > span').should(haveText(''))
+        get('#resolve-outer').click()
+        get('#outer > span').should(haveText('outer-ready'))
+        get('#inner span').should(haveText(''))
+        get('#resolve-inner').click()
+        get('#inner span').should(haveText('inner-ready'))
+    }
+)
+
+test('a suspended element removed from the DOM never initializes',
+    [html`
+        <div id="deferred" defer-me x-data="recordInit">
+            <span>doomed</span>
+        </div>
+
+        <button id="remove" x-data @click="removeIt()">remove</button>
+        <button id="resolve" x-data @click="resolveIt()">resolve</button>
+    `,
+    suspendOnDeferMe + `
+        window.initCount = 0
+
+        window.removeIt = () => document.querySelector('#deferred').remove()
+
+        Alpine.data('recordInit', () => ({
+            init() { window.initCount++ }
+        }))
+    `],
+    ({ get }) => {
+        get('#remove').click()
+        get('#resolve').click()
+
+        // Give the settled promise a beat to (incorrectly) initialize...
+        cy.wait(50)
+
+        cy.window().its('initCount').should(beEqualTo(0))
+    }
+)
+
+test('interceptors run again when a suspended tree resumes',
+    [html`
+        <div id="deferred" defer-me x-data="{ message: 'ready' }">
+            <span x-text="message"></span>
+        </div>
+
+        <button x-data @click="resolveIt()">resolve</button>
+    `,
+    suspendOnDeferMe + `
+        window.interceptCount = 0
+
+        Alpine.interceptInit(el => {
+            if (el.hasAttribute('defer-me')) window.interceptCount++
+        })
+    `],
+    ({ get }) => {
+        get('button').click()
+        get('#deferred span').should(haveText('ready'))
+
+        // Once suspended, once for the real initialization on resume...
+        cy.window().its('interceptCount').should(beEqualTo(2))
+    }
+)
+
+test('a suspended tree survives being morphed',
+    [html`
+        <div id="deferred" defer-me x-data="morphedData">
+            <span x-text="message"></span>
+        </div>
+
+        <button id="morph" x-data @click="morphIt()">morph</button>
+        <button id="resolve" x-data @click="registerAndResolve()">resolve</button>
+    `,
+    `
+        window.ready = false
+
+        window.promise = new Promise(resolve => window.resolveIt = () => {
+            window.ready = true
+
+            resolve()
+        })
+
+        Alpine.interceptInit(el => {
+            if (el.hasAttribute('defer-me') && ! window.ready) {
+                Alpine.deferInit(el, window.promise)
+            }
+        })
+
+        window.morphIt = () => {
+            Alpine.morph(document.querySelector('#deferred'), \`
+                <div id="deferred" defer-me x-data="morphedData">
+                    <span x-text="message"></span>
+                    <h1 x-text="message"></h1>
+                </div>
+            \`)
+        }
+
+        window.registerAndResolve = () => {
+            Alpine.data('morphedData', () => ({ message: 'morphed-and-loaded' }))
+
+            window.resolveIt()
+        }
+    `],
+    ({ get }) => {
+        // Morph the tree while it's still suspended — the clone evaluation
+        // and the added node must both stay inside the boundary...
+        get('#morph').click()
+        get('#deferred span').should(haveText(''))
+        get('#deferred h1').should(haveText(''))
+        get('#resolve').click()
+        get('#deferred span').should(haveText('morphed-and-loaded'))
+        get('#deferred h1').should(haveText('morphed-and-loaded'))
+    }
+)
+
+test('a suspended element re-entering the DOM after settling initializes normally',
+    [html`
+        <div id="parking" style="display: none"></div>
+
+        <div id="deferred" defer-me x-data="{ message: 'back-alive' }">
+            <span x-text="message"></span>
+        </div>
+
+        <button id="remove" x-data @click="removeIt()">remove</button>
+        <button id="resolve" x-data @click="resolveIt()">resolve</button>
+        <button id="reattach" x-data @click="reattachIt()">reattach</button>
+    `,
+    suspendOnDeferMe + `
+        window.removeIt = () => {
+            window.parked = document.querySelector('#deferred')
+
+            window.parked.remove()
+        }
+
+        window.reattachIt = () => {
+            document.querySelector('#parking').after(window.parked)
+        }
+    `],
+    ({ get }) => {
+        get('#remove').click()
+        get('#resolve').click()
+        get('#reattach').click()
+        get('#deferred span').should(haveText('back-alive'))
+    }
+)


### PR DESCRIPTION
## The problem

Alpine initializes a tree of elements synchronously. Integrations that load JavaScript for a component asynchronously — Livewire's co-located script modules registering `Alpine.data()` providers, for example — lose that race: Alpine evaluates `x-data="audioUploader"` before the registration exists, and the tree initializes broken.

Until now the only way out was juggling private state from the outside — setting `_x_ignore`, clearing `_x_marker`, mirroring flags through `interceptClone`, and manually re-running `initTree()`. Every consumer of that approach has to rediscover the same sharp edges (detached morph clones, mutations during the window, double-initialized directives).

## The API

```js
Alpine.interceptInit(el => {
    if (el.hasAttribute('data-widget') && ! widgetIsLoaded(el)) {
        Alpine.deferInit(el, loadWidget(el))
    }
})
```

One method: `Alpine.deferInit(el, promise)`. While suspended, nothing inside the tree initializes — directives don't evaluate, nodes added inside it wait, attribute changes are held — and the rest of the page initializes normally. When every registered promise settles, the tree initializes in place.

## The contract

- **Registration is synchronous** — from an `interceptInit` callback before the element initializes, or on a live element to suspend future activity in its tree (e.g. ahead of a morph that brings in new markup).
- **Multiple promises compose** — calling `deferInit()` again before resume adds a prerequisite; the tree initializes after all of them settle.
- **Rejection fails open** — the error goes through Alpine's error handler, then the tree initializes anyway. A failed prerequisite never wedges a tree.
- **Removal is safe** — an element that left the DOM never initializes; if it re-enters, the mutation observer picks it up like any added node.
- **Interceptors run again on resume** for elements that hadn't initialized yet. Consumers defer only while their prerequisite is outstanding (like the `widgetIsLoaded()` check above), so the resume pass initializes normally.
- **`x-cloak` is honored** through the suspended window — the attribute is only removed when the element actually initializes.
- **`alpine:initialized` does not wait** for suspended trees.

## The implementation

The design insight that keeps this small: **suspension rides on the existing ignore flag**. `initTree`'s walker, `getDirectiveHandler`'s `_x_ignore` check, and the added-node path's closest-ignored check already implement "don't initialize this tree" — `deferInit` sets the flag (tracking whether it owned it) and records the suspension on the element. The new code is only the bookkeeping the flag can't do alone:

- **Attribute mutations inside a suspended tree are queued and replayed on resume** (`lifecycle.js` routes the attributes-added handler through the queue). Without this, a morph that adds `x-data` to a live root during the window would either evaluate too early or be dropped forever. Replay only touches elements that already carry an `_x_marker` — everything else is covered by the resume walk.
- **Morph clones mirror the suspension** (`interceptClone`): morphing evaluates directives on detached clones where the live tree's flag can't be seen.
- **Settlement flushes pending mutations synchronously first** (`flushPendingMutations()` in `mutation.js`), so everything the observer saw during the window lands in the queue while the tree is still suspended, instead of firing against a half-ready tree.
- **Resume is just `initTree(el)`**: an already-marked root skips itself but walks its children; a fresh root re-enters interception and initializes normally. No continuation capture, no marker surgery.

Pages that never call `deferInit()` hit one added check: a counter guard (`activeDefers === 0`) in the attributes-added handler, and the same guard first in the clone interceptor. Zero defers → zero extra work.

## Tests

`tests/cypress/integration/defer-init.spec.js` — 12 specs: suspension until resolve, tree isolation, multiple promises, rejection fail-open, `x-cloak` honoring, nodes added during suspension, attribute replay on live elements, nested suspension composing, removal during suspension, the interceptor-rerun contract, morph-while-suspended (exercising the clone mirroring), and a removed element re-entering the DOM after settlement. Full existing Cypress suite (all 62 spec files) and Vitest pass unchanged.

The implementation was additionally hardened against three edges found in adversarial review: `settle()` is re-entrancy-safe when a handler running during its mutation flush registers a new prerequisite on the same element; queued-attribute entries are pinned to the element's marker so an element that left the tree and re-initialized elsewhere is never double-initialized; and a replay that finds an enclosing tree still suspended hands its entries to that tree instead of evaluating under it.

One known edge is documented rather than handled: swapping the `x-data` attribute on an already-initialized element mid-suspension splits its cleanup (immediate) from its re-initialization (at resume) — the same children-hold-stale-scope behavior the un-suspended path has, stretched over the suspension window.

## Motivation

Built as the foundation for fixing livewire/livewire's "component script module vs. Alpine init" race (discussions livewire/livewire#9591, #9737, #9830; prior attempts livewire/livewire#9861, #10295, #10619, #10623). The Livewire consumer PR follows. The `@alpinejs/csp` build picks the method up automatically since it shares `src/alpine.js`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxEoar4u3NVYop2jweewwf
