### PR TITLE
Allow custom value and modifier operators

### DIFF
--- a/packages/alpinejs/src/alpine.js
+++ b/packages/alpinejs/src/alpine.js
@@ -1,5 +1,5 @@
 import { setReactivityEngine, disableEffectScheduling, reactive, effect, release, raw, watch, transaction } from './reactivity'
-import { mapAttributes, directive, setPrefix as prefix, prefix as prefixed } from './directives'
+import { mapAttributes, directive, setPrefix as prefix, prefix as prefixed, useValueOperator } from './directives'
 import { start, addRootSelector, addInitSelector, closestRoot, findClosest, initTree, destroyTree, interceptInit } from './lifecycle'
 import { onElRemoved, onAttributeRemoved, onAttributesAdded, mutateDom, deferMutations, flushAndStopDeferringMutations, startObservingMutations, stopObservingMutations } from './mutation'
 import { deferInit } from './deferInit'
@@ -86,6 +86,7 @@ let Alpine = {
     walk,
     data,
     bind,
+    useValueOperator,
 }
 
 export default Alpine

--- a/packages/alpinejs/src/alpine.js
+++ b/packages/alpinejs/src/alpine.js
@@ -1,5 +1,5 @@
 import { setReactivityEngine, disableEffectScheduling, reactive, effect, release, raw, watch, transaction } from './reactivity'
-import { mapAttributes, directive, setPrefix as prefix, prefix as prefixed, useValueOperator } from './directives'
+import { mapAttributes, directive, setPrefix as prefix, prefix as prefixed, useModifierOperator, useValueOperator } from './directives'
 import { start, addRootSelector, addInitSelector, closestRoot, findClosest, initTree, destroyTree, interceptInit } from './lifecycle'
 import { onElRemoved, onAttributeRemoved, onAttributesAdded, mutateDom, deferMutations, flushAndStopDeferringMutations, startObservingMutations, stopObservingMutations } from './mutation'
 import { deferInit } from './deferInit'
@@ -86,6 +86,7 @@ let Alpine = {
     walk,
     data,
     bind,
+    useModifierOperator,
     useValueOperator,
 }
 

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -197,7 +197,7 @@ function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) 
         if (name === value) value = ''
 
         let typeMatch = name.match(alpineAttributeRegex())
-        let valueMatch = name.match(new RegExp(`${RegExp.escape(valueOperatorAsString)}([a-zA-Z0-9\\-_:]+)`))
+        let valueMatch = name.match(new RegExp(`${RegExp.escape(valueOperatorAsString)}(.+?)(?=${RegExp.escape(modifierOperatorAsString)}|$)`))
         let modifiers = name.match(new RegExp(`${RegExp.escape(modifierOperatorAsString)}(.+?)(?=${RegExp.escape(modifierOperatorAsString)}|\\]|$)(?=[^\\]]*$)`, 'g')) || []
         let original = originalAttributeOverride || transformedAttributeMap[name] || name
 

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -14,6 +14,10 @@ export function setPrefix(newPrefix) {
     prefixAsString = newPrefix
 }
 
+export function useValueOperator(newOperator) {
+    valueOperatorAsString = newOperator
+}
+
 let directiveHandlers = {}
 
 export function directive(name, callback) {

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -183,7 +183,7 @@ function outNonAlpineAttributes({ name }) {
     return alpineAttributeRegex().test(name)
 }
 
-let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}([^${valueOperatorAsString}^.]+)\\b`))
+let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}([^${RegExp.escape(valueOperatorAsString)}^.]+)\\b`))
 
 function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) {
     return ({ name, value }) => {
@@ -192,7 +192,7 @@ function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) 
         if (name === value) value = ''
 
         let typeMatch = name.match(alpineAttributeRegex())
-        let valueMatch = name.match(new RegExp(`${valueOperatorAsString}([a-zA-Z0-9\\-_:]+)`))
+        let valueMatch = name.match(new RegExp(`${RegExp.escape(valueOperatorAsString)}([a-zA-Z0-9\\-_:]+)`))
         let modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || []
         let original = originalAttributeOverride || transformedAttributeMap[name] || name
 

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -4,6 +4,7 @@ import { elementBoundEffect } from './reactivity'
 import Alpine from './alpine'
 
 let prefixAsString = 'x-'
+let valueOperatorAsString = ':'
 
 export function prefix(subject = '') {
     return prefixAsString + subject
@@ -46,7 +47,7 @@ export function directives(el, attributes, originalAttributeOverride) {
         vAttributes = vAttributes.map(attribute => {
             if (staticAttributes.find(attr => attr.name === attribute.name)) {
                 return {
-                    name: `x-bind:${attribute.name}`,
+                    name: `x-bind${valueOperatorAsString}${attribute.name}`,
                     value: `"${attribute.value}"`,
                 }
             }
@@ -178,7 +179,7 @@ function outNonAlpineAttributes({ name }) {
     return alpineAttributeRegex().test(name)
 }
 
-let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}([^:^.]+)\\b`))
+let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}([^${valueOperatorAsString}^.]+)\\b`))
 
 function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) {
     return ({ name, value }) => {
@@ -187,7 +188,7 @@ function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) 
         if (name === value) value = ''
 
         let typeMatch = name.match(alpineAttributeRegex())
-        let valueMatch = name.match(/:([a-zA-Z0-9\-_:]+)/)
+        let valueMatch = name.match(new RegExp(`${valueOperatorAsString}([a-zA-Z0-9\\-_:]+)`))
         let modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || []
         let original = originalAttributeOverride || transformedAttributeMap[name] || name
 

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -15,6 +15,10 @@ export function setPrefix(newPrefix) {
     prefixAsString = newPrefix
 }
 
+export function useModifierOperator(newOperator) {
+    modifierOperatorAsString = newOperator
+}
+
 export function useValueOperator(newOperator) {
     valueOperatorAsString = newOperator
 }

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -183,7 +183,7 @@ function outNonAlpineAttributes({ name }) {
     return alpineAttributeRegex().test(name)
 }
 
-let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}([^${RegExp.escape(valueOperatorAsString)}^.]+)\\b`))
+let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}(.+?)(?=${RegExp.escape(valueOperatorAsString)}|\.|$)\\b`))
 
 function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) {
     return ({ name, value }) => {

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -3,6 +3,7 @@ import { evaluate, evaluateLater } from './evaluator'
 import { elementBoundEffect } from './reactivity'
 import Alpine from './alpine'
 
+let modifierOperatorAsString = '.'
 let prefixAsString = 'x-'
 let valueOperatorAsString = ':'
 
@@ -183,7 +184,7 @@ function outNonAlpineAttributes({ name }) {
     return alpineAttributeRegex().test(name)
 }
 
-let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}(.+?)(?=${RegExp.escape(valueOperatorAsString)}|\.|$)\\b`))
+let alpineAttributeRegex = () => (new RegExp(`^${prefixAsString}(.+?)(?=${RegExp.escape(valueOperatorAsString)}|${RegExp.escape(modifierOperatorAsString)}|$)\\b`))
 
 function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) {
     return ({ name, value }) => {
@@ -193,13 +194,13 @@ function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) 
 
         let typeMatch = name.match(alpineAttributeRegex())
         let valueMatch = name.match(new RegExp(`${RegExp.escape(valueOperatorAsString)}([a-zA-Z0-9\\-_:]+)`))
-        let modifiers = name.match(/\.[^.\]]+(?=[^\]]*$)/g) || []
+        let modifiers = name.match(new RegExp(`${RegExp.escape(modifierOperatorAsString)}[^.\\]]+(?=[^\\]]*$)`, 'g')) || []
         let original = originalAttributeOverride || transformedAttributeMap[name] || name
 
         return {
             type: typeMatch ? typeMatch[1] : null,
             value: valueMatch ? valueMatch[1] : null,
-            modifiers: modifiers.map(i => i.replace('.', '')),
+            modifiers: modifiers.map(i => i.replace(modifierOperatorAsString, '')),
             expression: value,
             original,
         }

--- a/packages/alpinejs/src/directives.js
+++ b/packages/alpinejs/src/directives.js
@@ -198,7 +198,7 @@ function toParsedDirectives(transformedAttributeMap, originalAttributeOverride) 
 
         let typeMatch = name.match(alpineAttributeRegex())
         let valueMatch = name.match(new RegExp(`${RegExp.escape(valueOperatorAsString)}([a-zA-Z0-9\\-_:]+)`))
-        let modifiers = name.match(new RegExp(`${RegExp.escape(modifierOperatorAsString)}[^.\\]]+(?=[^\\]]*$)`, 'g')) || []
+        let modifiers = name.match(new RegExp(`${RegExp.escape(modifierOperatorAsString)}(.+?)(?=${RegExp.escape(modifierOperatorAsString)}|\\]|$)(?=[^\\]]*$)`, 'g')) || []
         let original = originalAttributeOverride || transformedAttributeMap[name] || name
 
         return {

--- a/tests/cypress/integration/custom-prefix.spec.js
+++ b/tests/cypress/integration/custom-prefix.spec.js
@@ -1,4 +1,4 @@
-import { haveAttribute, haveText, html, test } from '../utils'
+import { haveAttribute, haveData, haveText, html, test } from '../utils'
 
 test('can set a custom x- prefix',
     html`
@@ -33,5 +33,30 @@ test('can set a custom value operator',
         get('span').should(haveAttribute('foo', 'bar'))
         get('button').click()
         get('span').should(haveAttribute('foo', 'baz'))
+    }
+)
+
+test('can set a custom modifier operator',
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.useModifierOperator('--modifier--')
+            })
+        </script>
+
+        <div x-data="{ defaultPrevented: null }">
+            <button
+                x-on:mousedown--modifier--passive="
+                    $event.preventDefault();
+                    defaultPrevented = $event.defaultPrevented;
+                "
+            >
+                <span></span>
+            </button>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('div').should(haveData('defaultPrevented', false))
     }
 )

--- a/tests/cypress/integration/custom-prefix.spec.js
+++ b/tests/cypress/integration/custom-prefix.spec.js
@@ -1,4 +1,4 @@
-import { haveAttribute, haveData, haveText, html, test } from '../utils'
+import { haveAttribute, haveText, html, notBeChecked, test } from '../utils'
 
 test('can set a custom x- prefix',
     html`
@@ -44,19 +44,12 @@ test('can set a custom modifier operator',
             })
         </script>
 
-        <div x-data="{ defaultPrevented: null }">
-            <button
-                x-on:mousedown--modifier--passive="
-                    $event.preventDefault();
-                    defaultPrevented = $event.defaultPrevented;
-                "
-            >
-                <span></span>
-            </button>
+        <div x-data="{}">
+            <input type="checkbox" x-on:click--modifier--prevent>
         </div>
     `,
     ({ get }) => {
-        get('button').click()
-        get('div').should(haveData('defaultPrevented', false))
+        get('input').check()
+        get('input').should(notBeChecked())
     }
 )

--- a/tests/cypress/integration/custom-prefix.spec.js
+++ b/tests/cypress/integration/custom-prefix.spec.js
@@ -1,4 +1,4 @@
-import { haveText, html, test } from '../utils'
+import { haveAttribute, haveText, html, test } from '../utils'
 
 test('can set a custom x- prefix',
     html`
@@ -13,4 +13,25 @@ test('can set a custom x- prefix',
         </div>
     `,
     ({ get }) => get('span').should(haveText('bar'))
+)
+
+test('can set a custom value operator',
+    html`
+        <script>
+            document.addEventListener('alpine:init', () => {
+                Alpine.useValueOperator('--value--')
+            })
+        </script>
+
+        <div x-data="{ foo: 'bar' }">
+            <button x-on--value--click="foo = 'baz'"></button>
+
+            <span x-bind--value--foo="foo"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('span').should(haveAttribute('foo', 'bar'))
+        get('button').click()
+        get('span').should(haveAttribute('foo', 'baz'))
+    }
 )


### PR DESCRIPTION
This exposes new `useModifierOperator` and `useValueOperator` functions that allows the default value (`:`) and modifier (`.`) operators to be swapped out.

I ran into an issue with a page builder I was using, where it allowed custom attributes, but sanitized the attribute names according to what is allowed for valid HTML. This meant that all values and modifiers were stripped off. If I was able to specify the operators manually for this installation, I would have been able to use Alpine without any issue.

Example:
```js
document.addEventListener('alpine:init', () => {
    Alpine.useValueOperator('--value--')
    Alpine.useModifierOperator('--modifier--')
})
```

```html
<div x-data="{ foo: 'bar' }">
    <button x-on--value--click="foo = 'baz'"></button>

    <span x-bind--value--foo="foo"></span>
    
    <input type="checkbox" x-on--value--click--modifier--prevent>
</div>
```