### PR TITLE
Stop x-on and x-model's own modifiers from being read as key names

### DIFF
--- a/packages/alpinejs/src/utils/on.js
+++ b/packages/alpinejs/src/utils/on.js
@@ -131,11 +131,25 @@ function isClickEvent(event) {
     return ['contextmenu','click','mouse'].some(i => event.includes(i))
 }
 
+// Every modifier x-on and x-model consume themselves. None of them is a key
+// name, so none of them may be mistaken for one. (`enter` is deliberately
+// absent: it is a real key. `preserve-scroll` is specifically for Livewire
+// and is not used by Alpine...)
+const nonKeyModifiers = [
+    // x-on's own modifiers:
+    'window', 'document', 'prevent', 'stop', 'once', 'capture', 'self',
+    'away', 'outside', 'passive', 'dot', 'camel', 'preserve-scroll',
+    // x-model's own modifiers:
+    'blur', 'change', 'lazy', 'number', 'boolean', 'trim', 'fill',
+    'unintrusive', 'parent',
+]
+
 function isListeningForASpecificKeyThatHasntBeenPressed(e, modifiers) {
-    let keyModifiers = modifiers.filter(i => {
-        // `preserve-scroll` is specifically for Livewire and is not used by Alpine...
-        // `blur`, `change`, `enter`, `lazy` are x-model event trigger modifiers, not key modifiers
-        return ! ['window', 'document', 'prevent', 'stop', 'once', 'capture', 'self', 'away', 'outside', 'passive', 'preserve-scroll', 'blur', 'change', 'lazy'].includes(i)
+    let keyModifiers = modifiers.filter((modifier, index) => {
+        // `.passive.false` - the argument isn't a key name either.
+        if (modifier === 'false' && modifiers[index - 1] === 'passive') return false
+
+        return ! nonKeyModifiers.includes(modifier)
     })
 
     if (keyModifiers.includes('debounce')) {

--- a/tests/cypress/integration/directives/x-model.spec.js
+++ b/tests/cypress/integration/directives/x-model.spec.js
@@ -752,3 +752,21 @@ test('x-model does not fire change handlers when x-for options initialize', html
     get('select').should(haveValue('Orange'))
     get('span').should(haveText('0'))
 })
+
+test('x-model.enter still syncs when a value modifier is also present',
+    html`
+    <div x-data="{ foo: '' }">
+        <input x-model.enter.number="foo">
+        <span x-text="foo"></span>
+        <h1 x-text="typeof foo"></h1>
+    </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText(''))
+        get('input').type('42')
+        get('span').should(haveText(''))
+        get('input').type('{enter}')
+        get('span').should(haveText('42'))
+        get('h1').should(haveText('number'))
+    }
+)

--- a/tests/cypress/integration/directives/x-on.spec.js
+++ b/tests/cypress/integration/directives/x-on.spec.js
@@ -645,6 +645,41 @@ test('.dot modifier correctly binds event listener',
         get('span').should(haveText('baz'))
     }
 )
+
+test('.camel and .dot modifiers bind event names that contain "click"',
+    html`
+        <div x-data="{ foo: 'bar', baz: 'bar' }"
+            x-on:click-outside.camel="foo = 'baz'"
+            x-on:item-clicked.dot="baz = 'baz'">
+            <button x-on:click="$dispatch('clickOutside'); $dispatch('item.clicked')"></button>
+
+            <span x-text="foo"></span>
+            <h1 x-text="baz"></h1>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('button').click()
+        get('span').should(haveText('baz'))
+        get('h1').should(haveText('baz'))
+    }
+)
+
+test('.passive.false modifier does not swallow click listeners',
+    html`
+        <div x-data="{ foo: 'bar' }">
+            <button x-on:click.passive.false="foo = 'baz'"></button>
+
+            <span x-text="foo"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveText('bar'))
+        get('button').click()
+        get('span').should(haveText('baz'))
+    }
+)
+
 test('underscores are allowed in event names',
     html`
         <div x-data="{ foo: 'bar' }" x-on:event_name="foo = 'baz'">


### PR DESCRIPTION
`isListeningForASpecificKeyThatHasntBeenPressed()` reads any modifier it does not recognise as a key name, so an unrecognised one silently swallows the event. Its exclusion list has 14 entries; 22 modifiers reach it from `x-on` and `x-model`, and `.passive`'s optional argument is orphaned too.

Broken on `main` today, all three verified in a browser:

```html
<input x-model.enter.number="foo">   <!-- never syncs on Enter -->
<div @click-outside.camel="...">     <!-- listens for `clickOutside`; never fires -->
<button @click.passive.false="...">  <!-- never fires -->
```

`.camel`/`.dot` break only when the resulting name contains `click`/`mouse`, which is why the existing `.camel` test misses it; the existing `.passive.false` test uses `touchmove`, which never reaches this gate.

Precedent: fcc3cd2 hit this and added `blur`, `change`, `lazy` — the three it needed. The value modifiers (`number`, `boolean`, `trim`, `fill`, `unintrusive`, `parent`) and `x-on`'s own `dot`/`camel` were left behind. The list is now derived from what `x-on` and `x-model` consume; `enter` stays out, it is a real key.

3 new tests. Reverting only `on.js` fails exactly those 3, nothing else (x-on 42/44, x-model 39/40). Extending the list without the `.passive` argument still fails two of them. Full Cypress suite: 613 passing, 3 failing — all 3 `intersect.spec.js` `.dwell`, identical on pristine `main`.

Nothing changes for a modifier already covered.

🤖 Written with Claude Code (claude-opus-5)
