### PR TITLE
Change x-for to allow loops like `(foo)in(bar)`

### DIFF
--- a/packages/alpinejs/src/directives/x-for.js
+++ b/packages/alpinejs/src/directives/x-for.js
@@ -143,7 +143,7 @@ function loop(templateEl, iteratorNames, evaluateItems, evaluateKey) {
 function parseForExpression(expression) {
     let forIteratorRE = /,([^,\}\]]*)(?:,([^,\}\]]*))?$/
     let stripParensRE = /^\s*\(|\)\s*$/g
-    let forAliasRE = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/
+    let forAliasRE = /([\s\S]*?)\b(?:in|of)\b([\s\S]*)/
     let inMatch = expression.match(forAliasRE)
 
     if (! inMatch) return

--- a/tests/cypress/integration/directives/x-for.spec.js
+++ b/tests/cypress/integration/directives/x-for.spec.js
@@ -58,6 +58,46 @@ test('renders loops with x-for that have space or newline',
     }
 )
 
+test('render loops with x-for that don\'t have spaces between in/of',
+    html`
+        <div x-data="{ items: ['foo'] }">
+            <button x-on:click="items = ['foo', 'bar']">click me</button>
+            <div x-bind:id="1">
+                <template x-for="(item)in items">
+                    <span x-text="item"></span>
+                </template>
+            </div>
+
+            <div x-bind:id="2">
+                <template x-for="item in(items)">
+                    <span x-text="item"></span>
+                </template>
+            </div>
+
+            <div x-bind:id="3">
+                <template x-for="(item)in(items)">
+                    <span x-text="item"></span>
+                </template>
+            </div>
+        </div>
+    `,
+    ({ get }) => {
+        get('#1 span:nth-of-type(1)').should(haveText('foo'))
+        get('#1 span:nth-of-type(2)').should(notExist())
+        get('#2 span:nth-of-type(1)').should(haveText('foo'))
+        get('#2 span:nth-of-type(2)').should(notExist())
+        get('#3 span:nth-of-type(1)').should(haveText('foo'))
+        get('#3 span:nth-of-type(2)').should(notExist())
+        get('button').click()
+        get('#1 span:nth-of-type(1)').should(haveText('foo'))
+        get('#1 span:nth-of-type(2)').should(haveText('bar'))
+        get('#2 span:nth-of-type(1)').should(haveText('foo'))
+        get('#2 span:nth-of-type(2)').should(haveText('bar'))
+        get('#3 span:nth-of-type(1)').should(haveText('foo'))
+        get('#3 span:nth-of-type(2)').should(haveText('bar'))
+    }
+)
+
 test('can destructure arrays',
     html`
         <div x-data="{ items: [[1, 'foo'], [2, 'bar']] }">


### PR DESCRIPTION
Currently, the loop in x-for must have a space between the in/of and both the bindings and the source expression. However, JS doesn't require the space - only that they are separate tokens - so `(item, index) in list` may be minified to `(item,index)in list` which `x-for` no longer parses.

This patch alters the regular expression in `parseForExpression` to split the bindings and expression on word boundries (`\b`) rather than spaces, to support this syntax.