### PR TITLE
Fix CSP initialization in sandboxed iframes

### DIFF
--- a/packages/csp/src/parser.js
+++ b/packages/csp/src/parser.js
@@ -5,7 +5,16 @@ Object.getOwnPropertyNames(globalThis).forEach(key => {
     // Prevent Chrome and Safari deprecation warning...
     if (key === "styleMedia" || key === "sharedStorage") return
 
-    globals.add(globalThis[key])
+    let value
+
+    try {
+        value = globalThis[key]
+    } catch {
+        // Some globals throw when accessed in sandboxed contexts...
+        return
+    }
+
+    globals.add(value)
 })
 
 class Token {

--- a/tests/cypress/integration/plugins/csp-compatibility.spec.js
+++ b/tests/cypress/integration/plugins/csp-compatibility.spec.js
@@ -1,5 +1,10 @@
 import { haveText, html, notContain, notExist, notHaveAttribute, test } from '../../utils'
 
+it('initializes in a sandboxed iframe without same-origin access', () => {
+    cy.visit(__dirname+'/../../spec-csp-sandboxed.html')
+    cy.get('#status').should(haveText('initialized'))
+})
+
 test.csp('supports regular syntax', 
     [html`
         <div x-data="{ value: 0, user: { name: 'John' } }">

--- a/tests/cypress/spec-csp-sandboxed.html
+++ b/tests/cypress/spec-csp-sandboxed.html
@@ -1,0 +1,24 @@
+<html>
+    <p id="status">not initialized</p>
+
+    <script>
+        window.addEventListener('message', event => {
+            if (event.source !== document.querySelector('iframe').contentWindow) return
+            if (event.data !== 'initialized') return
+
+            document.querySelector('#status').textContent = event.data
+        })
+    </script>
+
+    <iframe sandbox="allow-scripts" srcdoc='
+        <span x-data="{ status: &apos;initialized&apos; }" x-text="status">not initialized</span>
+
+        <script>
+            document.addEventListener("alpine:initialized", () => {
+                parent.postMessage(document.querySelector("span").textContent, "*")
+            })
+        </script>
+
+        <script src="/../../packages/csp/dist/cdn.js"></script>
+    '></iframe>
+</html>


### PR DESCRIPTION
## What this fixes

Closes #4892.

The CSP build snapshots values from globalThis when the module loads so the evaluator can reject global objects later. Some browser globals are accessors that can throw when unavailable; in a sandboxed iframe without allow-same-origin, reading localStorage throws a SecurityError and aborts Alpine before initialization.

## Changes

- Skip global properties whose getters throw while building the CSP global-value set.
- Add a browser regression fixture that runs the CSP build in an opaque-origin iframe and verifies x-data/x-text initialize.

## Verification

- Confirmed the new Cypress regression fails on unpatched main.
- npm run build
- npx cypress run --browser chrome --spec tests/cypress/integration/plugins/csp-compatibility.spec.js
- npx vitest run tests/vitest/csp-parser.spec.js