### PR TITLE
Fix decode-uri-component Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3477,12 +3477,13 @@
             "license": "MIT"
         },
         "node_modules/decode-uri-component": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+            "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=0.10"
+                "node": ">=14.16"
             }
         },
         "node_modules/deep-eql": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         "jsdom": "^26.1.0",
         "vitest": "^3.2.4"
     },
+    "overrides": {
+        "decode-uri-component": "^0.5.0"
+    },
     "scripts": {
         "build": "node ./scripts/build.js",
         "watch": "node ./scripts/build.js --watch",


### PR DESCRIPTION
Resolves Dependabot alert #165 by overriding the deprecated Jest transitive dependency to the patched 0.5.x line.

Verification:
- npm ci --ignore-scripts --no-audit --no-fund
- npm ls decode-uri-component --all
- npm run build
- npm run vitest (185 passed, 1 skipped)
- npm audit confirms decode-uri-component is no longer vulnerable
- git diff --check