### PR TITLE
Fix: `$watch` and `x-modelable` can fire after being unwatched/released

### DIFF
--- a/packages/alpinejs/src/entangle.js
+++ b/packages/alpinejs/src/entangle.js
@@ -1,4 +1,5 @@
 import { effect, release } from './reactivity'
+import { dequeueJob } from './scheduler'
 
 export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set: innerSet }) {
     let firstRun = true
@@ -30,6 +31,10 @@ export function entangle({ get: outerGet, set: outerSet }, { get: innerGet, set:
     })
 
     return () => {
+        // This effect isn't tracked in an element's _x_effects, so cleanupElement()
+        // never dequeues it automatically.
+        dequeueJob(reference)
+
         release(reference)
     }
 }

--- a/packages/alpinejs/src/reactivity.js
+++ b/packages/alpinejs/src/reactivity.js
@@ -1,5 +1,5 @@
 
-import { scheduler, startTransaction as startTx, commitTransaction as commitTx } from './scheduler'
+import { scheduler, dequeueJob, startTransaction as startTx, commitTransaction as commitTx } from './scheduler'
 
 let reactive, effect, release, raw
 let nextStructuralEffectOrder = 0
@@ -104,7 +104,13 @@ export function watch(getter, callback) {
         firstTime = false
     })
 
-    return () => release(effectReference)
+    return () => {
+        // This effect isn't tracked in an element's _x_effects, so cleanupElement()
+        // never dequeues it automatically.
+        dequeueJob(effectReference)
+
+        release(effectReference)
+    }
 }
 
 export async function transaction(callback) {

--- a/tests/cypress/integration/directives/x-modelable.spec.js
+++ b/tests/cypress/integration/directives/x-modelable.spec.js
@@ -191,3 +191,19 @@ test('works when inside x-teleport with x-data directly on it',
         get('h1').should(haveText('lob'))
     }
 )
+
+test('x-modelable does not resync for a change made after its element is removed',
+    html`
+        <div x-data="{ outer: 'foo' }">
+            <div x-data="{ inner: 'bar' }" x-modelable="inner" x-model="outer">
+                <button x-on:click="$root.remove(); inner = 'baz'"></button>
+            </div>
+
+            <h1 x-text="outer"></h1>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('h1').should(haveText('foo'))
+    }
+)

--- a/tests/cypress/integration/magics/$watch.spec.js
+++ b/tests/cypress/integration/magics/$watch.spec.js
@@ -252,3 +252,22 @@ test('deep $watch receives old value with null',
     }
 )
 
+test('$watch does not fire for a change made after its element is removed',
+    html`
+        <div x-data="{ calls: 0 }">
+            <div
+                x-data="{ foo: 'bar' }"
+                x-init="$watch('foo', () => { calls++ })"
+            >
+                <button x-on:click="$root.remove(); foo = 'baz'"></button>
+            </div>
+
+            <span x-text="calls"></span>
+        </div>
+    `,
+    ({ get }) => {
+        get('button').click()
+        get('span').should(haveText('0'))
+    }
+)
+


### PR DESCRIPTION
## Summary

- `watch()` and `entangle()` build their effect with the default `effect()`, not `elementBoundEffect(el)`. Unlike directive effects (x-show, x-text, etc.), their job is never tracked in an element's `_x_effects`. That means `cleanupElement()`'s `el._x_effects?.forEach(dequeueJob)` sweep never reaches them: a value change that queues their effect right before the watcher is torn down can leave a stale job in the scheduler that still runs afterward.
- While tracking this down, I noticed `Alpine.entangle()` has the exact same problem, whether it's reached through `x-modelable` or Livewire's `$wire.$entangle`, so this PR fixes both.
- Fixed by dequeuing the effect explicitly in the function each one returns, right before releasing it. No public API change, so existing consumers (Livewire's `$wire.$watch` included) get the fix for free.

## Alternatives considered

- Override `release` globally to always dequeue. I haven't measured the performance impact or the scope of this change.
- Check whether the effect is still active at the moment a queued job runs, instead of dequeuing. I don't know if that's feasible, and haven't measured any performance cost either.
- Fix this only in `$watch` and `x-modelable`, not in `Alpine.watch`/`Alpine.entangle` themselves. That would leave direct consumers of the primitives (like Livewire) needing to adapt their own code to benefit from the fix, which I'd rather avoid.

## Test plan

- [x] `tests/cypress/integration/magics/$watch.spec.js`, `$watch does not fire for a change made after its element is removed`
- [x] `tests/cypress/integration/directives/x-modelable.spec.js`, `x-modelable does not resync for a change made after its element is removed`
- [x] `npm run test && npm run vitest` (unaffected, still green)


Fixes #4902