### PR TITLE
Fix: skip init() in x-data during clone, matching x-init behavior

### DIFF
--- a/packages/alpinejs/src/directives/x-data.js
+++ b/packages/alpinejs/src/directives/x-data.js
@@ -2,7 +2,7 @@ import { directive, prefix } from '../directives'
 import { initInterceptors } from '../interceptor'
 import { injectDataProviders } from '../datas'
 import { addRootSelector } from '../lifecycle'
-import { interceptClone, isCloning, isCloningLegacy } from '../clone'
+import { interceptClone, isCloning, isCloningLegacy, skipDuringClone } from '../clone'
 import { addScopeToNode } from '../scope'
 import { injectMagics, magic } from '../magics'
 import { reactive } from '../reactivity'
@@ -57,7 +57,9 @@ directive('data', ((el, { expression }, { cleanup }) => {
 
     let undo = addScopeToNode(el, reactiveData)
 
-    reactiveData['init'] && evaluate(el, reactiveData['init'])
+    skipDuringClone(() => {
+        reactiveData['init'] && evaluate(el, reactiveData['init'])
+    })()
 
     cleanup(() => {
         reactiveData['destroy'] && evaluate(el, reactiveData['destroy'])

--- a/tests/cypress/integration/plugins/morph.spec.js
+++ b/tests/cypress/integration/plugins/morph.spec.js
@@ -1339,3 +1339,22 @@ test('$refs are available during morph',
         get('p').should(haveText('bar'))
     },
 )
+
+test('wont run x-data init() method twice when morph patches a node to add x-data',
+    [html`
+        <div id="from"></div>
+    `],
+    ({ get }, reload, window) => {
+        window.timesInitRan = 0
+
+        let toHtml = html`
+            <div id="from" x-data="{ init() { window.timesInitRan++ } }"></div>
+        `
+
+        get('#from').then(([el]) => {
+            window.Alpine.morph(el, toHtml)
+        })
+
+        cy.wrap(window).its('timesInitRan').should('equal', 1)
+    },
+)


### PR DESCRIPTION
## Problem

`x-data`'s `init()` method runs during `Alpine.morph()`'s internal clone pass, unlike `x-init` which is correctly skipped. This causes `init()` to fire twice when a patch adds `x-data` to a node that didn't have it before.

## Solution

Wrap the `init()` call in `x-data.js` with the same `skipDuringClone()` already used by `x-init.js`.

## Tests

Adds a regression test in `morph.spec.js` covering the double-init.

Fixes #4900