### PR TITLE
Fix(CspParser): accept reserved words as property/method names and object keys

### DIFF
--- a/packages/csp/src/parser.js
+++ b/packages/csp/src/parser.js
@@ -26,6 +26,9 @@ class Token {
     }
 }
 
+// Token types allowed as a property or method name (object key, or after `.`)
+const IDENTIFIER_NAME_TYPES = ['IDENTIFIER', 'KEYWORD', 'BOOLEAN', 'NULL', 'UNDEFINED'];
+
 class Tokenizer {
     constructor(input) {
         this.input = input;
@@ -442,11 +445,11 @@ class Parser {
 
         while (true) {
             if (this.match('PUNCTUATION', '.')) {
-                const property = this.consume('IDENTIFIER');
+                const name = this.consumeIdentifierName();
                 expr = {
                     type: 'MemberExpression',
                     object: expr,
-                    property: { type: 'Identifier', name: property.value },
+                    property: { type: 'Identifier', name },
                     computed: false
                 };
             } else if (this.match('PUNCTUATION', '[')) {
@@ -568,8 +571,8 @@ class Parser {
 
             if (this.match('STRING')) {
                 key = { type: 'Literal', value: this.previous().value };
-            } else if (this.match('IDENTIFIER')) {
-                const name = this.previous().value;
+            } else if (this.checkIdentifierName()) {
+                const name = this.consumeIdentifierName();
                 key = { type: 'Identifier', name };
             } else if (this.match('PUNCTUATION', '[')) {
                 key = this.parseExpression();
@@ -669,6 +672,26 @@ class Parser {
         }
         if (this.check(type)) return this.advance();
         throw new Error(`Expected ${type} but got ${this.current().type} "${this.current().value}"`);
+    }
+
+    checkIdentifierName() {
+        if (this.isAtEnd()) return false;
+        return IDENTIFIER_NAME_TYPES.includes(this.current().type);
+    }
+
+    consumeIdentifierName() {
+        if (!this.checkIdentifierName()) {
+            throw new Error(`Expected an identifier name but got ${this.current().type} "${this.current().value}"`);
+        }
+
+        const token = this.advance();
+
+        switch (token.type) {
+            case 'BOOLEAN': return token.value ? 'true' : 'false';
+            case 'NULL': return 'null';
+            case 'UNDEFINED': return 'undefined';
+            default: return token.value;
+        }
     }
 }
 

--- a/tests/vitest/csp-parser.spec.js
+++ b/tests/vitest/csp-parser.spec.js
@@ -93,6 +93,44 @@ describe('CSP Parser', () => {
             const scope = { nullValue: null };
             expect(() => generateRuntimeFunction('nullValue.prop')({ scope })).toThrow('Cannot read property');
         });
+
+        it('should access a keyword-named property', () => {
+            const scope = {
+                obj: {
+                    new: 'value'
+                }
+            };
+            expect(generateRuntimeFunction('obj.new')({ scope })).toBe('value');
+        });
+
+        it('should access a boolean-named property', () => {
+            const scope = {
+                obj: {
+                    true: 'a',
+                    false: 'b'
+                }
+            };
+            expect(generateRuntimeFunction('obj.true')({ scope })).toBe('a');
+            expect(generateRuntimeFunction('obj.false')({ scope })).toBe('b');
+        });
+
+        it('should access a null-named property', () => {
+            const scope = {
+                obj: {
+                    null: 'value'
+                }
+            };
+            expect(generateRuntimeFunction('obj.null')({ scope })).toBe('value');
+        });
+
+        it('should access an undefined-named property', () => {
+            const scope = {
+                obj: {
+                    undefined: 'value'
+                }
+            };
+            expect(generateRuntimeFunction('obj.undefined')({ scope })).toBe('value');
+        });
     });
 
     describe('Function Calls', () => {
@@ -177,6 +215,44 @@ describe('CSP Parser', () => {
 
             expect(scope.foo.bar).toEqual('qux');
         });
+
+        it('should call a keyword-named method', () => {
+            const scope = {
+                obj: {
+                    delete: (arg) => 'called ' + arg
+                }
+            };
+            expect(generateRuntimeFunction("obj.delete('test')")({ scope })).toBe('called test');
+        });
+
+        it('should call a boolean-named method', () => {
+            const scope = {
+                obj: {
+                    true: (arg) => 'called ' + arg,
+                    false: (arg) => 'called ' + arg
+                }
+            };
+            expect(generateRuntimeFunction("obj.true('test')")({ scope })).toBe('called test');
+            expect(generateRuntimeFunction("obj.false('test')")({ scope })).toBe('called test');
+        });
+
+        it('should call a null-named method', () => {
+            const scope = {
+                obj: {
+                    null: (arg) => 'called ' + arg
+                }
+            };
+            expect(generateRuntimeFunction("obj.null('test')")({ scope })).toBe('called test');
+        });
+
+        it('should call an undefined-named method', () => {
+            const scope = {
+                obj: {
+                    undefined: (arg) => 'called ' + arg
+                }
+            };
+            expect(generateRuntimeFunction("obj.undefined('test')")({ scope })).toBe('called test');
+        });
     });
 
     describe('Array Literals', () => {
@@ -228,6 +304,22 @@ describe('CSP Parser', () => {
             expect(generateRuntimeFunction('{ outer: { inner: "value" } }')()).toEqual({
                 outer: { inner: 'value' }
             });
+        });
+
+        it('should parse an object literal with a keyword key', () => {
+            expect(generateRuntimeFunction('{ new: 1 }')()).toEqual({ new: 1 });
+        });
+
+        it('should parse an object literal with a boolean key', () => {
+            expect(generateRuntimeFunction('{ true: 1, false: 2 }')()).toEqual({ true: 1, false: 2 });
+        });
+
+        it('should parse an object literal with a null key', () => {
+            expect(generateRuntimeFunction('{ null: 1 }')()).toEqual({ null: 1 });
+        });
+
+        it('should parse an object literal with an undefined key', () => {
+            expect(generateRuntimeFunction('{ undefined: 1 }')()).toEqual({ undefined: 1 });
         });
     });
 
@@ -459,6 +551,7 @@ describe('CSP Parser', () => {
             expect(() => generateRuntimeFunction('5 +')).toThrow('CSP Parser Error');
             expect(() => generateRuntimeFunction('{ foo: }')).toThrow('CSP Parser Error');
             expect(() => generateRuntimeFunction('"unclosed string')).toThrow('Unterminated string');
+            expect(() => generateRuntimeFunction('obj.')).toThrow('Expected an identifier name');
         });
 
         it('should provide helpful runtime errors', () => {


### PR DESCRIPTION
## Summary

- Reserved words like `delete`, `new`, `true`, `null`, `undefined`, etc. couldn't be used as property or method names after a `.` or as object literal keys in the CSP build, even though this is valid JavaScript. This broke Livewire's `wire:click="delete"` directive, which compiles down to `x-on:click="$wire.delete()"`.

- Real ECMAScript distinguishes [Identifier](https://tc39.es/ecma262/#sec-identifiers) (variable references, reserved words forbidden) from [IdentifierName](https://tc39.es/ecma262/#sec-identifier-names) (property names, reserved words allowed). The CSP tokenizer already classifies its own reserved words (`KEYWORD`, `BOOLEAN`, `NULL`, `UNDEFINED`) into their own token types, and they should all be usable as property names just like ECMAScript's `IdentifierName` allows for its own reserved words. Member access (`.foo`) and object literal keys only accepted `IDENTIFIER`, rejecting the rest.

- Added `checkIdentifierName()`/`consumeIdentifierName()` to the parser to accept any identifier-name-eligible token and resolve it to its string form. The tokenizer stays context-free, the fix lives entirely in the parser.

- Variable references (`parsePrimary`) are untouched: reserved words still can't be used as bare identifiers, matching real JS.

> [!NOTE]  
> While auditing this, I also noticed object literals don't accept a `NUMBER` key (`{ 5: 1 }`, valid in real JS via `LiteralPropertyName`). I haven't hit this in a real-world case, not sure it's worth a separate issue, but it might come up eventually i suppose.


## Test Plan

- [x] Added tests for reserved-word property access, method calls, and object literal keys (keyword/boolean/null/undefined)
- [x] Added a test for the parse error when `.` isn't followed by a valid identifier name
- [x] Full `csp-parser.spec.js`

Fixes #4904